### PR TITLE
Properly fix monospace on Windows bug

### DIFF
--- a/src/static/commandline.css
+++ b/src/static/commandline.css
@@ -6,8 +6,7 @@ body {
 input {
   width: 100%;
   padding: 0;
-  /* MS doesn't know what monospace is */
-  font-family: "monospace", "Courier New";
+  font-family: monospace;
   font-size: 9pt;
   line-height: 1.5;
   color: black;
@@ -25,8 +24,7 @@ input {
   color: black;
   display: inline-block;
   font-size: 10pt;
-  /* MS doesn't know what monospace is */
-  font-family: "monospace", "Courier New";
+  font-family: monospace;
   overflow: hidden;
   width: 100%;
   border-top: 0.5px solid grey;


### PR DESCRIPTION
The actual issue (workaround committed in #119) was that font-family names should _not_ be quoted.