### PR TITLE
Include default bind for tabonly function

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -47,6 +47,7 @@ const DEFAULTS = o({
         "H": "back",
         "L": "forward",
         "d": "tabclose",
+        "D": "tabonly",
         "u": "undo",
         "r": "reload",
         "R": "reloadhard",


### PR DESCRIPTION
Add in config.ts a sugestion for default binding to the orphaned
function tabonly (close other tabs)