### PR TITLE
Automatically percent-encode seach query only if in query string (and add tests)

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -86,8 +86,8 @@ import {ModeName} from './state'
 import * as keydown from "./keydown_background"
 //#background_helper
 import {activeTab, activeTabId, firefoxVersionAtLeast} from './lib/webext'
-//#content_helper
 import * as UrlUtil from "./url_util"
+
 //#background_helper
 import * as CommandLineBackground from './commandline_background'
 //#content_helper
@@ -122,12 +122,7 @@ function searchURL(provider: string, query: string) {
         throw new TypeError(`Unknown provider: '${provider}'`)
     }
 
-    // build search URL: either replace "%s" in URL with query or append query to URL
-    const url = searchurlprovider.includes("%s") ?
-        new URL(searchurlprovider.replace("%s", encodeURIComponent(query))) :
-        new URL(searchurlprovider + encodeURIComponent(query))
-
-    return url
+    return UrlUtil.interpolateSearchItem(new URL(searchurlprovider), query)
 }
 
 /** If maybeURI doesn't have a schema, affix http:// */
@@ -1285,7 +1280,15 @@ export function bind(key: string, ...bindarr: string[]){
     config.set("nmaps",exstring,key)
 }
 
-/** Set a search engine keyword for use with *open or `set searchengine` */
+/**
+ * Set a search engine keyword for use with *open or `set searchengine`
+ *
+ * @param keyword   the keyword to use for this search (e.g. 'esa')
+ * @param url       the URL to interpolate the query into. If %s is found in
+ *                  the URL, the query is inserted there, else it is appended.
+ *                  If the insertion point is in the "query string" of the URL,
+ *                  the query is percent-encoded, else it is verbatim.
+ * */
 //#background
 export function searchsetkeyword(keyword: string, url: string){
     config.set("searchurls",forceURI(url),keyword)

--- a/src/url_util.test.ts
+++ b/src/url_util.test.ts
@@ -306,6 +306,45 @@ function test_url_graft_path() {
     }
 }
 
+function test_url_query_interpolation() {
+
+    let cases = [
+        [
+            // not percent-encoded and appended
+            "http://example.com",
+            "a/query",
+            "http://example.com/a/query"
+        ],
+        [
+            // not percent-encoded and interpolated
+            "http://example.com/%s/path",
+            "a/query",
+            "http://example.com/a/query/path"
+        ],
+        [
+            // percent-encoded and appended
+            "http://example.com/?query=",
+            "a/query",
+            "http://example.com/?query=a%2Fquery"
+        ],
+        [
+            // percent-encoded and interpolated
+            "http://example.com/?query=%s&q2=v2",
+            "a/query",
+            "http://example.com/?query=a%2Fquery&q2=v2"
+        ]
+    ]
+
+    for (let [url, qy, exp_res] of cases) {
+
+        let modified = UrlUtil.interpolateSearchItem(new URL(url), qy)
+
+        test(`interpolate ${qy} into ${url} --> ${exp_res}`,
+            () => expect(modified.href).toEqual(exp_res)
+        )
+    }
+}
+
 test_increment()
 test_root()
 test_parent()
@@ -313,3 +352,4 @@ test_download_filename()
 test_query_delete()
 test_query_replace()
 test_url_graft_path()
+test_url_query_interpolation()

--- a/src/url_util.ts
+++ b/src/url_util.ts
@@ -341,3 +341,40 @@ export function graftUrlPath(url: URL, newTail: string, level: number) {
 
     return newUrl
 }
+
+/**
+ * Interpolates a query or other search item into a URL
+ *
+ * If the URL pattern contains "%s", the query is interpolated there. If not,
+ * it is appended to the end of the pattern.
+ *
+ * If the interpolation point is in the query string of the URL, it is
+ * percent encoded, otherwise it is is inserted verbatim.
+ *
+ * @param urlPattern        a URL to interpolate/append a query to
+ * @param query             a query to interpolate/append into the URL
+ *
+ * @return                  the URL with the query encoded (if needed) and
+ *                          inserted at the relevant point
+ */
+export function interpolateSearchItem(urlPattern: URL, query: string): URL {
+    const hasInterpolationPoint = urlPattern.href.includes("%s")
+
+    // percent-encode if theres a %s in the query string, or if we're apppending
+    // and there's a query string
+    if (hasInterpolationPoint && (urlPattern.search.includes("%s"))
+            || urlPattern.search !== "") {
+        query = encodeURIComponent(query)
+    }
+
+    let newUrl
+
+    // replace or append as needed
+    if (hasInterpolationPoint) {
+        newUrl = new URL(urlPattern.href.replace("%s", query))
+    } else {
+        newUrl = new URL(urlPattern.href + query)
+    }
+
+    return newUrl
+}


### PR DESCRIPTION
For issue #300 

Move search term encode/interpolate/append logic to UrlUtil and put some tests on it. This allows an easier interface to add explicit encoding later if guessing based on location in the URL doesn't cut it for some searches.

Use in `excmds.ts `is a follow-up commit as I a little unsure about the import method for a "hidden" helper.