### PR TITLE
excmds: add "quit" and "q" commands

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -766,6 +766,23 @@ export async function qall(){
     windows.map((window) => browser.windows.remove(window.id))
 }
 
+/** Close the current tab, and close the current window if no tabs remain. */
+//#background
+export async function quit() {
+    let tabs = await browser.tabs.query({currentWindow: true})
+    if (tabs.length > 1) {
+        tabclose()
+    } else {
+        winclose()
+    }
+}
+
+/** Convenience shortcut for [[quit]] */
+//#background
+export async function q() {
+    quit()
+}
+
 // }}}
 
 // {{{ MISC


### PR DESCRIPTION
Closing the final tab via "tabclose" doesn't actually close the window. Instead, we just get an empty placeholder tab.
Let's instead add a "quit" command which can be used to quit the current tab, and if it's the last tab in the window,
close the _window_.

This is similar to how vim (and pentadactyl) work, which lets you ":q" your way through any open buffers.