### PR TITLE
Fix floating commandline iframe on some sites #289

### DIFF
--- a/src/static/content.css
+++ b/src/static/content.css
@@ -8,4 +8,6 @@
     border: 0;
     padding: 0;
     margin: 0;
+    min-height: 0;
+    max-height: none;
 }


### PR DESCRIPTION
This is caused (at least in this instance) by sites setting a CSS
min-height rule for `iframe` elements, which is then applied to the
Tridactyl iframe too.

Fix this by adding `min-height: 0` to the CSS for `#cmdline_iframe`.
Because this is an ID, it will always have higher specificity than any
CSS the site sets (unless we collide the ID, maybe), so it doesn't need
important.

Also add `max-height: none` in case anyone tries to cramp our iframe
style.

Perhaps there will be more styles that can mess up the iframe styling
but this seems to fix all the sites reported in #289 and #282. Using
cleanslate might help if it turns out there are very many more ways for
the outer site to ruin our day, but since it's only the iframe that the
site CSS can touch (inner HTML is safe), maybe this will be enough and
save a lot of !important'ing.