### PR TITLE
Add tabfirst and tablast commands

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -482,29 +482,49 @@ document.addEventListener("focusin",e=>{if (DOM.isTextEditable(e.target as HTMLE
 
 // {{{ TABS
 
-/** Switch to the next tab by index (position on tab bar), wrapping round.
-
-    optional increment is number of tabs forwards to move.
- */
-//#background
-export async function tabnext(increment = 1) {
+/** Switch to the tab by index (position on tab bar), wrapping round. */
+/** @hidden */
+//#background_helper
+async function tabindex(index: number) {
     // Get an array of tabs in the current window
     let current_window = await browser.windows.getCurrent()
     let tabs = await browser.tabs.query({windowId: current_window.id})
 
-    // Derive the index we want
-    let desiredIndex = ((await activeTab()).index + increment).mod(tabs.length)
-
     // Find and switch to the tab with that index
     let desiredTab = tabs.find((tab: any) => {
-        return tab.index === desiredIndex
+        return tab.index === index.mod(tabs.length)
     })
     tabSetActive(desiredTab.id)
 }
 
+/** Switch to the next tab, wrapping round.
+
+    If increment is specified, move that many tabs forwards.
+ */
 //#background
-export function tabprev(increment = 1) {
-    tabnext(increment * -1)
+export async function tabnext(increment = 1) {
+    tabindex((await activeTab()).index + increment)
+}
+
+/** Switch to the previous tab, wrapping round.
+
+    If increment is specified, move that many tabs backwards.
+ */
+//#background
+export async function tabprev(increment = 1) {
+    tabindex((await activeTab()).index - increment)
+}
+
+/** Switch to the first tab. */
+//#background
+export async function tabfirst() {
+    tabindex(0)
+}
+
+/** Switch to the last tab. */
+//#background
+export async function tablast() {
+    tabindex(-1)
 }
 
 /** Like [[open]], but in a new tab */

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -482,7 +482,10 @@ document.addEventListener("focusin",e=>{if (DOM.isTextEditable(e.target as HTMLE
 
 // {{{ TABS
 
-/** Switch to the tab by index (position on tab bar), wrapping round. */
+/** Switch to the tab by index (position on tab bar), wrapping round.
+
+    Note: all internal indices should start at 0.
+ */
 /** @hidden */
 //#background_helper
 async function tabindex(index: number) {
@@ -797,23 +800,26 @@ export async function buffers() {
     tabs()
 }
 
-/** Change active tab */
+/** Change active tab.
+
+    The buffer index starts at 1.
+ */
 //#background
 export async function buffer(n?: number | string) {
-    if (!n || Number(n) == 0) return // Vimperator index starts at 1
+    if (!n)
+        return
+
     if (n === "#") {
-        n =
+        // Switch to the most recently accessed buffer
+        tabindex(
             (await browser.tabs.query({currentWindow: true})).sort((a, b) => {
                 return a.lastAccessed < b.lastAccessed ? 1 : -1
-            })[1].index + 1
-    }
-    if (Number.isInteger(Number(n))) {
-        tabSetActive(
-            (await browser.tabs.query({
-                currentWindow: true,
-                index: Number(n) - 1,
-            }))[0].id
+            })[1].index
         )
+    }
+    else if (Number.isInteger(Number(n))) {
+        // Internal indices start at 0.
+        tabindex(Number(n) - 1)
     }
 }
 

--- a/src/parsers/normalmode.ts
+++ b/src/parsers/normalmode.ts
@@ -39,6 +39,8 @@ export const DEFAULTNMAPS = {
     "gi": "focusinput -l",
     "gt": "tabnext",
     "gT": "tabprev",
+    "g^": "tabfirst",
+    "g$": "tablast",
     "gr": "reader",
     "gu": "urlparent",
     "gU": "urlroot",


### PR DESCRIPTION
This adds two new commands along with keybindings, both of which have existed in Vimperator for about a decade.

* `g^` - `:tabfirst` - Switches to the first tab.
* `g$` - `:tablast` - Switches to the last tab.

In case we're not just trying to emulate Vimperator, both `tabfirst` and `tablast` exist in Vim so there's a good argument for having them, but the `g^` and `g$` keybindings might be a Vimperator invention (they don't clash with any existing keybindings though).

I've also done some minor refactoring to how `tabnext` and `tabprev` work to keep the code nice and simple.