### PR TITLE
Variable hintname length

### DIFF
--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -68,14 +68,24 @@ export function hintPage(
 }
 
 /** vimperator-style minimal hint names */
-function* hintnames(hintchars = config.get("hintchars")): IterableIterator<string> {
+function* hintnames(n: number, hintchars = config.get("hintchars")): IterableIterator<string> {
     let taglen = 1
+    var source = permutationsWithReplacement(hintchars, taglen)
+    for (let i = 0;i < n / hintchars.length;i++) {
+        // drop hints that will be used as the prefix of longer hints
+        if (source.next()['done'])
+            // if the current taglen tags are exhausted, increase the length
+            taglen++
+            source = permutationsWithReplacement(hintchars, taglen)
+            source.next()
+        }
     while (true) {
-        yield* map(permutationsWithReplacement(hintchars, taglen), e=>{
+        yield* map(source, e=>{
             if (config.get("hintorder") == "reverse") e = e.reverse()
             return e.join('')
         })
         taglen++
+        source = permutationsWithReplacement(hintchars, taglen)
     }
 }
 

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -71,14 +71,15 @@ export function hintPage(
 function* hintnames(n: number, hintchars = config.get("hintchars")): IterableIterator<string> {
     let taglen = 1
     var source = permutationsWithReplacement(hintchars, taglen)
-    for (let i = 0;i < n / hintchars.length;i++) {
+    for (let i = 0;i < Math.floor(n / hintchars.length);i++) {
         // drop hints that will be used as the prefix of longer hints
-        if (source.next()['done'])
+        if (source.next()['done']) {
             // if the current taglen tags are exhausted, increase the length
             taglen++
             source = permutationsWithReplacement(hintchars, taglen)
             source.next()
         }
+    }
     while (true) {
         yield* map(source, e=>{
             if (config.get("hintorder") == "reverse") e = e.reverse()

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -47,7 +47,7 @@ let modeState: HintState = undefined
 export function hintPage(
     hintableElements: Element[],
     onSelect: HintSelectedCallback,
-    names = hintnames_uniform(hintableElements.length),
+    names = hintnames(hintableElements.length),
 ) {
     state.mode = 'hint'
     modeState = new HintState()

--- a/src/itertools.ts
+++ b/src/itertools.ts
@@ -87,7 +87,7 @@ export function* permutationsWithReplacement(arr, n) {
     for (let _ of range(Math.pow(len, n))) {
         yield counters.map(i=>arr[i])
         for (let i of range(counters.length)) {
-            if (index.mod(Math.pow(len, i)) === 0)
+            if (index.mod(Math.pow(len, counters.length - 1 - i)) === 0)
                 counters[i] = (counters[i] + 1).mod(len)
         }
         index++


### PR DESCRIPTION
This branch enables hint names with varied length. If a longer name uses a shorter one as a prefix, the shorter ones are not used.