### PR TITLE
src/excmds.ts: Fix gh failing to open the homepage.

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -258,6 +258,7 @@ export async function reloadhard(n = 1) {
 //#content
 export function open(...urlarr: string[]) {
     let url = urlarr.join(" ")
+    console.log("open url:" + url)
     window.location.href = forceURI(url)
 }
 
@@ -274,7 +275,7 @@ export function home(all: "false" | "true" = "false"){
     let homepages = config.get("homepages")
     console.log(homepages)
     if (homepages.length > 0){
-        if (all === "false") open(homepages[-1])
+        if (all === "false") open(homepages[homepages.length - 1])
         else {
             homepages.map(t=>tabopen(t))
         }


### PR DESCRIPTION
Problem: When using home() to open the homepage, tridactyl opens the
default search engine instead.

Solution: This was due to calling open(homepages[-1]). Open recieved
`undefined` as argument, gave it to forceURI which returned the default
search engine URL. Replacing `-1` with `homepages.length-1` fixes the
issue.

Fixes issue https://github.com/cmcaine/tridactyl/issues/188