### PR TITLE
Update commandline.css

### DIFF
--- a/src/static/commandline.css
+++ b/src/static/commandline.css
@@ -25,7 +25,8 @@ input {
   color: black;
   display: inline-block;
   font-size: 10pt;
-  font-family: "monospace";
+  /* MS doesn't know what monospace is */
+  font-family: "monospace", "Courier New";
   overflow: hidden;
   width: 100%;
   border-top: 0.5px solid grey;


### PR DESCRIPTION
MS still doesn't know what monospace is. Pls not Times New Roman in my buffers.

(@cmcaine missed a bit last night.)

edit for those not based locally: since 7bbe81f, on Windows FF Trid has used Times New Roman (default font), despite the elements having the monospace font-family defined, and my monospace font being _anything_ but that. FF gives me my correct monospace font elsewhere.

edit2: Would also be fixed by item 4 in #94 