### PR TITLE
Hint CSS: make easier to see stacked hints

### DIFF
--- a/src/static/hint.css
+++ b/src/static/hint.css
@@ -5,7 +5,7 @@ span.TridactylHint {
     font-weight: bold;
     text-transform: uppercase;
     color: white;
-    background-color: red;
+    background-color: #CC0000;
     border-color: ButtonShadow;
     border-width: 0px;
     min-width: .75em;
@@ -21,8 +21,15 @@ span.TridactylHint {
     transition: unset;
 }
 
-.TridactylHintElem { background-color: yellow;  }
-.TridactylHintActive { background-color: #88FF00; }
+.TridactylHintElem {
+    background-color: rgba(255, 240, 0, 0.5);
+    outline: 1px solid #8F5902;
+}
+
+.TridactylHintActive {
+    background-color: #88FF00;
+    outline: 1px solid #CC0000;
+}
 
 div.TridactylHintHost {
     position: static !important;


### PR DESCRIPTION
This has two major aspects:

 - Add a border so the extent of a hint is clear
 - Make hint BG translucent, so stacked hints can be discerned

 Also used more Tango-ish colours to soften the intense yellow.

----
Related to #69. I'm not claiming this is the best CSS ever, and CSS will be configurable in the end, but I think this makes it easier to see where hints are when they get crowded?

Note: outline is used over border so as not to change the element sizes when styled.

Here is the effect for `;p` (very stacked) and `f` (sparse):

![2017-11-29-030023_1005x601_scrot](https://user-images.githubusercontent.com/5386578/33355920-7c0e8bb6-d4b1-11e7-8828-565f441f1b4b.png)
![2017-11-29-030028_1005x601_scrot](https://user-images.githubusercontent.com/5386578/33355921-7c225c36-d4b1-11e7-8f8f-e185b9f9ae6f.png)

