### PR TITLE
Add C-j and C-m keybindings

### DIFF
--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -97,6 +97,18 @@ clInput.addEventListener("keydown", function (keyevent) {
             }
             break
 
+       case "j":
+            if (keyevent.ctrlKey){
+	       process()
+	    }
+            break
+
+       case "m":
+            if (keyevent.ctrlKey){
+	       process()
+	    }
+            break
+
         case "Tab":
             // Stop tab from losing focus
             keyevent.preventDefault()


### PR DESCRIPTION
In pentadactyl and in various line-editing libraries such as readline
used in Bash or linenoise it's possible to accept input with Control-m
and Control-j just like with the Return key.  I often use this
keybindings because they happen to be easier to use as you don't have to
move your hand to the Return key.