### PR TITLE
excmds.ts: Fix scrolling not working on some websites

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -203,7 +203,10 @@ export function unfocus() {
 
 //#content
 export function scrollpx(a: number, b: number) {
-    window.scrollBy(a, b)
+    let top = document.body.getClientRects()[0].top;
+    window.scrollBy(a, b);
+    if (top == document.body.getClientRects()[0].top)
+        recursiveScroll(a, b, [document.body])
 }
 
 /** If two numbers are given, treat as x and y values to give to window.scrollTo
@@ -227,13 +230,32 @@ export function scrollto(a: number, b: number | "x" | "y" = "y") {
     }
 }
 
+//#content_helper
+function recursiveScroll(x: number, y: number, nodes: Element[]) {
+    let rect = null;
+    let node = null;
+    do {
+        node = nodes.splice(0, 1)[0]
+        if (!node)
+            return
+        rect = node.getClientRects()[0]
+    } while (!rect)
+    let top = rect.top
+    node.scrollBy(x, y);
+    if (top == node.getClientRects()[0].top) {
+        let children = Array.prototype.slice.call(node.children).filter(DOM.isVisible)
+        recursiveScroll(x, y, nodes.concat(children))
+    }
+}
+
 //#content
 export function scrollline(n = 1) {
     window.scrollByLines(n)
 }
+
 //#content
 export function scrollpage(n = 1) {
-    window.scrollBy(0, window.innerHeight * n)
+    scrollpx(0, window.innerHeight * n)
 }
 
 /** @hidden */

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -243,14 +243,25 @@ function recursiveScroll(x: number, y: number, nodes: Element[]) {
     let top = rect.top
     node.scrollBy(x, y);
     if (top == node.getClientRects()[0].top) {
-        let children = Array.prototype.slice.call(node.children).filter(DOM.isVisible)
+        // children used to be .filter(DOM.isVisible)'d but apparently nodes
+        // that are !DOM.isVisible can have children that are DOM.isVisible
+        let children = Array.prototype.slice.call(node.childNodes)
         recursiveScroll(x, y, nodes.concat(children))
     }
 }
 
 //#content
 export function scrollline(n = 1) {
+    let top = document.body.getClientRects()[0].top
     window.scrollByLines(n)
+    if (top == document.body.getClientRects()[0].top) {
+        const cssHeight = window.getComputedStyle(document.body).getPropertyValue('line-height')
+        // Remove the "px" at the end
+        const lineHeight = parseInt(cssHeight.substr(0, cssHeight.length - 2))
+        // lineHeight probably can't be NaN but let's make sure
+        if (lineHeight)
+            recursiveScroll(0, lineHeight * n, [window.document.body])
+    }
 }
 
 //#content


### PR DESCRIPTION
Mostly tested on [http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html](http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html) and [https://duckduckgo.com/?q=test&t=ffab&ia=web](https://duckduckgo.com/?q=test&t=ffab&ia=web) with Firefox 58.
This PR enables scrolling on some websites, if the user binds `j` to `scrollpx 10 10` or something equivalent.
This PR does not fix https://github.com/cmcaine/tridactyl/issues/63 and https://github.com/cmcaine/tridactyl/issues/218 .
I couldn't test whether this PR fixes https://github.com/cmcaine/tridactyl/issues/35 or https://github.com/cmcaine/tridactyl/issues/273 .