### PR TITLE
scrollpage: use scrollByPages

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -109,7 +109,7 @@ export function scrollline(n = 1) {
 }
 //#content
 export function scrollpage(n = 1) {
-    window.scrollBy(0, n)
+    window.scrollByPages(n)
 }
 
 /** @hidden */


### PR DESCRIPTION
as an alternative, we can use `scrollBy(0, window.innerHeight * n)`, which will open up the possibility of scrolling by partial pages. That would be useful for `C-f` and `C-u` bindings.