### PR TITLE
Fix #266 (Focus hijacking)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -176,6 +176,10 @@ const DEFAULTS = o({
     hintchars: "hjklasdfgyuiopqwertnmzxcvb",
     hintfiltermode: "simple", // "simple", "vimperator", "vimperator-reflow"
 
+    // Controls whether the page can focus elements for you via js
+    // Remember to also change browser.autofocus (autofocusing elements via
+    // HTML) in about:config
+    // Maybe have a nice user-vicible message when the setting is changed?
     allowautofocus: "true",
 
     tabopenpos: "next",

--- a/src/config.ts
+++ b/src/config.ts
@@ -168,12 +168,15 @@ const DEFAULTS = o({
             "https://wiki.gentoo.org/index.php?title=Special%3ASearch&profile=default&fulltext=Search&search=",
         qwant: "https://www.qwant.com/?q=",
     }),
+
     newtab: "",
     viewsource: "tridactyl", // "tridactyl" or "default"
     storageloc: "sync",
     homepages: [],
     hintchars: "hjklasdfgyuiopqwertnmzxcvb",
     hintfiltermode: "simple", // "simple", "vimperator", "vimperator-reflow"
+
+    allowautofocus: false,
 
     tabopenpos: "next",
     relatedopenpos: "related",

--- a/src/config.ts
+++ b/src/config.ts
@@ -176,7 +176,7 @@ const DEFAULTS = o({
     hintchars: "hjklasdfgyuiopqwertnmzxcvb",
     hintfiltermode: "simple", // "simple", "vimperator", "vimperator-reflow"
 
-    allowautofocus: false,
+    allowautofocus: "true",
 
     tabopenpos: "next",
     relatedopenpos: "related",

--- a/src/content.ts
+++ b/src/content.ts
@@ -45,6 +45,7 @@ import Mark from "mark.js"
     l: prom => prom.then(console.log).catch(console.error),
 })
 
+dom.setupFocusHandler()
 dom.hijackPageListenerFunctions()
 
 if (

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -426,3 +426,54 @@ export function focus(e: HTMLElement): void {
         e.selectionEnd = e.selectionStart
     }
 }
+
+/** DOM reference to the last used Input field
+ */
+//#content_helper
+let LAST_USED_INPUT: HTMLElement = null
+
+export function getLastUsedInput () {
+   return LAST_USED_INPUT
+}
+
+/** WARNING: This function can potentially recieve malicious input! For the
+ *  whole discussion about this, see
+ *  https://github.com/cmcaine/tridactyl/pull/225
+ *
+ *  Remember to check whether WebComponents change anything security-wise:
+ *  https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements
+ *  https://bugzilla.mozilla.org/show_bug.cgi?id=1406825
+ * */
+function onPageFocus(elem: HTMLElement, args: any[]): void {
+    if (isTextEditable(elem)) {
+        LAST_USED_INPUT = elem
+        config.getAsync("allowautofocus").then((allow) => {
+            if (allow)
+                elem.focus(args)
+        });
+    }
+}
+
+/** Replaces the page's HTMLElement.prototype.focus with our own, onPageFocus */
+function hijackPageFocusFunction(): void {
+    let exportedName = "onPageFocus";
+    exportFunction(onPageFocus, window, {defineAs: exportedName})
+
+    let eval_str = `HTMLElement.prototype.focus = ((realFocus, ${exportedName}) => {
+        return function (...args) {
+            ${exportedName}(this, args)
+        }
+     })(HTMLElement.prototype.focus, ${exportedName})`
+
+     window.eval(eval_str + `;delete ${exportedName}`)
+}
+
+export function setupFocusHandler(): void {
+    // Handles when a user selects an input
+    document.addEventListener("focusin", e => {
+        if (isTextEditable(e.target as HTMLElement))
+            LAST_USED_INPUT = e.target as HTMLElement
+    })
+    // Handles when the page tries to select an input
+    hijackPageFocusFunction()
+}

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -448,7 +448,7 @@ function onPageFocus(elem: HTMLElement, args: any[]): void {
     if (isTextEditable(elem)) {
         LAST_USED_INPUT = elem
         config.getAsync("allowautofocus").then((allow) => {
-            if (allow)
+            if (allow === "true")
                 elem.focus(args)
         });
     }

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -750,12 +750,6 @@ const INPUTPASSWORD_selectors = `
 input[type='password']
 `
 
-/** DOM reference to the last used Input field
- * @hidden
- */
-//#content_helper
-let LAST_USED_INPUT: HTMLElement = null
-
 /** Focus the last used input on the page
  *
  * @param nth   focus the nth input on the page, or "special" inputs:
@@ -777,8 +771,8 @@ export function focusinput(nth: number | string) {
     if (nth === "-l") {
         // try to recover the last used input stored as a
         // DOM node, which should be exactly the one used before (or null)
-        if (LAST_USED_INPUT) {
-            inputToFocus = LAST_USED_INPUT
+        if (DOM.getLastUsedInput()) {
+            inputToFocus = DOM.getLastUsedInput()
         } else {
             // Pick the first input in the DOM.
             inputToFocus = DOM.getElemsBySelector(INPUTTAGS_selectors, [DOM.isSubstantial])[0] as HTMLElement
@@ -790,8 +784,8 @@ export function focusinput(nth: number | string) {
         // attempt to find next/previous input
         let inputs = DOM.getElemsBySelector(INPUTTAGS_selectors, [DOM.isSubstantial]) as HTMLElement[]
         if (inputs.length) {
-            let index = inputs.indexOf(LAST_USED_INPUT)
-            if (LAST_USED_INPUT) {
+            let index = inputs.indexOf(DOM.getLastUsedInput())
+            if (DOM.getLastUsedInput()) {
                 if (nth === "-n") {
                     index++
                 } else {
@@ -832,12 +826,6 @@ export function focusinput(nth: number | string) {
         }
     }
 }
-
-// Store the last focused element
-//#content_helper
-document.addEventListener("focusin", e => {
-    if (DOM.isTextEditable(e.target as HTMLElement)) LAST_USED_INPUT = e.target as HTMLElement
-})
 
 // }}}
 

--- a/src/tridactyl.d.ts
+++ b/src/tridactyl.d.ts
@@ -16,6 +16,12 @@ interface Window {
     eval(str: string): any
 }
 
+interface HTMLElement {
+    // Let's be future proof:
+    // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus
+    focus(options: any): void
+}
+
 declare function exportFunction(
     func: Function,
     targetScope: object,


### PR DESCRIPTION
This fixes https://github.com/cmcaine/tridactyl/issues/266
This is done by hijacking the page's `HTMLElement.prototype.focus()` function. I am not very satisfied with this solution but it's the only way I found to reliably prevent autofocus, merely using event listeners for focus/focusin events didn't cut it.

We already had a whole discussion about hijacking functions which can be found here: https://github.com/cmcaine/tridactyl/pull/225 . The gist of it is that security currently isn't negatively impacted by hijacking functions, although this might not be true once WebComponents are implemented, hence we need to follow their implementation in Firefox closely and re-evaluate the situation once it lands in Firefox Nightly.
