### PR TITLE
src/excmds.ts: Implement :sanitize.

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -38,6 +38,7 @@
     "permissions": [
         "activeTab",
         "bookmarks",
+        "browsingData",
         "contextMenus",
         "clipboardWrite",
         "clipboardRead",


### PR DESCRIPTION
This implements part of Vimperator/Pentadactyl's :sanitize function.

Three things that should be discussed: Some items can be deleted under Chrome but not under Firefox. Should support for deleting these items be added to Tridactyl? It really wouldn't complicate the code much (just a three line long `if` condition).

Deleting the "pluginData" item makes a lot of errors pop up in the console. Should we prevent users from deleting this item at all? It might be useful if the user really needs to reset his Tridactyl profile, but it can be very dangerous too since there's no way to really backup your settings yet. Maybe we should let the user delete it and ask for confirmation?

I also didn't implement the timespan feature vimperator and pentadactyl have. I'm unsure about how to proceed for command line flags. Let me know how you want it to be implemented and how it should look.

This will fix https://github.com/cmcaine/tridactyl/issues/132 once it is merged.