### PR TITLE
excmds: add `q`, `qa`, and `quit` synonyms

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -732,6 +732,18 @@ export async function undo(){
     }
 }
 
+/** Synonym for [[tabclose]]. */
+//#background
+export async function quit() {
+    tabclose()
+}
+
+/** Convenience shortcut for [[quit]]. */
+//#background
+export async function q() {
+    tabclose()
+}
+
 /** Move the current tab to be just in front of the index specified.
 
     Known bug: This supports relative movement, but autocomple doesn't know
@@ -794,6 +806,12 @@ export async function winclose() {
 export async function qall(){
     let windows = await browser.windows.getAll()
     windows.map((window) => browser.windows.remove(window.id))
+}
+
+/** Convenience shortcut for [[qall]]. */
+//#background
+export async function qa() {
+    qall()
 }
 
 // }}}


### PR DESCRIPTION
Other vim-likes map `q` and `quit` to `tabclose`, so let's do the same to appease their muscle memory.

While we're at it, we can add `qa` as a shortcut for `qall` (vim also supports this shorthand).