### PR TITLE
Implement different scroll excmds

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -6,9 +6,10 @@ namespace content {
         window.history.go(message.number)
     }
 
-
-    function scrollHandler(message: Message) {
-        window.scrollBy(0, message.number)
+    function scrollHandler(message: Message, scope?: string) {
+        if (!scope) window.scrollBy(0, message.number)
+        else if (scope === "lines") window.scrollByLines(message.number)
+        else if (scope === "pages") window.scrollByPages(message.number)
     }
 
     function evalHandler(message: Message) {
@@ -22,6 +23,12 @@ namespace content {
                 break
             case "scroll":
                 scrollHandler(message)
+                break
+            case "scroll_lines":
+                scrollHandler(message, "lines")
+                break
+            case "scroll_pages":
+                scrollHandler(message, "pages")
                 break
             case "eval":
                 evalHandler(message)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -20,14 +20,23 @@ namespace ExCmds {
         }
     }
 
-    let scroll = messageHelper("scroll")
+    const scroll = messageHelper("scroll")
+    const scroll_lines = messageHelper("scroll_lines")
+    const scroll_pages = messageHelper("scroll_pages")
 
-    export function scrolldown(n = 1) {
-        scroll(n)
+    export function scrolldown(n = 1) { scroll(n) }
+    export function scrolldownline(n = 1) { scroll_lines(n) }
+    export function scrolldownpage(n = 1) { scroll_pages(n) }
+
+    export const scrollup = function (n = 1) { scrolldown(n*-1) }
+    export const scrollupline = function (n = 1) { scrolldownline(n*-1) }
+    export const scrolluppage = funciton (n = 1) { scrolluppage(n*-1) }
+
+    export const scrolldownhalfpage = async function (n = 1) {
+      const current_window = await browser.windows.getCurrent()
+      scrolldown(n*0.5*current_window.height)
     }
-        
-    export let scrollup = function (n = 1) { scrolldown(n*-1) }
-
+    export const scrolluphalfpage = async function (n = 1) { scrolldownhalfpage(n*-1) }
 }
 
 // From main.ts

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -99,15 +99,21 @@ namespace Parsing {
         // ex_str function names
         // TODO: These should be automatically discovered with introspection of the ExCmd object.
         const ex_str_to_func = {
-            tabopen:        console.log,
-            scrolldown:     ExCmds.scrolldown,
-            scrollup:       ExCmds.scrollup,
-            nextab:         console.log,
-            prevtab:        console.log,
-            reader:         console.log,
-            exmode:         console.log,
-            open:           console.log,
-            //something:      console.log,
+            tabopen:             console.log,
+            scrolldown:          ExCmds.scrolldown,
+            scrollup:            ExCmds.scrollup,
+            scrolldownline:      ExCmds.scrolldownline,
+            scrollupline:        ExCmds.scrollupline,
+            scrolldownpage:      ExCmds.scrolldownpage,
+            scrolluppage:        ExCmds.scrolluppage,
+            scrolldownhalfpage:  ExCmds.scrolldownhalfpage,
+            scrolluphalfpage:    ExCmds.scrolluphalfpage,
+            nextab:              console.log,
+            prevtab:             console.log,
+            reader:              console.log,
+            exmode:              console.log,
+            open:                console.log,
+            //something:           console.log,
         }
 
         // Simplistic Ex command line parser.

--- a/src/tridactyl.d.ts
+++ b/src/tridactyl.d.ts
@@ -13,4 +13,8 @@ interface Message {
     number?: number
 }
 
+interface Window {
+    scrollByLines(n: number): void
+    scrollByPages(n: number):  void
+}
 


### PR DESCRIPTION
In addition to scrollByLine and scrollByPage, an excmd to scroll by half pages is included to mimic default <C-u> and <C-d> behavior. In a future revision, it may be preferred to have some variable V for scroll values that pulls current window height when called: a user can set their scroll value to V for their own maps/cmds.