### PR TITLE
Allow levelled logging for debug

### DIFF
--- a/src/commandline_content.ts
+++ b/src/commandline_content.ts
@@ -1,5 +1,7 @@
 /** Inject an input element into unsuspecting webpages and provide an API for interaction with tridactyl */
 
+import * as Logging from './logging'
+
 /* TODO:
     CSS
     Friendliest-to-webpage way of injecting commandline bar?
@@ -16,14 +18,13 @@ let cmdline_iframe: HTMLIFrameElement = undefined
 function init(){
     if (cmdline_iframe === undefined && window.document.body !== null) {
         try {
-            console.log("INIT")
             cmdline_iframe = window.document.createElement("iframe")
             cmdline_iframe.setAttribute("src", browser.extension.getURL("static/commandline.html"))
             cmdline_iframe.setAttribute("id", "cmdline_iframe")
             hide()
             window.document.body.appendChild(cmdline_iframe)
         } catch (e) {
-            console.error("Couldn't initialise cmdline_iframe!", e)
+            Logging.error('cmdline', "Couldn't initialise cmdline_iframe!", e)
         }
     }
 }

--- a/src/commandline_content.ts
+++ b/src/commandline_content.ts
@@ -1,6 +1,7 @@
 /** Inject an input element into unsuspecting webpages and provide an API for interaction with tridactyl */
 
-import * as Logging from './logging'
+import Logger from './logging'
+const logger = new Logger('messaging')
 
 /* TODO:
     CSS
@@ -24,7 +25,7 @@ function init(){
             hide()
             window.document.body.appendChild(cmdline_iframe)
         } catch (e) {
-            Logging.error('cmdline', "Couldn't initialise cmdline_iframe!", e)
+            logger.error("Couldn't initialise cmdline_iframe!", e)
         }
     }
 }

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -7,7 +7,8 @@ import * as Messaging from './messaging'
 import * as SELF from './commandline_frame'
 import './number.clamp'
 import state from './state'
-import * as Logging from "./logging"
+import Logger from './logging'
+const logger = new Logger('cmdline')
 
 let activeCompletions: Completions.CompletionSource[] = undefined
 let completionsDiv = window.document.getElementById("completions") as HTMLElement
@@ -147,7 +148,7 @@ clInput.addEventListener("keydown", function (keyevent) {
 
 clInput.addEventListener("input", () => {
     // Fire each completion and add a callback to resize area
-    Logging.debug("cmdline", activeCompletions)
+    logger.debug(activeCompletions)
     activeCompletions.forEach(comp =>
         comp.filter(clInput.value).then(() => resizeArea())
     )
@@ -246,7 +247,7 @@ export function setClipboard(content: string) {
         scratchpad.select()
         if (document.execCommand("Copy")) {
             // // todo: Maybe we can consider to using some logger and show it with status bar in the future
-            Logging.info('cmdline', 'set clipboard:', scratchpad.value)
+            logger.info('set clipboard:', scratchpad.value)
         } else throw "Failed to copy!"
     })
 }

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -7,6 +7,7 @@ import * as Messaging from './messaging'
 import * as SELF from './commandline_frame'
 import './number.clamp'
 import state from './state'
+import * as Logging from "./logging"
 
 let activeCompletions: Completions.CompletionSource[] = undefined
 let completionsDiv = window.document.getElementById("completions") as HTMLElement
@@ -146,7 +147,7 @@ clInput.addEventListener("keydown", function (keyevent) {
 
 clInput.addEventListener("input", () => {
     // Fire each completion and add a callback to resize area
-    console.log(activeCompletions)
+    Logging.log("cmdline", Logging.LEVEL.DEBUG)(activeCompletions)
     activeCompletions.forEach(comp =>
         comp.filter(clInput.value).then(() => resizeArea())
     )

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -147,7 +147,7 @@ clInput.addEventListener("keydown", function (keyevent) {
 
 clInput.addEventListener("input", () => {
     // Fire each completion and add a callback to resize area
-    Logging.log("cmdline", Logging.LEVEL.DEBUG)(activeCompletions)
+    Logging.debug("cmdline", activeCompletions)
     activeCompletions.forEach(comp =>
         comp.filter(clInput.value).then(() => resizeArea())
     )
@@ -198,9 +198,7 @@ function history(n){
 
 /* Send the commandline to the background script and await response. */
 function process() {
-    console.log(clInput.value)
     const command = getCompletion() || clInput.value
-    console.log(command)
 
     hide_and_clear()
 
@@ -211,7 +209,6 @@ function process() {
     ) {
         state.cmdHistory = state.cmdHistory.concat([command])
     }
-    console.log(state.cmdHistory)
     cmdline_history_position = 0
 
     sendExstr(command)
@@ -249,7 +246,7 @@ export function setClipboard(content: string) {
         scratchpad.select()
         if (document.execCommand("Copy")) {
             // // todo: Maybe we can consider to using some logger and show it with status bar in the future
-            console.log('set clipboard:', scratchpad.value)
+            Logging.info('cmdline', 'set clipboard:', scratchpad.value)
         } else throw "Failed to copy!"
     })
 }
@@ -258,7 +255,6 @@ export function getClipboard() {
     return applyWithTmpTextArea(scratchpad => {
         scratchpad.focus()
         document.execCommand("Paste")
-        console.log('get clipboard', scratchpad.textContent)
         return scratchpad.textContent
     })
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -126,11 +126,14 @@ const DEFAULTS = o({
     "ttspitch": 1,          // 0 to 2
     "vimium-gi": true,
 
-    // Default logging levels - generally 2 == WARNING
+    // Default logging levels - 2 === WARNING
     "logging": o({
-        "message": 2,
+        "messaging": 2,
         "cmdline": 2,
         "controller": 2,
+        "hinting": 2,
+        "state": 2,
+        "excmd": 1,
     }),
 })
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@
 //
 // Really, we'd like a way of just letting things use the variables
 //
+
 const CONFIGNAME = "userconfig"
 
 type StorageMap = browser.storage.StorageMap
@@ -124,6 +125,13 @@ const DEFAULTS = o({
     "ttsrate": 1,           // 0.1 to 10
     "ttspitch": 1,          // 0 to 2
     "vimium-gi": true,
+
+    // Default logging levels - generally 2 == WARNING
+    "logging": o({
+        "message": 2,
+        "cmdline": 2,
+        "controller": 2,
+    }),
 })
 
 // currently only supports 2D or 1D storage

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -3,6 +3,7 @@ import {isTextEditable} from './dom'
 import {isSimpleKey} from './keyseq'
 import state from "./state"
 import {repeat} from './excmds_background'
+import * as Logging from "./logging"
 
 import {parser as exmode_parser} from './parsers/exmode'
 import {parser as hintmode_parser} from './hinting_background'
@@ -41,7 +42,8 @@ function *ParserController () {
                         state.mode = "normal"
                     }
                 }
-                console.log(keyevent, state.mode)
+                Logging.log("controller", Logging.LEVEL.DEBUG)(
+                    keyevent, state.mode)
 
                 // Special keys (e.g. Backspace) are not handled properly
                 // yet. So drop them. This also drops all modifier keys.
@@ -61,7 +63,8 @@ function *ParserController () {
                         response = (parsers[state.mode] as any)([keyevent])
                         break
                 }
-                console.debug(keys, response)
+                Logging.log("controller", Logging.LEVEL.DEBUG)(
+                    keys, response)
 
                 if (response.ex_str){
                     ex_str = response.ex_str

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -3,7 +3,7 @@ import {isTextEditable} from './dom'
 import {isSimpleKey} from './keyseq'
 import state from "./state"
 import {repeat} from './excmds_background'
-import * as Logging from "./logging"
+import Logger from "./logging"
 
 import {parser as exmode_parser} from './parsers/exmode'
 import {parser as hintmode_parser} from './hinting_background'
@@ -14,6 +14,7 @@ import * as gobblemode from './parsers/gobblemode'
 import * as inputmode from './parsers/inputmode'
 
 
+const logger = new Logger('controller')
 
 /** Accepts keyevents, resolves them to maps, maps to exstrs, executes exstrs */
 function *ParserController () {
@@ -42,7 +43,7 @@ function *ParserController () {
                         state.mode = "normal"
                     }
                 }
-                Logging.debug("controller", keyevent, state.mode)
+                logger.debug(keyevent, state.mode)
 
                 // Special keys (e.g. Backspace) are not handled properly
                 // yet. So drop them. This also drops all modifier keys.
@@ -62,7 +63,7 @@ function *ParserController () {
                         response = (parsers[state.mode] as any)([keyevent])
                         break
                 }
-                Logging.debug("controller", keys, response)
+                logger.debug(keys, response)
 
                 if (response.ex_str){
                     ex_str = response.ex_str

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -42,8 +42,7 @@ function *ParserController () {
                         state.mode = "normal"
                     }
                 }
-                Logging.log("controller", Logging.LEVEL.DEBUG)(
-                    keyevent, state.mode)
+                Logging.debug("controller", keyevent, state.mode)
 
                 // Special keys (e.g. Backspace) are not handled properly
                 // yet. So drop them. This also drops all modifier keys.
@@ -63,8 +62,7 @@ function *ParserController () {
                         response = (parsers[state.mode] as any)([keyevent])
                         break
                 }
-                Logging.log("controller", Logging.LEVEL.DEBUG)(
-                    keys, response)
+                Logging.debug("controller", keys, response)
 
                 if (response.ex_str){
                     ex_str = response.ex_str

--- a/src/download_background.ts
+++ b/src/download_background.ts
@@ -66,13 +66,9 @@ export async function downloadUrl(url: string, saveAs: boolean) {
 
     // TODO: at this point, could give feeback using the promise returned
     // by downloads.download(), needs status bar to show it (#90)
-    downloadPromise.then(id => {
-        //console.log("Downloaded OK: ", urlToSave)
-        },
-        error => {
-            console.log("Failed to download: ", urlToDownload, error)
-        }
-    )
+    // By awaiting the promise, we ensure that if it errors, the error will be
+    // thrown by this function too.
+    await downloadPromise
 }
 
 import * as Messaging from "./messaging"

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -95,6 +95,8 @@ import * as CommandLineBackground from './commandline_background'
 import * as DOM from './dom'
 
 import * as config from './config'
+//#background_helper
+import * as Logging from "./logging"
 
 
 /** @hidden */
@@ -171,6 +173,33 @@ function tabSetActive(id: number) {
 
 // }}}
 
+// {{{ INTERNAL/DEBUG
+
+/**
+ * Set the logging level for a given logging module.
+ *
+ * @param logModule     the logging module to set the level on
+ * @param level         the level to log at: in increasing verbosity, one of
+ *                      "never", "error", "warning", "info", "debug"
+ */
+//#background
+export function loggingsetlevel(logModule: string, level: string) {
+    const map = {
+        "never": Logging.LEVEL.NEVER,
+        "error": Logging.LEVEL.ERROR,
+        "warning": Logging.LEVEL.WARNING,
+        "info": Logging.LEVEL.INFO,
+        "debug": Logging.LEVEL.DEBUG,
+    }
+
+    let newLevel = map[level]
+
+    if (newLevel !== undefined) {
+        config.set("logging", newLevel, logModule)
+    }
+}
+
+// }}}
 
 // {{{ PAGE CONTEXT
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -95,8 +95,8 @@ import * as CommandLineBackground from './commandline_background'
 import * as DOM from './dom'
 
 import * as config from './config'
-//#background_helper
 import * as Logging from "./logging"
+const logger = new Logging.Logger('excmds')
 
 
 /** @hidden */
@@ -930,7 +930,7 @@ export function repeat(n = 1, ...exstr: string[]) {
     let cmd = state.last_ex_str
     if (exstr.length > 0)
         cmd = exstr.join(" ")
-    Logging.debug('excmd', "repeating " + cmd + " " + n + " times")
+    logger.debug("repeating " + cmd + " " + n + " times")
     for (let i = 0; i < n; i++)
         controller.acceptExCmd(cmd)
 }

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -191,7 +191,7 @@ export function loggingsetlevel(logModule: string, level: string) {
         "debug": Logging.LEVEL.DEBUG,
     }
 
-    let newLevel = map[level]
+    let newLevel = map[level.toLowerCase()]
 
     if (newLevel !== undefined) {
         config.set("logging", newLevel, logModule)
@@ -930,7 +930,7 @@ export function repeat(n = 1, ...exstr: string[]) {
     let cmd = state.last_ex_str
     if (exstr.length > 0)
         cmd = exstr.join(" ")
-    console.log("repeating " + cmd + " " + n + " times")
+    Logging.debug('excmd', "repeating " + cmd + " " + n + " times")
     for (let i = 0; i < n; i++)
         controller.acceptExCmd(cmd)
 }

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -146,7 +146,6 @@ function forceURI(maybeURI: string): string {
         const args = maybeURI.split(' ')
         return searchURL(args[0], args.slice(1).join(' ')).href
     } catch (e) {
-        console.log(e)
         if (e.name !== 'TypeError') throw e
     }
 
@@ -298,7 +297,6 @@ export async function reloadhard(n = 1) {
 //#content
 export function open(...urlarr: string[]) {
     let url = urlarr.join(" ")
-    console.log("open url:" + url)
     window.location.href = forceURI(url)
 }
 
@@ -313,7 +311,6 @@ export function open(...urlarr: string[]) {
 //#background
 export function home(all: "false" | "true" = "false"){
     let homepages = config.get("homepages")
-    console.log(homepages)
     if (homepages.length > 0){
         if (all === "false") open(homepages[homepages.length - 1])
         else {
@@ -1187,12 +1184,10 @@ export async function sanitize(...args: string[]) {
                 }
                 since = { "since": (new Date()).getTime() - millis }
             } else {
-                console.log(":sanitize error: expected time format: ^([0-9])+(m|h|d|w)$, given format:" + args[flagpos+1])
-                return
+                throw new Error(":sanitize error: expected time format: ^([0-9])+(m|h|d|w)$, given format:" + args[flagpos+1])
             }
         } else {
-            console.log(":sanitize error: -t given but no following arguments")
-            return
+            throw new Error(":sanitize error: -t given but no following arguments")
         }
     }
 
@@ -1427,10 +1422,10 @@ export async function ttsread(mode: "-t" | "-c", ...args: string[]) {
         if (args.length > 0) {
             tssReadFromCss(args[0])
         } else {
-            console.log("Error: no CSS selector supplied")
+            throw "Error: no CSS selector supplied"
         }
     } else {
-        console.log("Unknown mode for ttsread command: " + mode)
+        throw "Unknown mode for ttsread command: " + mode
     }
 }
 
@@ -1469,7 +1464,7 @@ export async function ttscontrol(action: string) {
     if (ttsAction) {
         TTS.doAction(ttsAction)
     } else {
-        console.log("Unknown text-to-speech action: " + action)
+        throw new Error("Unknown text-to-speech action: " + action)
     }
 }
 

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -19,7 +19,8 @@ import {messageActiveTab, message} from './messaging'
 import * as config from './config'
 import * as TTS from './text_to_speech'
 import {HintSaveType} from './hinting_background'
-import * as Logging from './logging'
+import Logger from './logging'
+const logger = new Logger('hinting')
 
 /** Simple container for the state of a single frame's hints. */
 class HintState {
@@ -54,13 +55,13 @@ export function hintPage(
     state.mode = 'hint'
     modeState = new HintState()
     for (let [el, name] of izip( hintableElements, names)) {
-        Logging.debug('hinting', {el, name})
+        logger.debug({el, name})
         modeState.hintchars += name
         modeState.hints.push(new Hint(el, name, onSelect))
     }
 
     if (modeState.hints.length) {
-        Logging.debug('hinting', "hints", modeState.hints)
+        logger.debug("hints", modeState.hints)
         modeState.focusedHint = modeState.hints[0]
         modeState.focusedHint.focused = true
         document.body.appendChild(modeState.hintHost)
@@ -456,7 +457,7 @@ function hintSave(hintType: HintSaveType, saveAs: boolean) {
 }
 
 function selectFocusedHint() {
-    Logging.debug("hinting", "Selecting hint.", state.mode)
+    logger.debug("Selecting hint.", state.mode)
     const focused = modeState.focusedHint
     reset()
     focused.select()

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -19,6 +19,7 @@ import {messageActiveTab, message} from './messaging'
 import * as config from './config'
 import * as TTS from './text_to_speech'
 import {HintSaveType} from './hinting_background'
+import * as Logging from './logging'
 
 /** Simple container for the state of a single frame's hints. */
 class HintState {
@@ -53,13 +54,13 @@ export function hintPage(
     state.mode = 'hint'
     modeState = new HintState()
     for (let [el, name] of izip( hintableElements, names)) {
-        console.log({el, name})
+        Logging.debug('hinting', {el, name})
         modeState.hintchars += name
         modeState.hints.push(new Hint(el, name, onSelect))
     }
 
     if (modeState.hints.length) {
-        console.log("HINTS", modeState.hints)
+        Logging.debug('hinting', "hints", modeState.hints)
         modeState.focusedHint = modeState.hints[0]
         modeState.focusedHint.focused = true
         document.body.appendChild(modeState.hintHost)
@@ -455,7 +456,7 @@ function hintSave(hintType: HintSaveType, saveAs: boolean) {
 }
 
 function selectFocusedHint() {
-    console.log("Selecting hint.", state.mode)
+    Logging.debug("hinting", "Selecting hint.", state.mode)
     const focused = modeState.focusedHint
     reset()
     focused.select()

--- a/src/hinting_background.ts
+++ b/src/hinting_background.ts
@@ -70,7 +70,6 @@ import {MsgSafeKeyboardEvent} from './msgsafe'
 
 */
 export function parser(keys: MsgSafeKeyboardEvent[]) {
-    console.log("hintparser", keys)
     const key = keys[0].key
     if (key === 'Escape') {
         reset()

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -4,7 +4,6 @@
 
 import * as Config from "./config"
 
-
 export enum LEVEL {
     NEVER = 0,      // don't use this in calls to log()
     ERROR = 1,
@@ -13,49 +12,61 @@ export enum LEVEL {
     DEBUG = 4,
 }
 
-/**
- * Config-aware logging function.
- *
- * @param logModule     the logging module name: this is ued to look up the
- *                      configured/default level in the user config
- * @param level         the level of the logging - if <= configured, the message
- *                      will be shown
- *
- * @return              logging function: this is returned as a function to
- *                      retain the call site
- */
-function log(logModule: string, level: LEVEL) {
+export class Logger {
+    /**
+     * Config-aware Logger class.
+     *
+     * @param logModule     the logging module name: this is ued to look up the
+     *                      configured/default level in the user config
+     */
+    constructor(private logModule) {}
 
-    let configedLevel = Config.get("logging", logModule) || LEVEL.WARNING
+    /**
+     * Config-aware logging function.
+     *
+     * @param level         the level of the logging - if <= configured, the message
+     *                      will be shown
+     *
+     * @return              logging function: this is returned as a function to
+     *                      retain the call site
+     */
+    private log(level: LEVEL) {
+        let configedLevel = Config.get("logging", this.logModule) || LEVEL.WARNING
 
-    if (level <= configedLevel) {
-        // hand over to console.log, error or debug as needed
-        switch (level) {
+        if (level <= configedLevel) {
+            // hand over to console.log, error or debug as needed
+            switch (level) {
 
-            case LEVEL.ERROR:
-                return console.error
-            case LEVEL.WARNING:
-                return console.warn
-            case LEVEL.INFO:
-                return console.log
-            case LEVEL.DEBUG:
-                return console.debug
+                case LEVEL.ERROR:
+                    return console.error
+                case LEVEL.WARNING:
+                    return console.warn
+                case LEVEL.INFO:
+                    return console.log
+                case LEVEL.DEBUG:
+                    return console.debug
+            }
         }
+
+        // do nothing with the message
+        return function(...args) {}
     }
 
-    // do nothing with the message
-    return function(...args) {}
+    // These are all getters so that logger.debug = console.debug and
+    // logger.debug('blah') translates into console.debug('blah') with the
+    // filename and line correct.
+    public get debug() {
+        return this.log(LEVEL.DEBUG)
+    }
+    public get info() {
+        return this.log(LEVEL.INFO)
+    }
+    public get warning() {
+        return this.log(LEVEL.WARNING)
+    }
+    public get error() {
+        return this.log(LEVEL.ERROR)
+    }
 }
 
-export function debug(logModule: string, ...args) {
-    log(logModule, LEVEL.DEBUG)(...args)
-}
-export function info(logModule: string, ...args) {
-    log(logModule, LEVEL.INFO)(...args)
-}
-export function warning(logModule: string, ...args) {
-    log(logModule, LEVEL.WARNING)(...args)
-}
-export function error(logModule: string, ...args) {
-    log(logModule, LEVEL.ERROR)(...args)
-}
+export default Logger

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -24,7 +24,7 @@ export enum LEVEL {
  * @return              logging function: this is returned as a function to
  *                      retain the call site
  */
-export function log(logModule: string, level: LEVEL) {
+function log(logModule: string, level: LEVEL) {
 
     let configedLevel = Config.get("logging", logModule) || LEVEL.WARNING
 
@@ -45,4 +45,17 @@ export function log(logModule: string, level: LEVEL) {
 
     // do nothing with the message
     return function(...args) {}
+}
+
+export function debug(logModule: string, ...args) {
+    log(logModule, LEVEL.DEBUG)(...args)
+}
+export function info(logModule: string, ...args) {
+    log(logModule, LEVEL.INFO)(...args)
+}
+export function warning(logModule: string, ...args) {
+    log(logModule, LEVEL.WARNING)(...args)
+}
+export function error(logModule: string, ...args) {
+    log(logModule, LEVEL.ERROR)(...args)
 }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,48 @@
+/**
+ * Helper functions for logging
+ */
+
+import * as Config from "./config"
+
+
+export enum LEVEL {
+    NEVER = 0,      // don't use this in calls to log()
+    ERROR = 1,
+    WARNING = 2,
+    INFO = 3,
+    DEBUG = 4,
+}
+
+/**
+ * Config-aware logging function.
+ *
+ * @param logModule     the logging module name: this is ued to look up the
+ *                      configured/default level in the user config
+ * @param level         the level of the logging - if <= configured, the message
+ *                      will be shown
+ *
+ * @return              logging function: this is returned as a function to
+ *                      retain the call site
+ */
+export function log(logModule: string, level: LEVEL) {
+
+    let configedLevel = Config.get("logging", logModule) || LEVEL.WARNING
+
+    if (level <= configedLevel) {
+        // hand over to console.log, error or debug as needed
+        switch (level) {
+
+            case LEVEL.ERROR:
+                return console.error
+            case LEVEL.WARNING:
+                return console.warn
+            case LEVEL.INFO:
+                return console.log
+            case LEVEL.DEBUG:
+                return console.debug
+        }
+    }
+
+    // do nothing with the message
+    return function(...args) {}
+}

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -1,4 +1,5 @@
 import {l, browserBg, activeTabId} from './lib/webext'
+import * as Logging from './logging'
 
 export type TabMessageType =
     "excmd_content" |
@@ -24,7 +25,8 @@ export type listener = (message: Message, sender?, sendResponse?) => void|Promis
 // Calls methods on obj that match .command and sends responses back
 export function attributeCaller(obj) {
     function handler(message: Message, sender, sendResponse) {
-        console.log("Message:", message)
+
+        Logging.log("message", Logging.LEVEL.DEBUG)(message)
 
         // Args may be undefined, but you can't spread undefined...
         if (message.args === undefined) message.args = []
@@ -35,13 +37,13 @@ export function attributeCaller(obj) {
 
             // Return response to sender
             if (response instanceof Promise) {
-                console.log("Returning promise...", response)
+                Logging.log("Returning promise...", Logging.LEVEL.DEBUG)(response)
                 sendResponse(response)
                 // Docs say you should be able to return a promise, but that
                 // doesn't work.
                 /* return response */
             } else if (response !== undefined) {
-                console.log("Returning synchronously...", response)
+                Logging.log("Returning synchronously...", Logging.LEVEL.DEBUG)(response)
                 sendResponse(response)
             }
         } catch (e) {

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -26,7 +26,7 @@ export type listener = (message: Message, sender?, sendResponse?) => void|Promis
 export function attributeCaller(obj) {
     function handler(message: Message, sender, sendResponse) {
 
-        Logging.log("message", Logging.LEVEL.DEBUG)(message)
+        Logging.debug("messaging", message)
 
         // Args may be undefined, but you can't spread undefined...
         if (message.args === undefined) message.args = []
@@ -37,17 +37,17 @@ export function attributeCaller(obj) {
 
             // Return response to sender
             if (response instanceof Promise) {
-                Logging.log("Returning promise...", Logging.LEVEL.DEBUG)(response)
+                Logging.debug("messaging", "Returning promise...", response)
                 sendResponse(response)
                 // Docs say you should be able to return a promise, but that
                 // doesn't work.
                 /* return response */
             } else if (response !== undefined) {
-                Logging.log("Returning synchronously...", Logging.LEVEL.DEBUG)(response)
+                Logging.debug("messaging", "Returning synchronously...", response)
                 sendResponse(response)
             }
         } catch (e) {
-            console.error(`Error processing ${message.command}(${message.args})`, e)
+            Logging.error('messaging', `Error processing ${message.command}(${message.args})`, e)
             return new Promise((resolve, error)=>error(e))
         }
     }
@@ -80,7 +80,7 @@ export async function messageAllTabs(type: TabMessageType, command: string, args
     let responses = []
     for (let tab of await browserBg.tabs.query({})) {
         try { responses.push(await messageTab(tab.id, type, command, args)) }
-        catch (e) { console.error(e) }
+        catch (e) { Logging.error('messaging', e) }
     }
     return responses
 }

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -1,5 +1,6 @@
 import {l, browserBg, activeTabId} from './lib/webext'
-import * as Logging from './logging'
+import Logger from './logging'
+const logger = new Logger('messaging')
 
 export type TabMessageType =
     "excmd_content" |
@@ -26,7 +27,7 @@ export type listener = (message: Message, sender?, sendResponse?) => void|Promis
 export function attributeCaller(obj) {
     function handler(message: Message, sender, sendResponse) {
 
-        Logging.debug("messaging", message)
+        logger.debug(message)
 
         // Args may be undefined, but you can't spread undefined...
         if (message.args === undefined) message.args = []
@@ -37,17 +38,17 @@ export function attributeCaller(obj) {
 
             // Return response to sender
             if (response instanceof Promise) {
-                Logging.debug("messaging", "Returning promise...", response)
+                logger.debug("Returning promise...", response)
                 sendResponse(response)
                 // Docs say you should be able to return a promise, but that
                 // doesn't work.
                 /* return response */
             } else if (response !== undefined) {
-                Logging.debug("messaging", "Returning synchronously...", response)
+                logger.debug("Returning synchronously...", response)
                 sendResponse(response)
             }
         } catch (e) {
-            Logging.error('messaging', `Error processing ${message.command}(${message.args})`, e)
+            logger.error(`Error processing ${message.command}(${message.args})`, e)
             return new Promise((resolve, error)=>error(e))
         }
     }
@@ -80,7 +81,7 @@ export async function messageAllTabs(type: TabMessageType, command: string, args
     let responses = []
     for (let tab of await browserBg.tabs.query({})) {
         try { responses.push(await messageTab(tab.id, type, command, args)) }
-        catch (e) { Logging.error('messaging', e) }
+        catch (e) { logger.error(e) }
     }
     return responses
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -14,7 +14,8 @@
     If this turns out to be expensive there are improvements available.
 */
 
-import * as Logging from './logging'
+import Logger from './logging'
+const logger = new Logger('state')
 
 export type ModeName = 'normal' | 'insert' | 'hint' | 'ignore' | 'gobble' | 'input'
 class State {
@@ -29,10 +30,10 @@ const defaults = Object.freeze(new State())
 const overlay = {} as any
 browser.storage.local.get('state').then(res=>{
     if ('state' in res) {
-        Logging.debug('state', "Loaded initial state:", res.state)
+        logger.debug("Loaded initial state:", res.state)
         Object.assign(overlay, res.state)
     }
-}).catch((...args) => Logging.error('state', ...args))
+}).catch((...args) => logger.error(...args))
 
 const state = new Proxy(overlay, {
 
@@ -47,7 +48,7 @@ const state = new Proxy(overlay, {
 
     /** Persist sets to storage immediately */
     set: function(target, property, value) {
-        Logging.debug('state', "State changed!", property, value)
+        logger.debug("State changed!", property, value)
         target[property] = value
         browser.storage.local.set({state: target})
         return true

--- a/src/state.ts
+++ b/src/state.ts
@@ -14,6 +14,8 @@
     If this turns out to be expensive there are improvements available.
 */
 
+import * as Logging from './logging'
+
 export type ModeName = 'normal' | 'insert' | 'hint' | 'ignore' | 'gobble' | 'input'
 class State {
     mode: ModeName = 'normal'
@@ -27,10 +29,10 @@ const defaults = Object.freeze(new State())
 const overlay = {} as any
 browser.storage.local.get('state').then(res=>{
     if ('state' in res) {
-        console.log("Loaded initial state:", res.state)
+        Logging.debug('state', "Loaded initial state:", res.state)
         Object.assign(overlay, res.state)
     }
-}).catch(console.error)
+}).catch((...args) => Logging.error('state', ...args))
 
 const state = new Proxy(overlay, {
 
@@ -45,7 +47,7 @@ const state = new Proxy(overlay, {
 
     /** Persist sets to storage immediately */
     set: function(target, property, value) {
-        console.log("State changed!", property, value)
+        Logging.debug('state', "State changed!", property, value)
         target[property] = value
         browser.storage.local.set({state: target})
         return true

--- a/src/text_to_speech.ts
+++ b/src/text_to_speech.ts
@@ -24,8 +24,7 @@ export function readText(text: string): void {
     if (window.speechSynthesis.getVoices().length === 0) {
         // should try to warn user? This apparently can happen on some machines
         // TODO: Implement when there's an error feedback mechanism
-        console.log("No voice found: cannot use Text-To-Speech API")
-        return
+        throw new Error("No voice found: cannot use Text-To-Speech API")
     }
 
     let utterance = new SpeechSynthesisUtterance(text);


### PR DESCRIPTION
This is useful for suppressing spew, but still allowing easy debugging
when needed, without rebuilding.

To use, use excmd:

     setlogginglevel <prefix> <level>

Where the level is one of:

    - never:  never log
    - error
    - warning
    - info
    - debug:  most verbose

Output is directed to console methods "error", "warn", "log", "debug".

-----

I've added a few uses, in `{message,commandline_frame,controller}.ts`, and with the defaults at WARNING, this quietens down the console. It used to lag for me on backspace with the console open, and now it doesn't.

Advice welcome on what to do about the `{config,logging}.ts` imports, as currently importing `logging` in `config.ts` is circular, so I didn't use the enums, just the numbers. Split to another file?