### PR TITLE
Fix builds when using BSD sed

### DIFF
--- a/scripts/commandline_injector.sh
+++ b/scripts/commandline_injector.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
-shopt -s globstar
-sed -i '/<\/body>/s@^@<script src="/content.js"></script><link rel="stylesheet" href="/static/content.css"><link rel="stylesheet" href="/static/hint.css">@' $1
+
+sed -i.bak '/<\/body>/s@^@<script src="/content.js"></script><link rel="stylesheet" href="/static/content.css"><link rel="stylesheet" href="/static/hint.css">@' "$1"
+rm "$1.bak"
+
 #static/docs/modules/_excmds_.html

--- a/scripts/newtab.md.sh
+++ b/scripts/newtab.md.sh
@@ -3,4 +3,9 @@
 # Combine newtab markdown and template
 
 cd src/static
-sed "/REPLACETHIS/s/REPLACETHIS/marked newtab.md/e" newtab.template.html > ../../generated/static/newtab.html
+
+newtab="../../generated/static/newtab.html"
+
+sed "/REPLACETHIS/,$ d" newtab.template.html > "$newtab"
+marked newtab.md >> "$newtab"
+sed "1,/REPLACETHIS/ d" newtab.template.html >> "$newtab"


### PR DESCRIPTION
I tried to build this on my work laptop (Mac OS X) and encountered a couple of issues due to incompatibilities between between GNU and BSD `sed`:

1. The `e` command used for templating is a [GNU extension](https://www.gnu.org/software/sed/manual/sed.html#Extended-Commands).

2. Use of the `-i` option for in-place editing requires a space with BSD `sed` but cannot have a space with GNU `sed` ([more details](https://stackoverflow.com/a/5694430)).

I've also removed the globstar option from one script since it requires bash >= 4.0 and I don't think it's being used anyway, but it'd be worth someone else double checking that.