### PR TITLE
Add reader excmd (toggle reader mode)

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -60,7 +60,7 @@ import {ModeName} from './state'
 //#background_helper
 import * as keydown from "./keydown_background"
 //#background_helper
-import {activeTab, activeTabId} from './lib/webext'
+import {activeTab, activeTabId, firefoxVersionAtLeast} from './lib/webext'
 //#content_helper
 import {incrementUrl, getUrlRoot, getUrlParent} from "./url_util"
 
@@ -309,6 +309,18 @@ export function urlparent (){
 export function zoom(level=0){
     level = level > 3 ? level / 100 : level
     browser.tabs.setZoom(level)
+}
+
+//#background
+export async function reader() {
+    if (await l(firefoxVersionAtLeast(58))) {
+	let aTab = await activeTab()
+	if (aTab.isArticle) {
+	    browser.tabs.toggleReaderMode()
+	} // else {
+	//  // once a statusbar exists an error can be displayed there
+	// }
+    }
 }
 
 // }}}

--- a/src/tridactyl.d.ts
+++ b/src/tridactyl.d.ts
@@ -25,4 +25,5 @@ declare namespace browser.find {
 declare namespace browser.tabs {
     function setZoom(zoomFactor: number): Promise<void>;
     function setZoom(tabId: number, zoomFactor: number): Promise<void>;
+    function toggleReaderMode(tabId?: number): Promise<void>;
 }


### PR DESCRIPTION
It was already bound to `gr`.

Unless and until the keyboard api is ready or Firefox allows webextensions to inject scripts into the very security-sensitive about:reader context, this will only switch on reader mode. One can get out of reader mode, by pressing <kbd>Alt-←</kbd>.

Once one of the above conditions is met, the toggling should work without any further changes.

I'm not sure if having a command/keybinding for reader mode is something desired at the moment considering that no keybindings will work on the reader page itself. OTOH at least firefox's <kbd>Alt-←</kbd> to exit and <kbd>Space</kbd>/<kbd>Shift-Space</kbd> to scroll up/down, do work, so it's not totally useless. 

A possibly over-kill / duplication-of-effort alternative would be to extract the code from the original readability bookmarklet or even Firefox's reader mode and use that.