### PR TITLE
Refactor normal mode parser and SEARCH_URLS, start options UI

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,24 @@
+import state from './state'
+import {SEARCH_NAMES} from './data'
+
+console.log(SEARCH_NAMES)
+
+function setup_ds() {
+    let ds = document.getElementById('default_search')
+    for(let k of SEARCH_NAMES.keys()) {
+        let opt = document.createElement('option')
+        opt.appendChild(document.createTextNode(SEARCH_NAMES.get(k)))
+        opt.id = k
+        if(k === state.search) {
+            opt.selected = true;
+        }
+        ds.appendChild(opt)
+    }
+    
+    ds.addEventListener("change", function(e) {
+        let sel = <HTMLSelectElement>(e.target)
+        state.search = sel.options[sel.selectedIndex].id
+    })
+}
+
+setup_ds()

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,0 +1,27 @@
+export const SEARCH_URLS = new Map<string, string>([
+    ["google","https://www.google.com/search?q="],
+    ["googleuk","https://www.google.co.uk/search?q="],
+    ["bing","https://www.bing.com/search?q="],
+    ["duckduckgo","https://duckduckgo.com/?q="],
+    ["yahoo","https://search.yahoo.com/search?p="],
+    ["twitter","https://twitter.com/search?q="],
+    ["wikipedia","https://en.wikipedia.org/wiki/Special:Search/"],
+    ["youtube","https://www.youtube.com/results?search_query="],
+    ["amazon","https://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Daps&field-keywords="],
+    ["amazonuk","https://www.amazon.co.uk/s/ref=nb_sb_noss?url=search-alias%3Daps&field-keywords="],
+    ["startpage","https://www.startpage.com/do/search?query="],
+])
+
+export const SEARCH_NAMES = new Map<string, string>([
+    ["google", "Google"],
+    ["googleuk", "Google (UK)"],
+    ["bing", "Bing"],
+    ["duckduckgo", "DuckDuckGo"],
+    ["yahoo", "Yahoo!"],
+    ["twitter", "Twitter"],
+    ["wikipedia", "Wikipedia"],
+    ["youtube", "YouTube"],
+    ["amazon", "Amazon"],
+    ["amazonuk","Amazon (UK)"],
+    ["startpage","StartPage"],
+])

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -50,6 +50,9 @@
         "webRequestBlocking",
         "<all_urls>"
     ],
+    "options_ui": {
+        "page": "static/settings.html"
+    },
     "applications": {
         "gecko": {
             "id": "tridactyl.vim@cmcaine.co.uk",

--- a/src/state.ts
+++ b/src/state.ts
@@ -14,10 +14,55 @@
     If this turns out to be expensive there are improvements available.
 */
 
+
+const normal_nmaps_default = new Map<string, string>([
+    ["o",  "fillcmdline open"],
+    ["O",  "current_url open"],
+    ["w",  "fillcmdline winopen"],
+    ["W",  "current_url winopen"],
+    ["t",  "tabopen"],
+ // ["t",  "fillcmdline tabopen", // for now, use mozilla completion
+    ["]]", "clicknext"], 
+    ["[[", "clicknext prev"], 
+    ["T",  "current_url tabopen"],
+    ["yy", "clipboard yank"],
+    ["p",  "clipboard open"],
+    ["P",  "clipboard tabopen"],
+    ["j",  "scrollline 10"],
+    ["k",  "scrollline -10"],
+    ["h",  "scrollpx -50"],
+    ["l",  "scrollpx 50"],
+    ["G",  "scrollto 100"],
+    ["gg", "scrollto 0"],
+    ["H",  "back"],
+    ["L",  "forward"],
+    ["d",  "tabclose"],
+    ["u",  "undo"],
+    ["r",  "reload"],
+    ["R",  "reloadhard"],
+    ["gt", "tabnext"],
+    ["gT", "tabprev"],
+    ["gr", "reader"],
+    [":",  "fillcmdline"],
+    ["s",  "fillcmdline open #SEARCH#"],
+    ["S",  "fillcmdline tabopen #SEARCH#"],
+    ["M",  "gobble 1 quickmark"],
+    ["xx", "something"],
+    ["b",  "openbuffer"],
+    ["ZZ", "qall"],
+    ["f",  "hint"],
+    ["F",  "hint -b"],
+    ["I",  "mode ignore"],
+    // Special keys must be prepended with ðŸ„°
+    // ["ðŸ„°Backspace", "something"]],
+])
+
 export type ModeName = 'normal' | 'insert' | 'hint' | 'ignore' | 'gobble'
 class State {
     mode: ModeName = 'normal'
     cmdHistory: string[] = []
+    search: string = "google"
+    normal_nmaps: Map<string, string> = normal_nmaps_default
 }
 
 // Don't change these from const or you risk breaking the Proxy below.

--- a/src/static/settings.html
+++ b/src/static/settings.html
@@ -1,0 +1,17 @@
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <link rel="stylesheet" href="newtab.css">
+        <link rel="stylesheet" href="content.css">
+        <link rel="stylesheet" href="hint.css">
+        <link rel="shortcut icon" href="logo/Tridactyl_64px.png">
+    </head>
+    <title>Tridactyl Settings</title>
+    <body>
+        <form>
+            <label>Default Search Engine: </label><select id="default_search"></select>
+        </form>
+    </body>
+    <script src="../content.js"></script>
+    <script src="../config.js"></script>
+</html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ module.exports = {
     entry: {
         background: "./src/background.ts",
         content: "./src/content.ts",
+        config: "./src/config.ts",
         commandline_frame: "./src/commandline_frame.ts",
     },
     output: {


### PR DESCRIPTION
I've moved all of the normal mode keybindings nmaps into the state module (rather than the normal mode module saved in the browser somehow), changed it from an object to a map, and added a simple configuration UI that allows the user to change their search engine (and thus, what comes up when 's' is pressed); I have also moved the search engine data into its own file (`data.ts`). It is not yet possible to add new search engines from the options UI.

(I was asked to create a pull request that won't automatically merge with master, but I'm not certain how to do that, so... hopefully it can be edited?)