### PR TITLE
Case insensitive isEditable check on tag names

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -12,7 +12,8 @@ import {MsgSafeNode} from './msgsafe'
  */
 export function isTextEditable (element: MsgSafeNode) {
     if (element) {
-        switch (element.nodeName) {
+        // HTML is always upper case, but XHTML is not necessarily upper case
+        switch (element.nodeName.toUpperCase()) {
             case 'INPUT':
                 return isEditableHTMLInput(element)
             case 'TEXTAREA':


### PR DESCRIPTION
Previously was a case-sensitive check against an uppercase name. This
works for HTML.

XHTML will be whatever the source document is, which could be upper or
lower. Firefox will render either one the same, but only uppercase will
be deemed editable by Tridactyl. Fix this by doing a case-insensitive
comparision.

Tag casing is described in:
https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName

Thanks Koushien for working this one out!

----

Example page where this broke inputs: http://www.legislation.gov.uk

The comment above this function does mention casing - I'm not sure what other casing issues might be meant here. It could be that comment is no longer needed?