### PR TITLE
Implement addEventListener hijacking. 

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -41,3 +41,5 @@ import * as webext from './lib/webext'
     webext,
     l: prom => prom.then(console.log).catch(console.error),
 })
+
+dom.hijackPageListenerFunctions()

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -59,16 +59,15 @@ function isEditableHTMLInput (element: MsgSafeNode) {
  * @param {{ ctrlKey, shiftKey, altKey, metaKey }} modifierKeys
  */
 export function mouseEvent (element: Element, type: 'hover'|'unhover'|'click', modifierKeys = {}) {
-    let events
+    let events = []
     switch (type) {
-        case 'hover':
-            events = ['mouseover', 'mouseenter', 'mousemove']
-            break
         case 'unhover':
             events = ['mousemove', 'mouseout', 'mouseleave']
             break
         case 'click':
-            events = ['mouseover', 'mousedown', 'mouseup', 'click']
+            events = ['mousedown', 'mouseup', 'click']
+        case 'hover':
+            events = ['mouseover', 'mouseenter', 'mousemove'].concat(events)
             break
     }
     events.forEach(type => {

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -370,10 +370,12 @@ function pushKey(ke) {
             1. Within viewport
             2. Not hidden by another element
 */
-function hintables(selectors=HINTTAGS_selectors) {
+function hintables(selectors=HINTTAGS_selectors, withjs=false) {
     let elems = DOM.getElemsBySelector(selectors, [])
-    elems = elems.concat(DOM.hintworthy_js_elems)
-    elems = unique(elems)
+    if (withjs) {
+        elems = elems.concat(DOM.hintworthy_js_elems)
+        elems = unique(elems)
+    }
     return elems.filter(DOM.isVisible)
 }
 
@@ -493,8 +495,8 @@ function simulateClick(target: HTMLElement) {
     }
 }
 
-function hintPageOpenInBackground() {
-    hintPage(hintables(), hint=>{
+function hintPageOpenInBackground(selectors=HINTTAGS_selectors) {
+    hintPage(hintables(selectors, true), hint=>{
         hint.target.focus()
         if (hint.target.href) {
             // Try to open with the webext API. If that fails, simulate a click on this page anyway.
@@ -507,7 +509,7 @@ function hintPageOpenInBackground() {
 }
 
 function hintPageSimple(selectors=HINTTAGS_selectors) {
-    hintPage(hintables(selectors), hint=>{
+    hintPage(hintables(selectors, true), hint=>{
         simulateClick(hint.target)
     })
 }

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -12,7 +12,7 @@
 
 import * as DOM from './dom'
 import {log} from './math'
-import {permutationsWithReplacement, islice, izip, map} from './itertools'
+import {permutationsWithReplacement, islice, izip, map, unique} from './itertools'
 import {hasModifiers} from './keyseq'
 import state from './state'
 import {messageActiveTab, message} from './messaging'
@@ -371,7 +371,10 @@ function pushKey(ke) {
             2. Not hidden by another element
 */
 function hintables(selectors=HINTTAGS_selectors) {
-    return DOM.getElemsBySelector(selectors, [DOM.isVisible])
+    let elems = DOM.getElemsBySelector(selectors, [])
+    elems = elems.concat(DOM.hintworthy_js_elems)
+    elems = unique(elems)
+    return elems.filter(DOM.isVisible)
 }
 
 function elementswithtext() {

--- a/src/itertools.ts
+++ b/src/itertools.ts
@@ -121,3 +121,12 @@ export function* map(arr, func) {
     for (const v of arr)
         yield func(v)
 }
+
+// Returns an array of unique elements.
+export function unique(arr) {
+    return arr.reduce((acc, cur) => {
+        if (acc.indexOf(cur) == -1)
+            acc.push(cur)
+        return acc
+    }, []);
+}

--- a/src/tridactyl.d.ts
+++ b/src/tridactyl.d.ts
@@ -9,12 +9,14 @@ interface Number {
     clamp(lo: number, hi: number): number
 }
 
-
 // Firefox-specific dom properties
 interface Window {
     scrollByLines(n: number): void
-    scrollByPages(n: number):  void
+    scrollByPages(n: number): void
+    eval(str: string): any
 }
+
+declare function exportFunction(func: Function, targetScope: object, options?: {defineAs?: string, allowCrossOriginArguments?: boolean}): Function
 
 // Fix typescript bugs
 interface StringConstructor {


### PR DESCRIPTION
This is my implementation of addEventListener hijacking.

There is no performance overhead as far as I know, I tested this code on a page that adds about ~1000 event listeners to the page and everything went smoothly (we might want to remove [this console.log](https://github.com/cmcaine/tridactyl/blob/baaa4cef61820309d257096fcc4debe1cbf62dc1/src/hinting.ts#L55) though, it makes things quite slow when a lot of hints are displayed).

An example of a site improved by this PR is [Searx](https://searx.me/?q=test&categories=general&language=en-US). Tridactyl doesn't currently put hints on the Files/Images/... labels, but with this PR merged it would.

This PR currently only replaces the orginal addEventListener with its own, which means that a page could decide to replace our addEventListener with another. To prevent this, we could use `Object.defineProperty` to create getters and setters for addEventListener, however, I don't think it's necessary, a website wouldn't gain anything from removing its own addEventListener.

This PR fixes https://github.com/cmcaine/tridactyl/issues/215 .
It also fixes https://github.com/cmcaine/tridactyl/issues/204 by implementing johnbeard's solution.
It might also fix https://github.com/cmcaine/tridactyl/issues/163 and https://github.com/cmcaine/tridactyl/issues/81 .