### PR TITLE
src/{config,controller,excmds,state}.ts: Implement dot repeat.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -81,6 +81,7 @@ const DEFAULTS = o({
         "zi": "zoom 0.1 true",
         "zo": "zoom -0.1 true",
         "zz": "zoom 1",
+        ".": "repeat",
     }),
     "searchengine": "google",
     "searchurls": o({

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,15 +1,17 @@
 import {MsgSafeKeyboardEvent, MsgSafeNode} from './msgsafe'
 import {isTextEditable} from './dom'
-import {parser as exmode_parser} from './parsers/exmode'
 import {isSimpleKey} from './keyseq'
 import state from "./state"
+import {repeat} from './excmds_background'
 
+import {parser as exmode_parser} from './parsers/exmode'
 import {parser as hintmode_parser} from './hinting_background'
 import * as normalmode from "./parsers/normalmode"
 import * as insertmode from "./parsers/insertmode"
 import * as ignoremode from "./parsers/ignoremode"
 import * as gobblemode from './parsers/gobblemode'
 import * as inputmode from './parsers/inputmode'
+
 
 
 /** Accepts keyevents, resolves them to maps, maps to exstrs, executes exstrs */
@@ -89,7 +91,8 @@ export function acceptExCmd(ex_str: string) {
     // TODO: Errors should go to CommandLine.
     try {
         let [func, args] = exmode_parser(ex_str)
-        if (!ex_str.startsWith("repeat"))
+        // Stop the repeat excmd from recursing.
+        if (func !== repeat)
             state.last_ex_str = ex_str
         try {
             func(...args)

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -68,8 +68,6 @@ function *ParserController () {
                     keys = response.keys
                 }
             }
-            if (ex_str != "repeat")
-                state.last_ex_str = ex_str
             acceptExCmd(ex_str)
         } catch (e) {
             // Rumsfeldian errors are caught here
@@ -91,6 +89,8 @@ export function acceptExCmd(ex_str: string) {
     // TODO: Errors should go to CommandLine.
     try {
         let [func, args] = exmode_parser(ex_str)
+        if (!ex_str.startsWith("repeat"))
+            state.last_ex_str = ex_str
         try {
             func(...args)
         } catch (e) {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -68,6 +68,8 @@ function *ParserController () {
                     keys = response.keys
                 }
             }
+            if (ex_str != "repeat")
+                state.last_ex_str = ex_str
             acceptExCmd(ex_str)
         } catch (e) {
             // Rumsfeldian errors are caught here

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -897,25 +897,13 @@ import * as controller from './controller'
     Executes the command once if `n` isn't defined either.
 */
 //#background
-export function repeat(...args: string[]) {
-    let n = 1
-    let cmd = getLastExstr()
-    if (args.length > 0)
-        n = parseInt(args[0])
-    if (isNaN(n)) {
-        console.log(":repeat error: " + args[0] + " is not a number")
-        return
-    }
-    if (args.length > 1)
-        cmd = args.slice(1).join(" ")
+export function repeat(n = 1, ...exstr: string[]) {
+    let cmd = state.last_ex_str
+    if (exstr.length > 0)
+        cmd = exstr.join(" ")
     console.log("repeating " + cmd + " " + n + " times")
-    for (let i = 0; i < n; ++i)
+    for (let i = 0; i < n; i++)
         controller.acceptExCmd(cmd)
-}
-
-//#background_helper
-export function getLastExstr() {
-    return state.last_ex_str
 }
 
 /** Split `cmds` on pipes (|) and treat each as it's own command.

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -892,6 +892,32 @@ async function getnexttabs(tabid: number, n?: number) {
 //#background_helper
 import * as controller from './controller'
 
+/** Repeats a `cmd` `n` times.
+    Falls back to the last executed command if `cmd` doesn't exist.
+    Executes the command once if `n` isn't defined either.
+*/
+//#background
+export function repeat(...args: string[]) {
+    let n = 1
+    let cmd = getLastExstr()
+    if (args.length > 0)
+        n = parseInt(args[0])
+    if (isNaN(n)) {
+        console.log(":repeat error: " + args[0] + " is not a number")
+        return
+    }
+    if (args.length > 1)
+        cmd = args.slice(1).join(" ")
+    console.log("repeating " + cmd + " " + n + " times")
+    for (let i = 0; i < n; ++i)
+        controller.acceptExCmd(cmd)
+}
+
+//#background_helper
+export function getLastExstr() {
+    return state.last_ex_str
+}
+
 /** Split `cmds` on pipes (|) and treat each as it's own command.
 
     Workaround: this should clearly be in the parser, but we haven't come up with a good way to deal with |s in URLs, search terms, etc. yet.

--- a/src/state.ts
+++ b/src/state.ts
@@ -18,6 +18,7 @@ export type ModeName = 'normal' | 'insert' | 'hint' | 'ignore' | 'gobble' | 'inp
 class State {
     mode: ModeName = 'normal'
     cmdHistory: string[] = []
+    last_ex_str: string = ""
 }
 
 // Don't change these from const or you risk breaking the Proxy below.


### PR DESCRIPTION
This implements a pentadactyl-like repeat operator bound to `.` by default. I find pentadactyl's behavior quite strange but I preferred implementing something that behaves the same rather than a more intuitive behavior.

Will fix https://github.com/cmcaine/tridactyl/issues/147 once approved and merged. 