### PR TITLE
Unless cancelled, insert mode when select tag focused

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9507,7 +9507,7 @@
       }
     },
     "web-ext-types": {
-      "version": "github:kelseasy/web-ext-types#33e1733e2f9c650d4b8b3fc18581e050dd2641a5",
+      "version": "github:kelseasy/web-ext-types#417d6ddcd76d8a05d7e2222aec3544e01637785b",
       "dev": true
     },
     "webidl-conversions": {

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -15,6 +15,7 @@ export function isTextEditable (element: MsgSafeNode) {
         switch (element.nodeName) {
             case 'INPUT':
                 return isEditableHTMLInput(element)
+            case 'SELECT':
             case 'TEXTAREA':
             case 'OBJECT':
                 return true


### PR DESCRIPTION
```
Added case to nodeName switch; handles basic
dropdown menus.
```

This does not handle the first few examples in https://semantic-ui.com/modules/dropdown.html from #281, but sufficient for case reported in Matrix and in example on https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select. Particularly, Tridactyl would not be in insert mode if the dropdown is closed (can't see all the options) but focused.

edit: Wrong example