### PR TITLE
Add incrementurl command

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -27,6 +27,8 @@ import {ModeName} from './state'
 import * as keydown from "./keydown_background"
 //#background_helper
 import {activeTab, activeTabId} from './lib/webext'
+//#content_helper
+import {incrementUrl} from "./url_util"
 
 /** @hidden */
 //#background_helper
@@ -181,6 +183,19 @@ export function clicknext(dir = "next"){
     // whereas lots of blogs have "VIEW MORE" etc. plastered all over their pages.
     // Stops us from having to hardcode in RPS and reddit, for example.
     window.location.href = nextlinks.slice(-1)[0].href
+}
+
+/** Increment the current tab URL
+ *
+ * @param count   the increment step, can be positive or negative
+*/
+//#content
+export function incrementurl(count = 1){
+    let newUrl = incrementUrl(window.location.href, count)
+
+    if (newUrl !== null) {
+        window.location.href = newUrl
+    }
 }
 
 //#background

--- a/src/url_util.test.ts
+++ b/src/url_util.test.ts
@@ -1,0 +1,30 @@
+/** Some tests for URL utilities */
+
+import {incrementUrl} from './url_util'
+
+function test_increment() {
+
+    let cases = [
+        // simple increment
+        [1, "http://example.com/item/1",   "http://example.com/item/2"],
+        // test non-1 increment
+        [2, "http://example.com/item/1",   "http://example.com/item/3"],
+        // test negative
+        [-1, "http://example.com/item/3",   "http://example.com/item/2"],
+        // test other numbers unaffected
+        [1, "http://www1.example.com/1",   "http://www1.example.com/2"],
+        // test numbers as part of words work
+        [1, "http://example.com/book1",   "http://example.com/book2"],
+        // test urls with no incrementable parts return null
+        [1, "http://example.com", null]
+    ]
+
+    for (let [step, input, output] of cases) {
+
+        test(`${input} + ${step} --> ${output}`, 
+            () => expect(incrementUrl(input, step)).toEqual(output)
+        )
+    }
+}
+
+test_increment()

--- a/src/url_util.ts
+++ b/src/url_util.ts
@@ -1,0 +1,35 @@
+/** URL handling utlity functions
+ */
+
+/** Increment the last number in a URL.
+ *
+ * (perhaps this could be made so you can select the "nth" number in a 
+ * URL rather than just the last one?)
+ *
+ * @param url       the URL to increment
+ * @param count     increment step to advance by (can be negative)
+ * @return          the incremented URL, or null if cannot be incremented
+ */
+export function incrementUrl(url, count) {
+    // Find the final number in a URL
+    let matches = url.match(/(.*?)(\d+)(\D*)$/);
+
+    // no number in URL - nothing to do here
+    if (matches === null) {
+        return null
+    }
+
+    let [, pre, number, post] = matches;
+    let newNumber = parseInt(number, 10) + count;
+    let newNumberStr = String(newNumber > 0 ? newNumber : 0);
+
+    // Re-pad numbers that were zero-padded to be the same length:
+    // 0009 + 1 => 0010
+    if (number.match(/^0/)) { 
+        while (newNumberStr.length < number.length) {
+            newNumberStr = "0" + newNumberStr;
+        }
+    }
+
+    return pre + newNumberStr + post
+}


### PR DESCRIPTION
Increments the last number in a URL by a given step (positive or
negative)

Also includes a url_util helper module and some tests for it

Logic taken from vimperator browser.js:17

Any thoughts on keybindings for this? Vimperator uses C-a and C-x for increment and decrement, respectively, but modifiers can't be used in keybindings: #41 (yet?)

Also, should there be a way to open the inc/dec'd address in a new tab?