### PR TITLE
Add focusinput command (gi)

### DIFF
--- a/src/parsers/normalmode.ts
+++ b/src/parsers/normalmode.ts
@@ -36,6 +36,7 @@ export const DEFAULTNMAPS = {
     "u": "undo",
     "r": "reload",
     "R": "reloadhard",
+    "gi": "focusinput -l",
     "gt": "tabnext",
     "gT": "tabprev",
     "gr": "reader",


### PR DESCRIPTION
Can focus the nth input from the start or end of a page.

Also has some special modes:

  -l: last focussed input (bound to 'gi')
  -p: first password input
  -b: the largest input by area

----
There are several helpers now in `dom.ts`. I'm open to putting them elsewhere if that's not a suitable place. I think the `isSubstantial` filter makes sense (it works when `isVisible` doesn't), but could do with a sanity check!