### PR TITLE
excmds.ts: Add search urls.

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -85,6 +85,12 @@ const SEARCH_URLS = new Map<string, string>([
     ["amazon","https://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Daps&field-keywords="],
     ["amazonuk","https://www.amazon.co.uk/s/ref=nb_sb_noss?url=search-alias%3Daps&field-keywords="],
     ["startpage","https://www.startpage.com/do/search?query="],
+    ["github","https://github.com/search?utf8=✓&q="],
+    ["searx","https://searx.me/?category_general=on&q="],
+    ["cnrtl","http://www.cnrtl.fr/lexicographie/"],
+    ["osm","https://www.openstreetmap.org/search?query="],
+    ["mdn","https://developer.mozilla.org/en-US/search?q="],
+    ["gentoo_wiki","https://wiki.gentoo.org/index.php?title=Special%3ASearch&profile=default&fulltext=Search&search="],
 ])
 
 // map a page-relation (next or previous) to a fallback pattern to match link texts against


### PR DESCRIPTION
First things first, thank you for creating Tridactyl! It's a great add-on and the first to feel like it could end-up being a proper replacement for Pentadactyl.

This commit adds Github, Searx, Cnrtl, OpenStreetMap, the Mozilla Dev Networkand the Gentoo wiki to the list of SEARCH_URLS. I consider this a temporary solution, the ideal solution would in my opinion be for Mozilla to add a "keyword" attribute to their [BookmarkTreeNode](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNode) object in order to be able to better integrate Tridactyl with Firefox's [smart keyword](http://kb.mozillazine.org/Using_keyword_searches) feature. I have no idea whether this idea has already been proposed to Mozilla (a quick search on bugzilla returns nothing) and am unsure about how to ask them if they'd be willing to implement it.