### PR TITLE
add `pre`, `code`, `span` to HINTTAGS_text_selectors

### DIFF
--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -246,7 +246,10 @@ iframe,
 textarea,
 button,
 p,
-div
+div,
+pre,
+code,
+span
 `
 
 import {activeTab, browserBg, l, firefoxVersionAtLeast} from './lib/webext'


### PR DESCRIPTION
i'm pretty bullish on `pre` and `code`

could see the argument that `span` is overkill in some cases, 

i tend to err on the side of more hints than less i guess

and for precedent's sake, vimfx seems to include `span`s in it's `yv` binding

on that note, there was also a [`cycle overlapping hints`](https://github.com/akhodakivskiy/VimFx/blob/376486f4dc61d75add1c26263d1f4baf39d3abd4/extension/locale/en-US/vimfx.properties#L122-L123) feature there, so even if it did get a little cluttered, you could always get at the hint you wanted. not sure what the overlapping hint handling story is like here?