### PR TITLE
gobble mode and quickmarks

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -21,6 +21,7 @@ import * as controller from './controller'
 import * as convert from './convert'
 import * as dom from './dom'
 import * as hinting_background from './hinting_background'
+import * as gobble_mode from './parsers/gobblemode'
 import * as itertools from './itertools'
 import * as keyseq from './keyseq'
 import * as msgsafe from './msgsafe'
@@ -35,6 +36,7 @@ import * as webext from './lib/webext'
     convert,
     dom,
     hinting_background,
+    gobble_mode,
     itertools,
     keydown_background,
     keyseq,

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -7,6 +7,7 @@ import {parser as hintmode_parser} from './hinting_background'
 import * as normalmode from "./parsers/normalmode"
 import * as insertmode from "./parsers/insertmode"
 import * as ignoremode from "./parsers/ignoremode"
+import { parser as gobblemode_parser } from './parsers/gobblemode'
 
 
 /** Accepts keyevents, resolves them to maps, maps to exstrs, executes exstrs */
@@ -16,6 +17,7 @@ function *ParserController () {
         insert: insertmode.parser,
         ignore: ignoremode.parser,
         hint: hintmode_parser,
+        gobble: gobblemode_parser,
     }
 
     while (true) {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,13 +1,14 @@
 import {MsgSafeKeyboardEvent, MsgSafeNode} from './msgsafe'
 import {isTextEditable} from './dom'
 import {parser as exmode_parser} from './parsers/exmode'
+import {isSimpleKey} from './keyseq'
 import state from "./state"
 
 import {parser as hintmode_parser} from './hinting_background'
 import * as normalmode from "./parsers/normalmode"
 import * as insertmode from "./parsers/insertmode"
 import * as ignoremode from "./parsers/ignoremode"
-import { parser as gobblemode_parser } from './parsers/gobblemode'
+import * as gobblemode from './parsers/gobblemode'
 
 
 /** Accepts keyevents, resolves them to maps, maps to exstrs, executes exstrs */
@@ -17,7 +18,7 @@ function *ParserController () {
         insert: insertmode.parser,
         ignore: ignoremode.parser,
         hint: hintmode_parser,
-        gobble: gobblemode_parser,
+        gobble: gobblemode.parser,
     }
 
     while (true) {
@@ -42,7 +43,7 @@ function *ParserController () {
                 // yet. So drop them. This also drops all modifier keys.
                 // When we put in handling for other special keys, remember
                 // to continue to ban modifiers.
-                if (state.mode === 'normal' && (keypress.length > 1 || keyevent.ctrlKey || keyevent.altKey || keyevent.metaKey)) {
+                if (state.mode === 'normal' && ! isSimpleKey(keyevent)) {
                     continue
                 }
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -727,7 +727,12 @@ export async function reset(key: string){
     browser.storage.sync.set({nmaps})
 }
 
-/** Bind quickmark to a key. Available with gn[key] and go[key].*/
+/** Bind a quickmark for the current URL to a key.
+
+    Afterwards use go[key], gn[key], or gw[key] to [[open]], [[tabopen]], or
+    [[winopen]] the URL respectively.
+    
+*/
 //#background
 export async function quickmark(key: string) {
     // ensure we're binding to a single key
@@ -763,8 +768,12 @@ export function hint(option?: "-b") {
 //#background_helper
 import * as gobbleMode from './parsers/gobblemode'
 
-/** Initialize gobble mode. It will read `nChars` input keys and append them to
-`endCmd`. */
+/** Initialize gobble mode.
+
+    It will read `nChars` input keys, append them to `endCmd` and execute that
+    string.
+
+*/
 //#background
 export async function gobble(nChars: number, endCmd: string) {
     gobbleMode.init(nChars, endCmd)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -736,8 +736,9 @@ export async function quickmark(key: string) {
     }
 
     let address = (await activeTab()).url
-    await bind("gn" + key, "tabopen", address)
+    bind("gn" + key, "tabopen", address)
     bind("go" + key, "open", address)
+    bind("gw" + key, "winopen", address)
 }
 
 // }}}

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -727,6 +727,19 @@ export async function reset(key: string){
     browser.storage.sync.set({nmaps})
 }
 
+/** Bind quickmark to a key. Available with gn[key] and go[key].*/
+//#background
+export async function quickmark(key: string) {
+    // ensure we're binding to a single key
+    if (key.length !== 1) {
+        return
+    }
+
+    let address = (await activeTab()).url
+    await bind("gn" + key, "tabopen", address)
+    bind("go" + key, "open", address)
+}
+
 // }}}
 
 // {{{ HINTMODE
@@ -744,5 +757,18 @@ export function hint(option?: "-b") {
 
 // }}}
 
+// {{{ GOBBLE mode
+
+//#background_helper
+import * as gobbleMode from './parsers/gobblemode'
+
+/** Initialize gobble mode. It will read `nChars` input keys and append them to
+`endCmd`. */
+//#background
+export async function gobble(nChars: number, endCmd: string) {
+    gobbleMode.init(nChars, endCmd)
+}
+
+// }}}
 
 // vim: tabstop=4 shiftwidth=4 expandtab

--- a/src/keydown_content.ts
+++ b/src/keydown_content.ts
@@ -3,6 +3,7 @@
 import * as Messaging from './messaging'
 import * as msgsafe from './msgsafe'
 import {isTextEditable} from './dom'
+import {isSimpleKey} from './keyseq'
 
 function keyeventHandler(ke: KeyboardEvent) {
     // Ignore JS-generated events for security reasons.
@@ -46,20 +47,26 @@ function TerribleModeSpecificSuppression(ke: KeyboardEvent) {
             // StartsWith happens to work for our maps so far. Obviously won't in the future.
             /* if (Object.getOwnPropertyNames(nmaps).find((map) => map.startsWith(ke.key))) { */
 
-            if (! ke.ctrlKey && ! ke.metaKey && ! ke.altKey
-                && ke.key.length === 1
+            if (! isSimpleKey(ke)
                 && ! normalmodewhitelist.includes(ke.key)
             ) {
                 ke.preventDefault()
                 ke.stopImmediatePropagation()
             }
             break
+        // Hintmode can't clean up after itself yet, so it needs to block more FF shortcuts.
         case "hint":
             if (! hintmodewhitelist.includes(ke.key)) {
                 ke.preventDefault()
                 ke.stopImmediatePropagation()
             }
             break;
+        case "gobble":
+            if (! isSimpleKey(ke) || ke.key === "Escape") {
+                ke.preventDefault()
+                ke.stopImmediatePropagation()
+            }
+            break
         case "ignore":
             break;
         case "insert":

--- a/src/keyseq.ts
+++ b/src/keyseq.ts
@@ -156,10 +156,6 @@ export function bracketexprToKey(be: string): [MinimalKey, string] {
     }
 }
 
-export function hasModifiers(keyEvent: MinimalKey) {
-    return keyEvent.ctrlKey || keyEvent.altKey || keyEvent.metaKey || keyEvent.shiftKey
-}
-
 export function mapstrToKeyseq(mapstr: string): MinimalKey[] {
     const keyseq: MinimalKey[] = []
     let key: MinimalKey
@@ -173,4 +169,23 @@ export function mapstrToKeyseq(mapstr: string): MinimalKey[] {
         }
     }
     return keyseq
+}
+
+// {{{ Utility functions for dealing with KeyboardEvents
+
+import {MsgSafeKeyboardEvent} from './msgsafe'
+
+type KeyEventLike = MinimalKey | MsgSafeKeyboardEvent | KeyboardEvent
+
+export function hasModifiers(keyEvent: KeyEventLike) {
+    return keyEvent.ctrlKey || keyEvent.altKey || keyEvent.metaKey || keyEvent.shiftKey
+}
+
+/** shiftKey is true for any capital letter, most numbers, etc. Generally care about other modifiers. */
+export function hasNonShiftModifiers(keyEvent: KeyEventLike) {
+    return keyEvent.ctrlKey || keyEvent.altKey || keyEvent.metaKey
+}
+
+export function isSimpleKey(keyEvent: KeyEventLike) {
+    return keyEvent.key.length === 1 && ! hasNonShiftModifiers(keyEvent)
 }

--- a/src/parsers/gobblemode.ts
+++ b/src/parsers/gobblemode.ts
@@ -1,0 +1,46 @@
+import state from '../state'
+
+/** Simple container for the gobble state. */
+class GobbleState {
+    public numChars = 0
+    public chars = ''
+    public endCommand = ''
+}
+
+let modeState: GobbleState = undefined
+
+/** Init gobble mode. After parsing the defined number of input keys, execute
+`endCmd` with attached parsed input. `Escape` cancels the mode and returns to
+normal mode. */
+export function init(numChars: number, endCommand: string) {
+    state.mode = 'gobble'
+    modeState = new GobbleState()
+    modeState.numChars = numChars;
+    modeState.endCommand = endCommand;
+}
+
+/** Reset state. */
+function reset() {
+    modeState = undefined
+    state.mode = 'normal'
+}
+
+import { MsgSafeKeyboardEvent } from '../msgsafe'
+
+/** Receive keypress. If applicable, execute a command. */
+export function parser(keys: MsgSafeKeyboardEvent[]) {
+    const key = keys[0].key
+
+    if (key === 'Escape') {
+        reset()
+    } else if (key.length == 1) {
+        // Workaround to avoid modifier keys, mainly Shift.
+        modeState.chars += key
+        if (modeState.chars.length >= modeState.numChars) {
+            const ex_str = modeState.endCommand + ' ' + modeState.chars
+            reset()
+            return { keys: [], ex_str }
+        }
+    }
+    return { keys: [], ex_str: '' }
+}

--- a/src/parsers/gobblemode.ts
+++ b/src/parsers/gobblemode.ts
@@ -1,4 +1,6 @@
 import state from '../state'
+import {isSimpleKey} from '../keyseq'
+import {MsgSafeKeyboardEvent} from '../msgsafe'
 
 /** Simple container for the gobble state. */
 class GobbleState {
@@ -25,16 +27,13 @@ function reset() {
     state.mode = 'normal'
 }
 
-import { MsgSafeKeyboardEvent } from '../msgsafe'
-
 /** Receive keypress. If applicable, execute a command. */
 export function parser(keys: MsgSafeKeyboardEvent[]) {
     const key = keys[0].key
 
     if (key === 'Escape') {
         reset()
-    } else if (key.length == 1) {
-        // Workaround to avoid modifier keys, mainly Shift.
+    } else if (isSimpleKey(keys[0])) {
         modeState.chars += key
         if (modeState.chars.length >= modeState.numChars) {
             const ex_str = modeState.endCommand + ' ' + modeState.chars

--- a/src/parsers/normalmode.ts
+++ b/src/parsers/normalmode.ts
@@ -40,6 +40,7 @@ export const DEFAULTNMAPS = {
     ":": "fillcmdline",
     "s": "fillcmdline open google",
     "S": "fillcmdline tabopen google",
+    "M": "gobble 1 quickmark",
     "xx": "something",
     "b": "openbuffer",
     "ZZ": "qall",

--- a/src/state.ts
+++ b/src/state.ts
@@ -14,7 +14,7 @@
     If this turns out to be expensive there are improvements available.
 */
 
-export type ModeName = 'normal'|'insert'|'hint'|'ignore'
+export type ModeName = 'normal' | 'insert' | 'hint' | 'ignore' | 'gobble'
 class State {
     mode: ModeName = 'normal'
     cmdHistory: string[] = []


### PR DESCRIPTION
Contents of this PR:
 -  gobble mode, which records a requested number of keys and then calls an ex cmd with the keys appended. This would mainly be used for 'marks' features. It can also be used for jumping to some open buffers with 2 keypresses: `bind J gobble 1 buffer`.
 - quickmarks; bookmarks that are bound to keys with `M` in normal mode. `gn[key]` opens a new tab and `go[key]` opens the quickmark in current tab.