### PR TITLE
Add yank anchor URL hint submode (;#)

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -183,23 +183,31 @@ export function isVisible (element: Element) {
 /** Get all elements that match the given selector
  *
  * @param selector   `the CSS selector to choose elements with
- * @param filter      filter to use to further chose items, or null for all
+ * @param filters     filter to use (in thre given order) to further chose
+ *                    items, or [] for all
  */
-export function getElemsBySelector(selector: string, filter: ElementFilter) {
+export function getElemsBySelector(selector: string,
+    filters: Array<ElementFilter>) {
+
     let elems = Array.from(document.querySelectorAll(selector))
 
-    return filter ? elems.filter(filter) : elems
+    for (let filter of filters) {
+        elems = elems.filter(filter)
+    }
+
+    return elems
 }
 
 /** Get the nth input element on a page
  *
  * @param nth         the element index, can be negative to start at the end
- * @param filter      filter to use to further chose items, or null for all
+ * @param filters     filter to use (in thre given order) to further chose
+ *                    items, or [] for all
  */
 export function getNthElement(selectors: string, nth: number,
-    filter: ElementFilter) {
+    filters: Array<ElementFilter>): HTMLElement {
 
-    let inputs = getElemsBySelector(selectors, filter)
+    let inputs = getElemsBySelector(selectors, filters)
 
     if (inputs.length) {
         let index = Number(nth).clamp(-inputs.length, inputs.length - 1)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1027,6 +1027,7 @@ import * as hinting from './hinting_background'
         - -i view an image
         - -I view an image in a new tab
         - -; focus an element
+        - -# yank an element's anchor URL to clipboard
 */
 //#background
 export function hint(option?: string) {
@@ -1036,6 +1037,7 @@ export function hint(option?: string) {
     else if (option === "-i") hinting.hintImage(false)
     else if (option === "-I") hinting.hintImage(true)
     else if (option === "-;") hinting.hintFocus()
+    else if (option === "-#") hinting.hintPageAnchorYank()
     else hinting.hintPageSimple()
 }
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -463,7 +463,7 @@ export function focusinput(nth: number|string) {
         fallbackToNumeric = false
 
         let inputs = DOM.getElemsBySelector(INPUTPASSWORD_selectors,
-                                            DOM.isSubstantial)
+                                            [DOM.isSubstantial])
 
         if (inputs.length) {
             inputToFocus = <HTMLElement>inputs[0]
@@ -472,7 +472,7 @@ export function focusinput(nth: number|string) {
     else if (nth === "-b") {
 
         let inputs = DOM.getElemsBySelector(INPUTTAGS_selectors,
-            DOM.isSubstantial) as HTMLElement[]
+            [DOM.isSubstantial]) as HTMLElement[]
 
         inputToFocus = inputs.sort(DOM.compareElementArea).slice(-1)[0]
     }
@@ -483,7 +483,7 @@ export function focusinput(nth: number|string) {
 
         let index = isNaN(<number>nth) ? 0 : <number>nth
         inputToFocus = DOM.getNthElement(INPUTTAGS_selectors,
-                                         index, DOM.isSubstantial)
+                                         index, [DOM.isSubstantial])
     }
 
     if (inputToFocus) inputToFocus.focus()

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -211,6 +211,14 @@ function hintableImages() {
         isVisible)
 }
 
+/** Get arrat of "anchors": elements which have id or name and can be addressed
+ * with the hash/fragment in the URL
+ */
+function anchors() {
+    return Array.from(document.querySelectorAll(HINTTAGS_anchor_selectors))
+        .filter(isVisible)
+}
+
 // CSS selectors. More readable for web developers. Not dead. Leaves browser to care about XML.
 const HINTTAGS_selectors = `
 input:not([type=hidden]):not([disabled]),
@@ -263,6 +271,11 @@ span
 const HINTTAGS_img_selectors = `
 img,
 [src]
+`
+
+const HINTTAGS_anchor_selectors = `
+[id],
+[name]
 `
 
 import {activeTab, browserBg, l, firefoxVersionAtLeast} from './lib/webext'
@@ -327,6 +340,20 @@ function hintPageYank() {
     })
 }
 
+/** Hint anchors and yank the URL on selection
+ */
+function hintPageAnchorYank() {
+
+    hintPage(anchors(), hint=>{
+
+        let anchorUrl = new URL(window.location.href)
+
+        anchorUrl.hash = hint.target.id || hint.target.name;
+
+        messageActiveTab("commandline_frame", "setClipboard", [anchorUrl.href])
+    })
+}
+
 /** Hint images, opening in the same tab, or in a background tab
  *
  * @param inBackground  opens the image source URL in a background tab,
@@ -366,6 +393,7 @@ addListener('hinting_content', attributeCaller({
     hintPageSimple,
     hintPageYank,
     hintPageTextYank,
+    hintPageAnchorYank,
     hintPageOpenInBackground,
     hintImage,
     hintFocus,

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -10,7 +10,7 @@
         Redraw on reflow
 */
 
-import {elementsByXPath, isVisible, mouseEvent} from './dom'
+import * as DOM from './dom'
 import {log} from './math'
 import {permutationsWithReplacement, islice, izip, map} from './itertools'
 import {hasModifiers} from './keyseq'
@@ -192,31 +192,29 @@ function pushKey(ke) {
             2. Not hidden by another element
 */
 function hintables() {
-    return Array.from(document.querySelectorAll(HINTTAGS_selectors)).filter(isVisible)
+    return DOM.getElemsBySelector(HINTTAGS_selectors, [DOM.isVisible])
 }
 
 function elementswithtext() {
-    return Array.from(document.querySelectorAll(HINTTAGS_text_selectors)).filter(
-        isVisible
-    ).filter(hint => {
-        return hint.textContent != ""
-    })
+
+    return DOM.getElemsBySelector(HINTTAGS_text_selectors,
+        [DOM.isVisible, hint => {
+            return hint.textContent != ""
+        }]
+    )
 }
 
 /** Get array of images in the viewport
  */
 function hintableImages() {
-    /* return [...elementsByXPath(HINTTAGS)].filter(isVisible) as any as Element[] */
-    return Array.from(document.querySelectorAll(HINTTAGS_img_selectors)).filter(
-        isVisible)
+    return DOM.getElemsBySelector(HINTTAGS_img_selectors, [DOM.isVisible])
 }
 
 /** Get arrat of "anchors": elements which have id or name and can be addressed
  * with the hash/fragment in the URL
  */
 function anchors() {
-    return Array.from(document.querySelectorAll(HINTTAGS_anchor_selectors))
-        .filter(isVisible)
+    return DOM.getElemsBySelector(HINTTAGS_anchor_selectors, [DOM.isVisible])
 }
 
 // CSS selectors. More readable for web developers. Not dead. Leaves browser to care about XML.
@@ -303,7 +301,7 @@ function simulateClick(target: HTMLElement) {
     ) {
         browserBg.tabs.create({url: (target as HTMLAnchorElement).href})
     } else {
-        mouseEvent(target, "click")
+        DOM.mouseEvent(target, "click")
         // Sometimes clicking the element doesn't focus it sufficiently.
         target.focus()
     }

--- a/src/hinting_background.ts
+++ b/src/hinting_background.ts
@@ -19,6 +19,11 @@ export async function hintPageYank() {
 export async function hintPageTextYank() {
     return await messageActiveTab('hinting_content', 'hintPageTextYank')
 }
+
+export async function hintPageAnchorYank() {
+    return await messageActiveTab('hinting_content', 'hintPageAnchorYank')
+}
+
 export async function hintPageSimple() {
     return await messageActiveTab('hinting_content', 'hintPageSimple')
 }

--- a/src/parsers/normalmode.ts
+++ b/src/parsers/normalmode.ts
@@ -61,6 +61,7 @@ export const DEFAULTNMAPS = {
     ";y": "hint -y",
     ";p": "hint -p",
     ";;": "hint -;",
+    ";#": "hint -#",
     "I": "mode ignore",
     "a": "current_url bmark",
     "A": "bmark",


### PR DESCRIPTION
This yanks the page URL with the hinted elements id or title as a hash
fragment, which can be used to link to the page at that element's
location.

The second commit is a refactor using the DOM CSS query helpers. It's not required for functionality, but I think it tidies the functions in `hinting.ts` quite well?