### PR TITLE
WIP: Native messenger

### DIFF
--- a/native/native_main.py
+++ b/native/native_main.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import json
+import sys
+import struct
+
+
+# Read a message from stdin and decode it.
+def get_message():
+    raw_length = sys.stdin.buffer.read(4)
+    if not raw_length:
+        sys.exit(0)
+    message_length = struct.unpack('@I', raw_length)[0]
+    message = sys.stdin.buffer.read(message_length)
+    return json.loads(message)
+
+
+# Encode a message for transmission, given its content.
+def encode_message(message_content):
+    encoded_content = json.dumps(message_content).encode("utf8")
+    encoded_length = struct.pack('@I', len(encoded_content))
+    return {'length': encoded_length, 'content': encoded_content}
+
+
+# Send an encoded message to stdout.
+def send_message(encoded_message):
+    sys.stdout.buffer.write(encoded_message['length'])
+    sys.stdout.buffer.write(encoded_message['content'])
+    sys.stdout.flush()
+
+
+def main():
+
+    while True:
+        message = get_message()
+        if message == "ping":
+            send_message(encode_message("pong"))
+
+
+if __name__ == "__main__":
+    main()

--- a/native/nm_comms.py
+++ b/native/nm_comms.py
@@ -1,0 +1,70 @@
+"""
+Native messenger browser commmunications
+"""
+
+import struct
+import sys
+import json
+
+
+class BrowserComms(object):
+    """ Generic browser comms interface for native message passing """
+
+    def get_message(self):
+        raise NotImplementedError
+
+    def send_message(self):
+        raise NotImplementedError
+
+    class NoConnectionError(Exception):
+        """ Exception thrown when the stdin cannot be read 
+        """
+
+
+class StdioComms(BrowserComms):
+    """ Handles the messaging protocol between Firefox and this native program
+
+    The format is:
+      - 4 bytes integer holding the size of the payload
+      - n bytes of payload, which is JSON
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def get_message(self):
+        """ Read a message from stdin and decode it.
+        """
+
+        raw_length = sys.stdin.buffer.read(4)
+
+        # failed to read from stdin, the connection is gone and there's
+        # nothing else we can do here
+        if not raw_length:
+            raise(self.NoConnectionError)
+
+        message_length = struct.unpack('@I', raw_length)[0]
+        message = sys.stdin.buffer.read(message_length)
+        return json.loads(message)
+
+    def _encode_message(self, message_content):
+        """ Encode a message for transmission, given its content.
+        """
+
+        encoded_content = json.dumps(message_content).encode("utf8")
+        encoded_length = struct.pack('@I', len(encoded_content))
+        return {
+            'length': encoded_length,
+            'content': encoded_content
+        }
+
+    def send_message(self, message_object):
+        """ Encodes and sends the message over stdout 
+        """
+
+        encoded_message = self._encode_message(message_object)
+        sys.stdout.buffer.write(encoded_message['length'])
+        sys.stdout.buffer.write(encoded_message['content'])
+        sys.stdout.flush()
+
+

--- a/native/nm_utils.py
+++ b/native/nm_utils.py
@@ -1,0 +1,13 @@
+"""
+Utility functions for native messaging
+"""
+
+
+import sys
+
+
+def eprint(*args, **kwargs):
+    """ Print to stderr, which gets echoed in the browsewr console when
+    run by Firefox
+    """
+    print(*args, file=sys.stderr, flush=True, **kwargs)

--- a/native/tridactyl.json
+++ b/native/tridactyl.json
@@ -1,0 +1,7 @@
+{
+    "name": "tridactyl",
+    "description": "Tridactyl native command handler",
+    "path": "/home/john/src/tridactyl/native/native_main.py",
+    "type": "stdio",
+    "allowed_extensions": [ "tridactyl.vim@cmcaine.co.uk" ]
+}

--- a/native/user_config.py
+++ b/native/user_config.py
@@ -1,0 +1,57 @@
+"""
+User configuration file interface
+"""
+
+import os
+import nm_utils
+
+
+def _getenv(variable, default):
+    """
+    Get an environment variable value, or use the default provided
+    """
+    return os.environ.get(variable) or default
+
+
+class ConfigManager(object):
+
+    def _find_user_config_file(self):
+        """ Find a user config file, if it exists
+
+        Return the file path, or None if not found
+        """
+
+        config_dir = _getenv("XDG_CONFIG_HOME",
+                             os.path.expandvars('$HOME/.config'))
+
+        candidate_files = [
+            os.path.join(config_dir, "tridactyl", "tridactylrc")
+        ]
+
+        nm_utils.eprint(candidate_files)
+
+        config_path = None
+
+        # find the first path in the list that exists
+        for path in candidate_files:
+
+            nm_utils.eprint("Checking file {}".format(path))
+
+            if os.path.isfile(path):
+                config_path = path
+                break
+
+        return config_path
+
+    def get_user_config(self):
+        # look it up freshly each time - the user could have
+        # moved or killed it
+        cfg_file = self._find_user_config_file()
+
+        # no file, return
+        if not cfg_file:
+            return None
+
+        # for now, this is a simple file read, but if the files can
+        # include other files, that will need more work
+        return open(cfg_file, 'r').read()

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1307,6 +1307,13 @@ export function unset(target: string, property?: string){
 //    saveconfig()
 //}
 
+import * as Native from "./native_background"
+
+//#background
+export async function ping() {
+    Native.connectNM()
+    Native.pingNM()
+}
 
 // }}}
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1315,6 +1315,12 @@ export async function ping() {
     Native.pingNM()
 }
 
+//#background
+export async function loadconfig() {
+    Native.connectNM()
+    Native.getUserConfig()
+}
+
 // }}}
 
 // {{{ HINTMODE

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -51,6 +51,7 @@
         "webNavigation",
         "webRequest",
         "webRequestBlocking",
+        "nativeMessaging",
         "<all_urls>"
     ],
     "applications": {

--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -34,6 +34,26 @@ export function connectNM() {
 
 function handleNMResponse(response) {
     console.log("Received: " + response);
+
+    switch (response.cmd)
+    {
+        case "version":
+            console.log("Version", response.version)
+            break
+        case "getconfig":
+
+            if (response.content && !response.error) {
+                console.log("Config:", response.content)
+            } else {
+                console.log("Config error:", response.error)
+            }
+            break
+        case "error":
+            console.log("Error in native messenger:", response.error)
+            break
+        default:
+            console.log("Unrecognised reponsed from native messenger")
+    }
 }
 
 
@@ -42,5 +62,10 @@ On a click on the browser action, send the app a message.
 */
 export function pingNM() {
   console.log("Sending:  ping");
-  NM_PORT.postMessage("ping");
+    NM_PORT.postMessage({"cmd": "version"});
+}
+
+export function getUserConfig() {
+    console.log("Sending user config request")
+    NM_PORT.postMessage({"cmd": "getconfig"})
 }

--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -1,0 +1,46 @@
+/** 
+ * Background functions for the native messenger interface
+ */
+
+/**
+ * THe native messenger port that communicates with the native app
+ * over stdio
+ */
+let NM_PORT = null
+    
+export function connectNM() {
+
+    // if connected, bail and reuse the old port
+    if (NM_PORT) {
+        console.log("port ok")
+        return
+    }
+
+    NM_PORT = browser.runtime.connectNative("tridactyl");
+
+    console.log("connected", NM_PORT)
+
+    NM_PORT.onMessage.addListener(handleNMResponse);
+
+    NM_PORT.onDisconnect.addListener((p) => {
+        console.log("Disconnected")
+        if (p.error) {
+            console.log(`Disconnected due to an error: ${p.error.message}`);
+        }
+
+        NM_PORT = null
+    });
+}
+
+function handleNMResponse(response) {
+    console.log("Received: " + response);
+}
+
+
+/*
+On a click on the browser action, send the app a message.
+*/
+export function pingNM() {
+  console.log("Sending:  ping");
+  NM_PORT.postMessage("ping");
+}


### PR DESCRIPTION
This is a very basic sketch from a while back about how to do a native messenger, based on the FF documentation for the ping pong messenger.

You need to modify `native/tridactyl.json` to point to the Python file and copy/symlink it to one of the locations where Firefox can find it (look near the end of [this page](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_manifests)). I used `~/.mozilla/native-messaging-hosts`.

There are two ex-commands:
* `ping`, which is a command that pings the native messenger and gets its version
* `loadconfig`, which reads from the file `~/.config/tridactyl/tridactylrc` or `XDG_CONFIG_HOME/tridactyl/tridactyrc`

You should see output from both in the Browser Console (not the Web Console!).

I haven't had a lot of time to deal with this recently and I won't have for a little while - feel free to repurpose anything in any way!