### PR TITLE
Remove missing marks from vimium

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,7 +98,6 @@ Missing:
 
 * command mode
 * jumplist
-* marks
 * :js
 * lots more.
 


### PR DESCRIPTION
Looks like they do have them: https://github.com/philc/vimium