### PR TITLE
Fix reference to keybindings in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,7 +76,7 @@ A pre-commit hook is added by `npm install` that simply runs `npm test`. If you 
 
 Ask in `#tridactyl` on [matrix.org][matrix-link], freenode, or [gitter][gitter-link]. We're friendly!
 
-Default keybindings are currently best discovered by reading the source for the [normal mode parser](./src/parsers/normalmode.ts).
+Default keybindings are currently best discovered by reading the [default config](./src/config.ts).
 
 Development notes are in the doc directory, but they're mostly out of date now. Code is quite short and not *too* badly commented, though.
 


### PR DESCRIPTION
The normal mode parser parses `config.ts` which contains `DEFAULTS` containing all default keybindings. Hence, a reference to `config.ts`.