### PR TITLE
src/dom.ts: Fix hints not being displayed on certain sites.

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -117,6 +117,47 @@ export function isSubstantial (element: Element) {
     return true
 }
 
+
+/** This function decides whether the height attribute contained in a
+   ComputedStyle matters.  For example, the height attribute doesn't matter for
+   elements that have "display: inline" because their height is overriden by
+   the height of the node they are in. */
+export function heightMatters (style: CSSStyleDeclaration) {
+   switch (style.display) {
+      case "inline":
+      case "table-column":
+      case "table-column-group":
+      /* These two depend on other factors such as the element's type (span,
+         div...) or its parent's style. If the previous cases aren't enough to
+         decide whether the width attribute of the element matters, we should
+         maybe try to test for them.
+      case "initial":
+      case "inherit":*/
+         return false
+   }
+   return true
+}
+
+/* See [[heightMatters]] */
+export function widthMatters (style: CSSStyleDeclaration) {
+   switch (style.display) {
+      case "inline":
+      case "table-column":
+      case "table-column-group":
+      case "table-header-group":
+      case "table-footer-group":
+      case "table-row-group":
+      case "table-cell":
+      case "table-row":
+      /* Take a look at [[heightMatters]] in order to understand why these two
+         cases are commented
+      case "initial":
+      case "inherit?:*/
+         return false
+   }
+   return true
+}
+
 // Saka-key caches getComputedStyle. Maybe it's a good idea!
 /* let cgetComputedStyle = cacheDecorator(getComputedStyle) */
 
@@ -136,8 +177,8 @@ export function isVisible (element: Element) {
         case clientRect.top >= innerHeight - 4:
         case clientRect.left < 0:
         case clientRect.left >= innerWidth - 4:
-        case clientRect.width < 3:
-        case clientRect.height < 3:
+        case widthMatters(computedStyle) && clientRect.width < 3:
+        case heightMatters(computedStyle) && clientRect.height < 3:
         case computedStyle.visibility !== 'visible':
         case computedStyle.display === 'none':
             return false


### PR DESCRIPTION
Problem: Hints aren't displayed for certain elements. This was because
the isVisible function didn't pay attention to the element's 'display'
attribute when deciding whether an element is visible according to its
height/width.

Solution: Add two functions to help decide whether the height and width
attribute of an element matter.

Note: The two functions do not do anything if an element's 'display'
attribute is set to either 'initial' or 'inherit' because taking these
into account seems complicated.

Fixes issue https://github.com/cmcaine/tridactyl/issues/127 .

This might also fix issues https://github.com/cmcaine/tridactyl/issues/163 and https://github.com/cmcaine/tridactyl/issues/81 but I can't test it.