### PR TITLE
Add cleanslate.css

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@types/node": "^8.0.46",
     "awesome-typescript-loader": "^3.2.3",
     "chokidar-cli": "^1.2.0",
+    "cleanslate": "^0.10.1",
     "copy-webpack-plugin": "^4.2.0",
     "jest": "^21.2.1",
     "shared-git-hooks": "^1.2.1",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,10 +4,16 @@ set -e
 
 PATH=$(npm bin):"$PATH"
 export PATH
+CLEANSLATE="node_modules/cleanslate/docs/files/cleanslate.css"
 
 mkdir -p generated/static
 scripts/excmds_macros.py
 scripts/newtab.md.sh
+if [ -e "$CLEANSLATE" ] ; then
+	cp "$CLEANSLATE" build/static/cleanslate.css
+else
+	echo "Couldn't find cleanslate.css. Try running 'npm install'"
+fi
 scripts/make_docs.sh &
 
 (webpack --display errors-only && scripts/git_version.sh)&

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,13 +9,14 @@ CLEANSLATE="node_modules/cleanslate/docs/files/cleanslate.css"
 mkdir -p generated/static
 scripts/excmds_macros.py
 scripts/newtab.md.sh
-if [ -e "$CLEANSLATE" ] ; then
-	cp "$CLEANSLATE" build/static/cleanslate.css
-else
-	echo "Couldn't find cleanslate.css. Try running 'npm install'"
-fi
 scripts/make_docs.sh &
 
 (webpack --display errors-only && scripts/git_version.sh)&
 
 wait
+
+if [ -e "$CLEANSLATE" ] ; then
+	cp "$CLEANSLATE" build/static/cleanslate.css
+else
+	echo "Couldn't find cleanslate.css. Try running 'npm install'"
+fi

--- a/src/commandline_content.ts
+++ b/src/commandline_content.ts
@@ -20,6 +20,7 @@ function init(){
     if (cmdline_iframe === undefined) {
         try {
             cmdline_iframe = window.document.createElement("iframe")
+            cmdline_iframe.className = "cleanslate"
             cmdline_iframe.setAttribute("src", browser.extension.getURL("static/commandline.html"))
             cmdline_iframe.setAttribute("id", "cmdline_iframe")
             hide()
@@ -36,11 +37,11 @@ init()
 
 export function show(){
     const height = cmdline_iframe.contentWindow.document.body.offsetHeight + 'px'
-    cmdline_iframe.setAttribute("style", `height: ${height};`)
+    cmdline_iframe.setAttribute("style", `height: ${height} !important;`)
 }
 
 export function hide(){
-    cmdline_iframe.setAttribute("style", "height: 0px;")
+    cmdline_iframe.setAttribute("style", "height: 0px !important;")
 }
 
 export function focus(){

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -25,7 +25,7 @@ const logger = new Logger('hinting')
 /** Simple container for the state of a single frame's hints. */
 class HintState {
     public focusedHint: Hint
-    readonly hintHost = html`<div class="TridactylHintHost">`
+    readonly hintHost = html`<div class="TridactylHintHost cleanslate">`
     readonly hints: Hint[] = []
     public filter = ''
     public hintchars = ''
@@ -156,8 +156,8 @@ class Hint {
         /*     left: ${rect.left}px; */
         /* ` */
         this.flag.style.cssText = `
-            top: ${window.scrollY + rect.top}px;
-            left: ${window.scrollX + rect.left}px;
+            top: ${window.scrollY + rect.top}px !important;
+            left: ${window.scrollX + rect.left}px !important;
         `
         modeState.hintHost.appendChild(this.flag)
         target.classList.add('TridactylHintElem')

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,6 +24,7 @@
                 "content.js"
             ],
             "css": [
+                "static/cleanslate.css",
                 "static/content.css",
                 "static/hint.css"
             ],

--- a/src/static/commandline.html
+++ b/src/static/commandline.html
@@ -1,6 +1,7 @@
 <html>
     <head>
         <meta charset="utf-8">
+        <link rel="stylesheet" href="cleanslate.css">
         <link rel="stylesheet" href="commandline.css">
     </head>
     <body>

--- a/src/static/content.css
+++ b/src/static/content.css
@@ -1,13 +1,13 @@
 #cmdline_iframe {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    z-index: 2147483647;
-    width: 100%;
-    height: 0;
-    border: 0;
-    padding: 0;
-    margin: 0;
-    min-height: 0;
-    max-height: none;
+    position: fixed !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    z-index: 2147483647 !important;
+    width: 100% !important;
+    height: 0 !important;
+    border: 0 !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    min-height: 0 !important;
+    max-height: none !important;
 }

--- a/src/static/hint.css
+++ b/src/static/hint.css
@@ -1,36 +1,36 @@
 span.TridactylHint {
-    position: absolute;
-    font-family: sans-serif;
-    font-size: 12px;
-    font-weight: bold;
-    text-transform: uppercase;
-    color: white;
-    background-color: red;
-    border-color: ButtonShadow;
-    border-width: 0px;
-    min-width: .75em;
-    border-style: solid;
-    padding: 0 1pt;
-    text-align: center;
-    z-index: 2147483647;
+    position: absolute !important;
+    font-family: sans-serif !important;
+    font-size: 12px !important;
+    font-weight: bold !important;
+    text-transform: uppercase !important;
+    color: white !important;
+    background-color: red !important;
+    border-color: ButtonShadow !important;
+    border-width: 0px !important;
+    min-width: .75em !important;
+    border-style: solid !important;
+    padding: 0 1pt !important;
+    text-align: center !important;
+    z-index: 2147483647 !important;
 }
 
 .TridactylHintElem, .TridactylHintActive {
-    color: black !important;
-    animation: none;
-    transition: unset;
+    color: black !important !important;
+    animation: none !important;
+    transition: unset !important;
 }
 
 .TridactylHintElem {
-    background-color: rgba(255, 255, 0, 0.25);
-    outline: 1px solid #8F5902;
+    background-color: rgba(255, 255, 0, 0.25) !important;
+    outline: 1px solid #8F5902 !important;
 }
 
 .TridactylHintActive {
-    background-color: #88FF00;
-    outline: 1px solid #CC0000;
+    background-color: #88FF00 !important;
+    outline: 1px solid #CC0000 !important;
 }
 
 div.TridactylHintHost {
-    position: static !important;
+    position: static !important !important;
 }


### PR DESCRIPTION
This PR adds cleanslate.css. In order to install cleanslate, be sure to run `npm install`.
This seems to fix https://github.com/cmcaine/tridactyl/issues/220 , https://github.com/cmcaine/tridactyl/issues/112 (it doesn't do anything for the slow fading-in/out of the background color but I don't think we can do much here without breaking websites) and maybe https://github.com/cmcaine/tridactyl/issues/279 , although I seriously doubt it.