### PR TITLE
Expose scrollto, add winopen, pin and tabmove

### DIFF
--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -22,7 +22,7 @@ function process() {
 
 function changecommand(newcommand?: string){
     if (newcommand !== undefined) {
-        clInput.value = newcommand
+        clInput.value = newcommand + " "
     }
     // Focus is lost for some reason.
     clInput.focus()

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -29,14 +29,15 @@ export namespace normalmode {
     // TODO: stop stealing keys from "insert mode"
     //          r -> refresh page is particularly unhelpful
     const nmaps = new Map<string, string>([
-        ["t", "tabopen"],
-        ["k", "scrollupline 10"],
+        ["o", "showcommandline open"],
+        ["w", "showcommandline winopen"],
+        ["t", "showcommandline tabopen"],
         ["j", "scrolldownline 10"],
+        ["k", "scrollupline 10"],
         ["h", "scrollleft"],
         ["l", "scrollright"],
         ["G", "scrolltobottom"],
         ["gg", "scrolltotop"],
-        ["o", "showcommandline open"],
         ["H", "historyback"],
         ["L", "historyforward"],
         ["d", "tabclose"],


### PR DESCRIPTION
The tabmove function could be made more concise, I'm sure, but initializing m to -1 did not have the desired effect of no arguments being passed -> moving tab to last in index.