### PR TITLE
[RFC] `Tab` to cycle throught inputs, fix #191

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -23,6 +23,7 @@ import * as config from './config'
 import * as dom from './dom'
 import * as hinting_background from './hinting_background'
 import * as gobble_mode from './parsers/gobblemode'
+import * as input_mode from './parsers/inputmode'
 import * as itertools from './itertools'
 import * as keyseq from './keyseq'
 import * as msgsafe from './msgsafe'
@@ -39,6 +40,7 @@ import * as webext from './lib/webext'
     dom,
     hinting_background,
     gobble_mode,
+    input_mode,
     itertools,
     keydown_background,
     keyseq,

--- a/src/config.ts
+++ b/src/config.ts
@@ -114,6 +114,7 @@ const DEFAULTS = o({
     "ttsvolume": 1,         // 0 to 1
     "ttsrate": 1,           // 0.1 to 10
     "ttspitch": 1,          // 0 to 2
+    "vimium-gi": true,
 })
 
 // currently only supports 2D or 1D storage

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -9,6 +9,7 @@ import * as normalmode from "./parsers/normalmode"
 import * as insertmode from "./parsers/insertmode"
 import * as ignoremode from "./parsers/ignoremode"
 import * as gobblemode from './parsers/gobblemode'
+import * as inputmode from './parsers/inputmode'
 
 
 /** Accepts keyevents, resolves them to maps, maps to exstrs, executes exstrs */
@@ -19,6 +20,7 @@ function *ParserController () {
         ignore: ignoremode.parser,
         hint: hintmode_parser,
         gobble: gobblemode.parser,
+        input: inputmode.parser,
     }
 
     while (true) {
@@ -30,7 +32,7 @@ function *ParserController () {
                 let keypress = keyevent.key
 
                 // TODO: think about if this is robust
-                if (state.mode != "ignore" && state.mode != "hint") {
+                if (state.mode != "ignore" && state.mode != "hint" && state.mode != "input") {
                     if (isTextEditable(keyevent.target)) {
                         state.mode = "insert"
                     } else if (state.mode === 'insert') {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -471,6 +471,8 @@ let LAST_USED_INPUT: HTMLElement = null
  *
  * @param nth   focus the nth input on the page, or "special" inputs:
  *                  "-l": last focussed input
+ *                  "-n": input after last focussed one
+ *                  "-N": input before last focussed one
  *                  "-p": first password field
  *                  "-b": biggest input field
  */
@@ -493,6 +495,22 @@ export function focusinput(nth: number|string) {
         // will need to serialise the last used input to a string that
         // we can look up in future (tabindex, selector?), perhaps along with
         // a way to remember the page it was on?
+    }
+    else if (nth === "-n" || nth === "-N") {
+        // attempt to find next/previous input
+        let inputs = DOM.getElemsBySelector(INPUTTAGS_selectors,
+            [DOM.isSubstantial]) as HTMLElement[]
+        if (inputs.length) {
+            let index = inputs.indexOf(LAST_USED_INPUT)
+            if (nth === "-n") {
+                index++
+            } else {
+                if (LAST_USED_INPUT === null) index = -1
+                else index--
+            }
+            index = index.mod(inputs.length)
+            inputToFocus = <HTMLElement>inputs[index]
+        }
     }
     else if (nth === "-p") {
         // attempt to find a password input
@@ -522,7 +540,10 @@ export function focusinput(nth: number|string) {
                                          index, [DOM.isSubstantial])
     }
 
-    if (inputToFocus) inputToFocus.focus()
+    if (inputToFocus) {
+        inputToFocus.focus()
+        if (nth === "-l") input_mode()
+    }
 }
 
 // Store the last focused element
@@ -1265,6 +1286,21 @@ import * as gobbleMode from './parsers/gobblemode'
 //#background
 export async function gobble(nChars: number, endCmd: string) {
     gobbleMode.init(nChars, endCmd)
+}
+
+// }}}
+//
+
+// {{{ INPUT mode
+
+//#content_helper
+import * as inputMode from './parsers/inputmode'
+
+/** Initialize input mode.
+*/
+//#content
+function input_mode() {
+    inputMode.init()
 }
 
 // }}}

--- a/src/keydown_content.ts
+++ b/src/keydown_content.ts
@@ -11,7 +11,7 @@ function keyeventHandler(ke: KeyboardEvent) {
 
     // Bad workaround: never suppress events in an editable field
     // and never suppress keys pressed with modifiers
-    if (! (isTextEditable(ke.target as Node) || ke.ctrlKey || ke.altKey)) {
+    if (state.mode === 'input' || ! (isTextEditable(ke.target as Node) || ke.ctrlKey || ke.altKey)) {
         suppressKey(ke)
     }
 
@@ -61,6 +61,12 @@ function TerribleModeSpecificSuppression(ke: KeyboardEvent) {
             break;
         case "gobble":
             if (isSimpleKey(ke) || ke.key === "Escape") {
+                ke.preventDefault()
+                ke.stopImmediatePropagation()
+            }
+            break
+        case "input":
+            if (ke.key === "Tab") {
                 ke.preventDefault()
                 ke.stopImmediatePropagation()
             }

--- a/src/parsers/inputmode.ts
+++ b/src/parsers/inputmode.ts
@@ -1,0 +1,21 @@
+import state from '../state'
+import {MsgSafeKeyboardEvent} from '../msgsafe'
+
+export function init() {
+    state.mode = 'input'
+}
+
+export function parser(keys: MsgSafeKeyboardEvent[]) {
+    const key = keys[0].key
+
+    if (key === 'Escape') {
+        state.mode = 'normal'
+        return { keys: [], ex_str: 'unfocus' }
+    } else if (key === 'Tab') {
+        if (keys[0].shiftKey)
+            return { keys: [], ex_str: 'focusinput -N' }
+        else
+            return { keys: [], ex_str: 'focusinput -n' }
+    }
+    return { keys: [], ex_str: '' }
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -14,7 +14,7 @@
     If this turns out to be expensive there are improvements available.
 */
 
-export type ModeName = 'normal' | 'insert' | 'hint' | 'ignore' | 'gobble'
+export type ModeName = 'normal' | 'insert' | 'hint' | 'ignore' | 'gobble' | 'input'
 class State {
     mode: ModeName = 'normal'
     cmdHistory: string[] = []


### PR DESCRIPTION
Not sure about the implementation, comments are welcome.

Keybinding has problem, `Tab` still focus on next any element, and then focus on next input element.