### PR TITLE
Add urlmodify command

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -87,7 +87,7 @@ import * as keydown from "./keydown_background"
 //#background_helper
 import {activeTab, activeTabId, firefoxVersionAtLeast} from './lib/webext'
 //#content_helper
-import {incrementUrl, getUrlRoot, getUrlParent} from "./url_util"
+import * as UrlUtil from "./url_util"
 //#background_helper
 import * as CommandLineBackground from './commandline_background'
 //#content_helper
@@ -299,7 +299,6 @@ export function open(...urlarr: string[]) {
     window.location.href = forceURI(url)
 }
 
-
 /** Go to your homepage(s)
 
     @param all
@@ -395,7 +394,7 @@ export function followpage(rel: 'next'|'prev' = 'next') {
 */
 //#content
 export function urlincrement(count = 1){
-    let newUrl = incrementUrl(window.location.href, count)
+    let newUrl = UrlUtil.incrementUrl(window.location.href, count)
 
     if (newUrl !== null) {
         window.location.href = newUrl
@@ -406,7 +405,7 @@ export function urlincrement(count = 1){
  */
 //#content
 export function urlroot (){
-    let rootUrl = getUrlRoot(window.location)
+    let rootUrl = UrlUtil.getUrlRoot(window.location)
 
     if (rootUrl !== null) {
         window.location.href = rootUrl.href
@@ -417,10 +416,92 @@ export function urlroot (){
  */
 //#content
 export function urlparent (count = 1){
-    let parentUrl = getUrlParent(window.location, count)
+    let parentUrl = UrlUtil.getUrlParent(window.location, count)
 
     if (parentUrl !== null) {
         window.location.href = parentUrl.href
+    }
+}
+
+/**
+ * Open a URL made by modifying the current URL
+ *
+ * @param mode      -t text replace
+ *                  -r regexp replace
+ *                  -q replace the value of the given query
+ *                  -Q delete the given query
+ *                  -g graft a new path onto URL or parent path of it
+ * @param replacement the replacement arguments:
+ *                  -t <old> <new>
+ *                  -r <regexp> <new> [flags]
+ *                  -q <query> <new_val>
+ *                  -Q <query>
+ *                  -g <graftPoint> <newPathTail>
+ *                      - graftPoint > 1 to count from left
+ *                      - graftPoint < 0 to count from right
+ */
+//#content
+export function urlmodify(mode: "-t" | "-r" | "-q" | "-Q" | "-g", ...args: string[]) {
+
+    let oldUrl = new URL(window.location.href)
+    let newUrl = undefined
+
+    switch(mode) {
+
+        case "-t":
+            if (args.length !== 2) {
+                throw new Error("Text replacement needs 2 arguments:"
+                    + "<old> <new>")
+            }
+
+            newUrl = oldUrl.href.replace(args[0], args[1])
+            break
+
+        case "-r":
+            if (args.length < 2 || args.length > 3) {
+                throw new Error("RegExp replacement takes 2 or 3 arguments: "
+                    + "<regexp> <new> [flags]")
+            }
+
+            if (args[2] && args[2].search('/^[gi]+$/') === -1)
+            {
+                throw new Error("RegExp replacement flags can only include 'g', 'i'")
+            }
+
+            let regexp = new RegExp(args[0], args[2])
+            newUrl = oldUrl.href.replace(regexp, args[1])
+            break
+
+        case "-q":
+            if (args.length !== 2) {
+                throw new Error("Query replacement needs 2 arguments:"
+                    + "<query> <new_val>")
+            }
+
+            newUrl = UrlUtil.replaceQueryValue(oldUrl, args[0],
+                args[1])
+            break
+        case "-Q":
+            if (args.length !== 1) {
+                throw new Error("Query deletion needs 1 argument:"
+                    + "<query>")
+            }
+
+            newUrl = UrlUtil.deleteQuery(oldUrl, args[0])
+            break
+
+        case "-g":
+            if (args.length !== 2) {
+                throw new Error("URL path grafting needs 2 arguments:"
+                    + "<graft point> <new path tail>")
+            }
+
+            newUrl = UrlUtil.graftUrlPath(oldUrl, args[1], Number(args[0]))
+            break
+    }
+
+    if (newUrl && newUrl !== oldUrl) {
+        window.location.href = newUrl
     }
 }
 

--- a/src/url_util.test.ts
+++ b/src/url_util.test.ts
@@ -127,7 +127,189 @@ function test_download_filename() {
     }
 }
 
+function test_query_delete() {
+
+    let cases = [
+        // no query
+        [
+            "http://example.com/",
+            "query",
+            "http://example.com/"
+        ],
+        // single query=val, removed
+        [
+            "http://example.com/?query=val",
+            "query",
+            "http://example.com/"
+        ],
+        // single query (no val), removed
+        [
+            "http://example.com/?query",
+            "query",
+            "http://example.com/"
+        ],
+        // single query=val, not removed
+        [
+            "http://example.com/?query=val",
+            "nomatch",
+            "http://example.com/?query=val",
+        ],
+        // single query (no val), not removed
+        [
+            "http://example.com/?query",
+            "nomatch",
+            "http://example.com/?query",
+        ],
+
+        // multiple queries, first removed
+        [
+            "http://example.com/?query=val&another=val2",
+            "query",
+            "http://example.com/?another=val2"
+        ],
+        // multiple queries, second removed
+        [
+            "http://example.com/?query=val&another=val2",
+            "another",
+            "http://example.com/?query=val"
+        ],
+        // multiple queries, repeated removed
+        [
+            "http://example.com/?query=val&another=val2&query=val3",
+            "query",
+            "http://example.com/?another=val2"
+        ],
+
+    ]
+
+    for (let [url, q, exp_res] of cases) {
+
+        let modified = UrlUtil.deleteQuery(new URL(url), q)
+
+        test (`delete query ${q} of ${url} --> ${exp_res}`,
+            () => expect(modified.href).toEqual(exp_res)
+        )
+    }
+}
+
+function test_query_replace() {
+
+    let cases = [
+        // no query
+        [
+            "http://example.com/",
+            "query", "val",
+            "http://example.com/"
+        ],
+        // single query
+        [
+            "http://example.com/?query=val",
+            "query", "newval",
+            "http://example.com/?query=newval"
+        ],
+        // single query, no replacement value
+        [
+            "http://example.com/?query=val",
+            "query", "",
+            "http://example.com/?query"
+        ],
+        // multiple, replace first
+        [
+            "http://example.com/?query1=val1&query2=val2",
+            "query1", "newval1",
+            "http://example.com/?query1=newval1&query2=val2"
+        ],
+        // multiple, replace last
+        [
+            "http://example.com/?query1=val1&query2=val2",
+            "query2", "newval2",
+            "http://example.com/?query1=val1&query2=newval2"
+        ],
+
+    ]
+
+    for (let [url, q, v, exp_res] of cases) {
+
+        let modified = UrlUtil.replaceQueryValue(new URL(url), q, v)
+
+        test (`change query ${q} of ${url} --> ${exp_res}`,
+            () => expect(modified.href).toEqual(exp_res)
+        )
+    }
+}
+
+function test_url_graft_path() {
+
+    let cases = [
+        // FROM LEFT
+        [
+            // complete replacement
+            "http://example.com/foo/bar/quux",
+            "0", "frob",
+            "http://example.com/frob"
+        ],
+        [
+            // one level down
+            "http://example.com/foo/bar/quux",
+            "1", "frob",
+            "http://example.com/foo/frob"
+        ],
+        [
+            // at last level
+            "http://example.com/foo/bar/quux",
+            "3", "frob",
+            "http://example.com/foo/bar/quux/frob"
+        ],
+
+        // FROM RIGHT
+        [
+            // test of extend-only
+            "http://example.com/test",
+            "-1", "newchild",
+            "http://example.com/test/newchild"
+        ],
+        [
+            // test of one level up graft (i.e. sibling)
+            "http://example.com/test",
+            "-2", "newsibling",
+            "http://example.com/newsibling"
+        ],
+        [
+            // test of multi level up graft (i.e. cousin)
+            "http://example.com/shop/by-id/42",
+            "-3", "by-name/foobar",
+            "http://example.com/shop/by-name/foobar"
+        ],
+
+        // ERRORS
+        [
+            // test of level too large and positive
+            "http://example.com/foo",
+            "2", "dummy",
+            null
+        ],
+        [
+            // test of level too large and negative
+            "http://example.com/foo",
+            "-3", "dummy",
+            null
+        ],
+    ]
+
+    for (let [url, level, tail, exp_res] of cases) {
+
+        let modified = UrlUtil.graftUrlPath(new URL(url), tail, Number(level))
+
+        test (`graft ${tail} onto ${url} at level ${level} --> ${exp_res}`,
+            () => expect(modified ? modified.href : modified).toEqual(exp_res)
+        )
+    }
+}
+
 test_increment()
 test_root()
 test_parent()
 test_download_filename()
+test_query_delete()
+test_query_replace()
+test_url_graft_path()


### PR DESCRIPTION
Has a few modes:

    -t: Straight text replacement
    -r: Regexp replacement
    -q: Change a query's value to a new one
    -Q: Delete a given query (and value if present)
    -g: Graft a path onto the current URL (or a parent path of it)

These can be used direct on the command line, or bound to keybindings.
The idea is to allow commands to easily navigate around a website. For
example, navigating to a project's issues page on GitHub can be done
with a graft command.

As a URL modification is generally site-specific, binding will be much
more useful with aucmds.