### PR TITLE
Implement vimperator-style hint filtering

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -152,7 +152,7 @@ const DEFAULTS = o({
     "storageloc": "sync",
     "homepages": [],
     "hintchars": "hjklasdfgyuiopqwertnmzxcvb",
-	"hintmode": "simple",   // "simple" or "vimperator"
+	"hintfiltermode": "simple",   // "simple", "vimperator", "vimperator-reflow"
 
     "ttsvoice": "default",  // chosen from the listvoices list, or "default"
     "ttsvolume": 1,         // 0 to 1

--- a/src/config.ts
+++ b/src/config.ts
@@ -152,6 +152,7 @@ const DEFAULTS = o({
     "storageloc": "sync",
     "homepages": [],
     "hintchars": "hjklasdfgyuiopqwertnmzxcvb",
+	"hintmode": "simple",   // "simple" or "vimperator"
 
     "ttsvoice": "default",  // chosen from the listvoices list, or "default"
     "ttsvolume": 1,         // 0 to 1

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1591,6 +1591,7 @@ import * as hinting from './hinting_background'
 
     Related settings:
         "hintchars": "hjklasdfgyuiopqwertnmzxcvb"
+        "hintfiltermode": "simple" | "vimperator" | "vimperator-reflow"
 */
 //#background
 export function hint(option?: string, selectors="") {

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -243,6 +243,10 @@ function filterHintsSimple(fstr) {
 }
 
 function filterHintsVimperatorReflow(fstr) {
+    filterHintsVimperator(fstr, true)
+}
+
+function filterHintsVimperator(fstr, reflow=false) {
     let active = modeState.hints.map(h => {
         return {
             'hint': h,
@@ -274,11 +278,13 @@ function filterHintsVimperatorReflow(fstr) {
                     act.hint.hidden = true
                 }
             }
-            // ...and then reflow the remaining active hints
-            let names = hintnames(nextActive.length)
-            for (let [act, name] of izip(nextActive, names)) {
-                act.name = name
-                act.hint.flag.textContent = name
+            if (reflow) {
+                // ...and then reflow the remaining active hints
+                let names = hintnames(nextActive.length)
+                for (let [act, name] of izip(nextActive, names)) {
+                    act.name = name
+                    act.hint.flag.textContent = name
+                }
             }
         }
         active = nextActive
@@ -300,54 +306,6 @@ function filterHintsVimperatorReflow(fstr) {
     if (active.length == 1) {
         selectFocusedHint()
     }
-}
-
-/** Show only hints:
-    - prefixed by the subset of fstr in the hintchars config.
-    - containing the rest of fstr as a subsequence in a dwim-type
-      chunk of their html.
-    Focus the first match.
-**/
-function filterHintsVimperator(fstr) {
-    const active: Hint[] = []
-    let foundMatch
-    for (let h of modeState.hints) {
-        if (!filterHintsVimperatorPredicate(fstr, h)) {
-            h.hidden = true
-        } else {
-            if (! foundMatch) {
-                h.focused = true
-                modeState.focusedHint = h
-                foundMatch = true
-            }
-            h.hidden = false
-            active.push(h)
-        }
-
-    }
-    if (active.length == 1) {
-        selectFocusedHint()
-    }
-}
-
-function filterHintsVimperatorPredicate(fstr, h) {
-    let fstrName = ''
-
-    let curIdx = 0
-    for (let c of fstr) {
-        if (config.get("hintchars").includes(c)) {
-            fstrName = fstrName + c
-            if (!h.name.startsWith(fstrName)) {
-                return false
-            }
-        } else {
-            curIdx = h.filterData.indexOf(c.toLowerCase(), curIdx)
-            if (-1 == curIdx) {
-                return false
-            }
-        }
-    }
-    return true
 }
 
 /** Remove all hints, reset STATE. */

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -195,7 +195,10 @@ function buildHintsSimple(els: Element[], onSelect: HintSelectedCallback) {
 
 function buildHintsVimperator(els: Element[], onSelect: HintSelectedCallback) {
     let names = hintnames(els.length)
-    const filterableTextFilter = new RegExp('[' + config.get('hintchars') + ']|[^[:alnum:]]', 'gi')
+    // escape the hintchars string so that strange things don't happen
+    // when special characters are used as hintchars (for example, ']')
+    const escapedHintChars = config.get('hintchars').replace(/^\^|[-\\\]]/g, "\\$&")
+    const filterableTextFilter = new RegExp('[' + escapedHintChars + ']', 'gi')
     for (let [el, name] of izip(els, names)) {
         let ft = elementFilterableText(el)
         // strip out non-alphanumeric characters and hintchars.

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -222,24 +222,18 @@ function buildHintsVimperator(els: Element[], onSelect: HintSelectedCallback) {
 
 function elementFilterableText(el: Element): string {
     const nodename = el.nodeName.toLowerCase()
+    let text: string
     if (nodename == 'input') {
-        return (<HTMLInputElement>el).value.toLowerCase()
-    // } else if (nodename == 'a'
-    //            && !el.textContent.trim()
-    //            && el.firstElementChild
-    //            && el.firstElementChild.nodeName.toLowerCase() == 'img') {
-    //     return el.firstElementChild.alt || el.firstElementChild.title
+        text = (<HTMLInputElement>el).value
     } else if (0 < el.textContent.length) {
-        return el.textContent.toLowerCase() || ''
+        text = el.textContent
     } else if (el.hasAttribute('title')) {
-        return el.getAttribute('title').toLowerCase() || ''
+        text = el.getAttribute('title')
     } else {
-        return el.innerHTML.toLowerCase() || ''
+        text = el.innerHTML
     }
-}
-
-function filter(fstr) {
-    modeState.filterFunc(fstr)
+    // Truncate very long text values
+    return text.slice(0,2048).toLowerCase() || ''
 }
 
 type HintFilter = (string) => void

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -53,8 +53,8 @@ let modeState: HintState = undefined
 export function hintPage(
     hintableElements: Element[],
     onSelect: HintSelectedCallback,
-    buildHints: HintBuilder = defaultHintBuilders[config.get('hintfiltermode')],
-    filterHints: HintFilter = defaultHintFilters[config.get('hintfiltermode')],
+    buildHints: HintBuilder = defaultHintBuilder(),
+    filterHints: HintFilter = defaultHintFilter(),
 ) {
     state.mode = 'hint'
     modeState = new HintState(filterHints)
@@ -70,16 +70,24 @@ export function hintPage(
     }
 }
 
-const defaultHintBuilders = {
-    'simple': buildHintsSimple,
-    'vimperator': buildHintsVimperator,
-    'vimperator-reflow': buildHintsVimperator,
+function defaultHintBuilder() {
+    if ('simple' == config.get('hintfiltermode')) {
+        return buildHintsSimple
+    } else if ('vimperator' == config.get('hintfiltermode')) {
+        return buildHintsVimperator
+    } else if ('vimperator-reflow' == config.get('hintfiltermode')) {
+        return buildHintsVimperator
+    }
 }
 
-const defaultHintFilters = {
-    'simple': filterHintsSimple,
-    'vimperator': filterHintsVimperator,
-    'vimperator-reflow': filterHintsVimperatorReflow,
+function defaultHintFilter() {
+    if ('simple' == config.get('hintfiltermode')) {
+        return filterHintsSimple
+    } else if ('vimperator' == config.get('hintfiltermode')) {
+        return filterHintsVimperator
+    } else if ('vimperator-reflow' == config.get('hintfiltermode')) {
+        return (fstr) => filterHintsVimperator(fstr, true)
+    }
 }
 
 /** vimperator-style minimal hint names */
@@ -240,10 +248,6 @@ function filterHintsSimple(fstr) {
     if (active.length == 1) {
         selectFocusedHint()
     }
-}
-
-function filterHintsVimperatorReflow(fstr) {
-    filterHintsVimperator(fstr, true)
 }
 
 function filterHintsVimperator(fstr, reflow=false) {

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -71,22 +71,24 @@ export function hintPage(
 }
 
 function defaultHintBuilder() {
-    if ('simple' == config.get('hintfiltermode')) {
-        return buildHintsSimple
-    } else if ('vimperator' == config.get('hintfiltermode')) {
-        return buildHintsVimperator
-    } else if ('vimperator-reflow' == config.get('hintfiltermode')) {
-        return buildHintsVimperator
+    switch (config.get('hintfiltermode')) {
+        case 'simple':
+            return buildHintsSimple
+        case 'vimperator':
+            return buildHintsVimperator
+        case 'vimperator-reflow':
+            return buildHintsVimperator
     }
 }
 
 function defaultHintFilter() {
-    if ('simple' == config.get('hintfiltermode')) {
-        return filterHintsSimple
-    } else if ('vimperator' == config.get('hintfiltermode')) {
-        return filterHintsVimperator
-    } else if ('vimperator-reflow' == config.get('hintfiltermode')) {
-        return (fstr) => filterHintsVimperator(fstr, true)
+    switch (config.get('hintfiltermode')) {
+        case 'simple':
+            return filterHintsSimple
+        case 'vimperator':
+            return filterHintsVimperator
+        case 'vimperator-reflow':
+            return (fstr) => filterHintsVimperator(fstr, true)
     }
 }
 

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -25,16 +25,12 @@ const logger = new Logger('hinting')
 /** Simple container for the state of a single frame's hints. */
 class HintState {
     public focusedHint: Hint
-    readonly hintHost = document.createElement('div')
+    readonly hintHost = html`<div class="TridactylHintHost">`
     readonly hints: Hint[] = []
     public filter = ''
     public hintchars = ''
 
-    constructor(
-        public filterFunc: HintFilter,
-    ){
-        this.hintHost.classList.add("TridactylHintHost")
-    }
+    constructor(public filterFunc: HintFilter) {}
 
     destructor() {
         // Undo any alterations of the hinted elements


### PR DESCRIPTION
This is a first pass at addressing #183. It has the necessary flows for control and data to implement that functionality, but there are some rough edges to be smoothed out before the feature is actually ready.

Changes:

- Add a `hintfiltermode` config option that selects hint filter modes. It defaults to `simple`.
- Augment the `Hint` class with a `filterdata` field of type `any` that can be used to store information for filtering.
- Add a layer of indirection in `hinting.ts` to permit selection of hint building (in `hintPage`) and filtering (in `filter`) functions.
- Move current hint selection functionality into the `simple` setting for `hintfiltermode`, backed by a builder that doesn't use `filterdata` at all and a filter that's a straight copy-paste of current hint filtering code. This mode should be identical to current behavior and it is set as the default in `config.ts`.
- Add a `vimperator` setting for `hintfiltermode`. The builder for this mode populates the `name` of the hint as in `simple` and the `filterData` field of hints with a DWIM string extract from the text, content, title, or inner html of the hint's target. The filter function consumes the filter string one character at a time. Characters in `hintchars` are matched against the names of hints, and other characters consume from the head of filterdata. This is equivalent to partitioning the filterstring into two (hintchar and non-hintchar) subsequences and testing for name starts with hintchar portion and filterdata string contains non-hintchar portion as a subsequence.
- Add a `vimperator-reflow` setting for `hintfiltermode`. The builder is the same as for `vimperator`. The filter is almost the same as for `vimperator`, but it chooses new names for each hint after every non-hintchar character in the filterstring. This essentially "reflows" hints as the user filters them down.

Thoughts:

- I feel like I could still improve the pattern of data mutation in the vimperator-style hint filter function. The following thoughts went into the structure here:
  - Hints should have some kind of immutable unique ID so that they can be more easily debugged.
  - The filterable text needs to be a snapshot of the element from the moment the page was hinted, otherwise elements that change while the user is selecting a hint would be impossible for users to handle.
  - When consuming a hintchar from the filterstring, hints are matched using their names, which are a function of any previous non-hintchars in the filterstring, so the outermost loop must be over the filterstring, unlike the simple-style hint filter.
  - The code should reduce to simple-mode filtering if the filter string is entirely composed of hintchars.
  - The vimperator-style hint filter currently operates by storing temporary versions of the names and filterdatas for hints and consuming from them as it processes characters from the filterstring. The alternative was to keep pointers into the immutable names and filterdatas. I felt that this code was clearer and easier to work with, and since its only operations are to slice strings I *think* - but I'm not certain that - the browser should be able to entirely avoid string copies and performance should be the same as maintaining indexes. I haven't tested this.
- Switching the filtering mode halfway through a hinting operation could select almost any hint on the page essentially at random, so I determine the filter function when hints are built and store it in the mode state.
- Should I try to break the vimperator filter function into smaller pieces? It feels a bit big right now.

Things to do in the future:
- It looks like this may be the first configuration option that's an enum. I did not address that problem in this PR: `hintfiltermode` is an arbitrary string and unrecognized strings have undefined behavior (but really just blow up).
- In the vimperator-style filter function, there's a relatively easy spot to add scoring and sorting of hints based on the quality of the match between the hint and the filterstring. I decided that that functionality was out of scope for this PR, as it's more fine-tuning and shouldn't require any changes to control flow or data structures.
- `' '` is captured by the browser and navigates to the currently focused hint, which is *very* annoying when the instinctive approach for narrowing to a single hint is to type a couple words selected from its target element. Setting `' '`as a hintchar in the mode state didn't seem to do anything. This will certainly be something to investigate when tuning the filtering and adding scoring+sorting; "all `/[^[:space:]]+/` must be filterable text" turns out to be *far* nicer than "filterstr is subsequence of filterable text".
- Go read the code for every vimperator-descendant out there that has a feature like this and see what their DWIM is for an element's filterable text.
- If the user is selecting a hint by narrowing to it with non-hintchar inputs, they's probably be typing a short selection of actual text from the hint's target element. If they're typing full words and going quickly, they almost certainly won't react to the hint being selected fast enough to stop typing before tridactyl starts taking non-filter-string input, resulting in spurious input. The hard solution to this is to ignore keystrokes for a bit after a successful non-hintchar selection. The easy solution is to add a setting that suppresses the automatic selection when only a single hint remains active.