### PR TITLE
Fix issue 247 - readme links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ Mozilla doesn't give us access to them. See [issue #73](https://github.com/cmcai
 
 - Why doesn't Tridactyl work on websites with frames?
 
-It should work on some frames now. See [#122](https://github.com/cmcaine/tridactyl/issues/122).
+It should work on some frames now. See [#158](https://github.com/cmcaine/tridactyl/issues/158).
 
 - Can I change proxy via commands?
 

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ Mozilla doesn't give us access to them. See [issue #73](https://github.com/cmcai
 
 - Why doesn't Tridactyl work on websites with frames?
 
-It should work on some frames now. See [#158](https://github.com/cmcaine/tridactyl/issues/158).
+It should work on some frames now. See [#122](https://github.com/cmcaine/tridactyl/issues/122).
 
 - Can I change proxy via commands?
 
@@ -82,7 +82,7 @@ No, this is a limitation of WebExtensions.
 
 - How do I disable Tridactyl on certain sites?
 
-You can't yet, see [#122](https://github.com/cmcaine/tridactyl/issues/122).
+You can't yet, see [#158](https://github.com/cmcaine/tridactyl/issues/158).
 
 - How can I list the current bindings?
 

--- a/readme.md
+++ b/readme.md
@@ -46,19 +46,19 @@ Remember that tridactyl cannot run on any page on addons.mozilla.org, about:\*, 
 
 Sort of: if you do `set storageloc local`, a JSON file will appear at `<your firefox profile>\browser-extension-data\tridactyl.vim@cmcaine.co.uk\storage.js`. You can find you profile folder by going to `about:support`. 
 
-You can edit this file to your heart's content. A more traditional rc file is planned but will require a native messenger. For more information, see issue #79.
+You can edit this file to your heart's content. A more traditional rc file is planned but will require a native messenger. For more information, see [issue #79](https://github.com/cmcaine/tridactyl/issues/79).
 
 - How can I bind to modifiers?
 
-You can't, yet. See issue #41.
+You can't, yet. See [issue #41](https://github.com/cmcaine/tridactyl/issues/41).
 
 - How can I tab complete from bookmarks?
 
-`bmarks `. Bookmarks are not currently supported on `*open`: see issue #214.
+`bmarks `. Bookmarks are not currently supported on `*open`: see [issue #214](https://github.com/cmcaine/tridactyl/issues/214).
 
 - When I type 'f', can I type link names (like Vimperator) in order to narrow down the number of highlighted links?
 
-Not yet. See issue #28.
+Not yet. See [issue #28](https://github.com/cmcaine/tridactyl/issues/28).
 
 - How to remap keybindings in both normal mode and ex mode?
 
@@ -70,11 +70,11 @@ You cannot. We only support normal mode bindings for now, with `bind [key] [excm
 
 - Why can't I use my bookmark keywords?
 
-Mozilla doesn't give us access to them. See issue #73.
+Mozilla doesn't give us access to them. See [issue #73](https://github.com/cmcaine/tridactyl/issues/73).
 
 - Why doesn't Tridactyl work on websites with frames?
 
-It should work on some frames now. See #122. <!-- expand -->
+It should work on some frames now. See [#122](https://github.com/cmcaine/tridactyl/issues/122).
 
 - Can I change proxy via commands?
 
@@ -82,11 +82,11 @@ No, this is a limitation of WebExtensions.
 
 - How do I disable Tridactyl on certain sites?
 
-You can't yet, see #158.
+You can't yet, see [#122](https://github.com/cmcaine/tridactyl/issues/122).
 
 - How can I list the current bindings?
 
-There is no easy way. See #98.
+There is no easy way. See [#98](https://github.com/cmcaine/tridactyl/issues/98).
 
 - Why doesn't Tridactyl work on some pages?
 
@@ -94,7 +94,7 @@ One possible reason is that the site has a strict content security policy. We ca
 
 - How can I know which mode I'm in/have a status line?
 
-Press `j` and see if you scroll down :) There's no status line yet: see #210.
+Press `j` and see if you scroll down :) There's no status line yet: see [#210](https://github.com/cmcaine/tridactyl/issues/210).
 
 
 


### PR DESCRIPTION
Fixes issue 247; turns out that GFM issue links are not processed on README files. [SO Link](https://stackoverflow.com/questions/16539687/github-readme-reference-issue).