### PR TITLE
Add the Prettier linter

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+tabWidth: 4
+useTabs: false
+semi: false
+singleQuote: false
+arrowParens: avoid

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+filetypes="*.js *.jsx *.ts"
+
+# Run prettier on the diffs
+$(npm bin)/precise-commits $filetypes
+# Re-add the modified files
+files=$(git diff --cached --name-only --diff-filter=ACM $filetypes)
+if [ "" != "$files" ]; then
+    echo "$files" | xargs git add
+fi

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "cleanslate": "^0.10.1",
     "copy-webpack-plugin": "^4.2.0",
     "jest": "^21.2.1",
+    "precise-commits": "^1.0.2",
+    "prettier": "^1.11.1",
     "shared-git-hooks": "^1.2.1",
     "source-map-loader": "^0.2.2",
     "ts-jest": "^21.1.3",


### PR DESCRIPTION
This commit adds the Prettier linter to the project. I think I remember talking about this with bovine3dom a few months ago.
The linter is run through a pre-commit hook and thanks to the "precise-commits" binary only on the actually-modified portions of the code, not the whole file (doing otherwise would have made every PR unmergeable). We might want to run prettier on all files in a few months/when all PRs are merged though.
As for the defaults, I tried to choose settings that matched the current code base. Let me know if anything should be changed. The list of options can be found here: https://prettier.io/docs/en/options.html