### PR TITLE
Add hint focus mode (;;)

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -777,7 +777,7 @@ export async function quickmark(key: string) {
 //#background_helper
 import * as hinting from './hinting_background'
 
-/** Hint a page. 
+/** Hint a page.
 *
 * Pass -b as first argument to open hinted page in background.
 * -y copies the link's target to the clipboard.
@@ -789,6 +789,7 @@ export function hint(option?: "-b") {
     else if (option === "-p") hinting.hintPageTextYank()
     else if (option === "-i") hinting.hintImage(false)
     else if (option === "-I") hinting.hintImage(true)
+    else if (option === "-;") hinting.hintFocus()
     else hinting.hintPageSimple()
 }
 

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -344,6 +344,13 @@ function hintImage(inBackground) {
     })
 }
 
+/** Hint elements to focus */
+function hintFocus() {
+    hintPage(hintables(), hint=>{
+        hint.target.focus()
+    })
+}
+
 function selectFocusedHint() {
     console.log("Selecting hint.", state.mode)
     const focused = modeState.focusedHint
@@ -361,4 +368,5 @@ addListener('hinting_content', attributeCaller({
     hintPageTextYank,
     hintPageOpenInBackground,
     hintImage,
+    hintFocus,
 }))

--- a/src/hinting_background.ts
+++ b/src/hinting_background.ts
@@ -31,6 +31,10 @@ export async function hintImage(inBackground) {
     return await messageActiveTab('hinting_content', 'hintImage', [inBackground])
 }
 
+export async function hintFocus() {
+    return await messageActiveTab('hinting_content', 'hintFocus')
+}
+
 import {MsgSafeKeyboardEvent} from './msgsafe'
 
 /** At some point, this might be turned into a real keyseq parser

--- a/src/parsers/normalmode.ts
+++ b/src/parsers/normalmode.ts
@@ -55,6 +55,7 @@ export const DEFAULTNMAPS = {
     ";I": "hint -I",
     ";y": "hint -y",
     ";p": "hint -p",
+    ";;": "hint -;",
     "I": "mode ignore",
     "a": "current_url bmark",
     "A": "bmark",


### PR DESCRIPTION
This focuses the hinted element with excmd ":hint -;".

Includes Vimperator binding to ";;"
----
Not sure about the use of "-;" for the excmd parameter, it's hardly a mnemonic except by virtue of the historical Vimperator binding. "-f" is probably frame focus and "-F" is multiple BG open, so not sure otherwise. Perhaps there should be equivalent long-form parameters too, so an alternative excmd is something like `hint --focus`?