### PR TITLE
Hints: do not force uppercase display of hintchars

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -105,7 +105,7 @@ const DEFAULTS = o({
     "newtab": undefined,
     "storageloc": "sync",
     "homepages": [],
-    "hintchars": "hjklasdfgyuiopqwertnmzxcvb",
+    "hintchars": "HJKLASDFGYUIOPQWERTNMZXCVB",
 
     "ttsvoice": "default",  // chosen from the listvoices list, or "default"
     "ttsvolume": 1,         // 0 to 1

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1204,7 +1204,7 @@ import * as hinting from './hinting_background'
           - `bind ;c hint -c [class*="expand"],[class="togg"]` works particularly well on reddit and HN
 
     Related settings:
-        "hintchars": "hjklasdfgyuiopqwertnmzxcvb"
+        "hintchars": "HJKLASDFGYUIOPQWERTNMZXCVB"
 */
 //#background
 export function hint(option?: string, selectors="") {

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -13,7 +13,7 @@
 import * as DOM from './dom'
 import {log} from './math'
 import {permutationsWithReplacement, islice, izip, map} from './itertools'
-import {hasModifiers} from './keyseq'
+import {hasNonShiftModifiers} from './keyseq'
 import state from './state'
 import {messageActiveTab} from './messaging'
 import * as config from './config'
@@ -187,7 +187,7 @@ function reset() {
 
 /** If key is in hintchars, add it to filtstr and filter */
 function pushKey(ke) {
-    if (hasModifiers(ke)) {
+    if (hasNonShiftModifiers(ke)) {
         return
     } else if (ke.key === 'Backspace') {
         modeState.filter = modeState.filter.slice(0,-1)
@@ -197,6 +197,13 @@ function pushKey(ke) {
     } else if (modeState.hintchars.includes(ke.key)) {
         modeState.filter += ke.key
         filter(modeState.filter)
+    } else {
+        let regexp = new RegExp(ke.key, "i")
+        let m = modeState.hintchars.match(regexp)
+        if (m) {
+            modeState.filter += m
+            filter(modeState.filter)
+        }
     }
 }
 

--- a/src/static/hint.css
+++ b/src/static/hint.css
@@ -3,7 +3,6 @@ span.TridactylHint {
     font-family: sans-serif;
     font-size: 12px;
     font-weight: bold;
-    text-transform: uppercase;
     color: white;
     background-color: red;
     border-color: ButtonShadow;


### PR DESCRIPTION
Those 2 commits allows to use both uppercase and lowercase hintchars.

Please see pr #130 for the origin of this pr.