### PR TITLE
Add Text To Speech API (and hint mode)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -70,6 +70,7 @@ const DEFAULTS = o({
         ";I": "hint -I",
         ";y": "hint -y",
         ";p": "hint -p",
+        ";r": "hint -r",
         ";;": "hint -;",
         ";#": "hint -#",
         "I": "mode ignore",
@@ -80,6 +81,11 @@ const DEFAULTS = o({
     "storageloc": "sync",
     "hintchars": "hjklasdfgyuiopqwertnmzxcvb",
     "hintorder": "normal",
+
+    "ttsvoice": "default",  // chosen from the listvoices list, or "default"
+    "ttsvolume": 1,         // 0 to 1
+    "ttsrate": 1,           // 0.1 to 10
+    "ttspitch": 1,          // 0 to 2
 })
 
 // currently only supports 2D or 1D storage

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -17,6 +17,7 @@ import {hasModifiers} from './keyseq'
 import state from './state'
 import {messageActiveTab} from './messaging'
 import * as config from './config'
+import * as TTS from './text_to_speech'
 
 /** Simple container for the state of a single frame's hints. */
 class HintState {
@@ -366,6 +367,13 @@ function hintFocus() {
     })
 }
 
+/** Hint items and read out the content of the selection */
+function hintRead() {
+    hintPage(elementswithtext(), hint=>{
+        TTS.readText(hint.target.textContent)
+    })
+}
+
 function selectFocusedHint() {
     console.log("Selecting hint.", state.mode)
     const focused = modeState.focusedHint
@@ -385,4 +393,5 @@ addListener('hinting_content', attributeCaller({
     hintPageOpenInBackground,
     hintImage,
     hintFocus,
+    hintRead,
 }))

--- a/src/hinting_background.ts
+++ b/src/hinting_background.ts
@@ -40,6 +40,10 @@ export async function hintFocus() {
     return await messageActiveTab('hinting_content', 'hintFocus')
 }
 
+export async function hintRead() {
+    return await messageActiveTab('hinting_content', 'hintRead')
+}
+
 import {MsgSafeKeyboardEvent} from './msgsafe'
 
 /** At some point, this might be turned into a real keyseq parser

--- a/src/text_to_speech.ts
+++ b/src/text_to_speech.ts
@@ -1,0 +1,90 @@
+/** Functions to deal with text to speech in Tridactyl
+ */
+
+import * as Config from './config'
+
+/** Find the voice object for a voice name
+ *
+ * @return voice from the TTS API, or undefined
+ */
+function getVoiceFromName(name: string | "default"): SpeechSynthesisVoice {
+
+    let voices = window.speechSynthesis.getVoices()
+
+    return voices.find(voice=>(voice.name === name))
+}
+
+/**
+ * Read the text using the borwser's HTML5 TTS API
+ *
+ * @param text      the text to read out
+ */
+export function readText(text: string): void {
+
+    let utterance = new SpeechSynthesisUtterance(text);
+
+    let pitch = Config.get("ttspitch")
+    let voice = Config.get("ttsvoice")
+    let volume = Config.get("ttsvolume")
+    let rate = Config.get("ttsrate")
+
+    if (pitch >= 0 && pitch < 2)
+        utterance.pitch = pitch
+
+    if (volume >= 0 && volume <= 1)
+        utterance.volume = volume
+
+    if (rate >= 0.1 && rate <= 10)
+        utterance.rate = rate
+
+    let voiceObj = getVoiceFromName(voice)
+    if (voiceObj) {
+        utterance.voice = voiceObj
+    }
+
+    window.speechSynthesis.speak(utterance);
+}
+
+/**
+ * Supported TTS control actions
+ */
+export type Action = "stop" | "play" | "pause" | "playpause"
+
+/**
+ * Control any reading in progress
+ *
+ * Note: pause() doesn't seem to work, so play, pause and playpause arent going
+ * to be very useful right now
+ */
+export function doAction(action: Action): void {
+
+    let synth = window.speechSynthesis
+
+    switch (action) {
+        case "play":
+            synth.resume()
+            break
+        case "pause":
+            synth.pause()
+            break
+        case "playpause":
+            synth.paused ? synth.resume() : synth.pause()
+            break
+        case "stop":
+            synth.cancel()
+            break
+    }
+}
+
+/**
+ * Get a list of the installed TTS voice names, by which users
+ * can refer to the vocies for use in config
+ *
+ * @return list of voice names
+ */
+export function listVoices(): string[] {
+
+    let voices = window.speechSynthesis.getVoices()
+
+    return voices.map(voice=>voice.name)
+}


### PR DESCRIPTION
This adds an excmd interface to the Web Speech API (TTS), which allows
users to read text out and set voice and parameters via config options.

Excmds:

    - ttsread: reads the given text or CSS selector content out
    - ttsvoices: lists available voice names (can be used in the
      'ttsvoice' option)
    - ttscontrol: stops the current reading (should also pause/resume,
      but that doesn't seem to work right now)

Config options:
    - ttsvoice: the name of the voice to use
    - ttsrate: (0.1-10)
    - ttsvolume: (0-1)
    - ttspitch: (0-2)

Also the ;r hint submode is added which reads the textcontent of the
element with the configured voice

----
I quite like being able to bind to, eg, `ttsread -c .storylink` on HN.

This uses the new config API. I'm happy to wait a bit in case that API needs to bed in, and piling options and call sites on top will make it hard to work on. 

I also don't know where to document options (as opposed to excmds). Vimperator and Pentadactyl seem to use (the same?) XML based system (c.f. options.xml in each project).