### PR TITLE
Fix mod implementation

### DIFF
--- a/src/excmds_background.ts
+++ b/src/excmds_background.ts
@@ -1,6 +1,6 @@
 /** Conventional definition of modulo that never gives a -ve result. */
 Number.prototype.mod = function (n: number): number {
-    return Math.abs(this % n)
+    return Math.abs(this % n + (this > 0 ? 0 : n))
 }
 
 // Implementation for all built-in ExCmds


### PR DESCRIPTION
e.g., 2 == -1 (mod 3) == -4 (mod 3) == -7 (mod 3) == ...
JS leaves it as -1 (for all negative integers congruent to -1)
This means the code as-is would evaluate `(-1).mod(3)` to `1` which is incorrect.