### PR TITLE
Impl viewsource

### DIFF
--- a/src/commandline_content.ts
+++ b/src/commandline_content.ts
@@ -52,6 +52,23 @@ export function blur() {
     cmdline_iframe.blur()
 }
 
+export function executeWithoutCommandLine(fn) {
+    let parent
+    if (cmdline_iframe) {
+        parent = cmdline_iframe.parentNode
+        parent.removeChild(cmdline_iframe)
+    }
+    let result
+    try {
+        result = fn()
+    } catch (e) {
+        console.log(e)
+    }
+    if (cmdline_iframe) parent.appendChild(cmdline_iframe)
+    return result
+}
+
+
 import * as Messaging from './messaging'
 import * as SELF from './commandline_content'
 Messaging.addListener('commandline_content', Messaging.attributeCaller(SELF))

--- a/src/config.ts
+++ b/src/config.ts
@@ -154,6 +154,7 @@ const DEFAULTS = o({
 
     }),
     "newtab": "",
+    "viewsource": "tridactyl", // "tridactyl" or "default"
     "storageloc": "sync",
     "homepages": [],
     "hintchars": "hjklasdfgyuiopqwertnmzxcvb",

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -84,6 +84,7 @@ import "./number.clamp"
 import * as SELF from "./excmds_content"
 Messaging.addListener('excmd_content', Messaging.attributeCaller(SELF))
 import * as DOM from './dom'
+import { executeWithoutCommandLine } from "./commandline_content"
 // }
 
 //#background_helper
@@ -292,11 +293,29 @@ export function open(...urlarr: string[]) {
     window.location.href = forceURI(url)
 }
 
+//#content_helper
+let sourceElement = undefined
 //#content
 export function viewsource(url = "") {
     if (url === "")
         url = window.location.href
-    window.location.href = "view-source:" + window.location.href
+    if (config.get("viewsource") === "default") {
+        window.location.href = "view-source:" + window.location.href
+        return
+    }
+    if (!sourceElement) {
+        sourceElement = executeWithoutCommandLine(() => {
+            let pre = document.createElement("pre")
+            pre.id = "TridactylViewsourceElement"
+            pre.className = "cleanslate"
+            pre.innerText = document.documentElement.innerHTML
+            document.documentElement.appendChild(pre)
+            return pre
+        })
+    } else {
+        sourceElement.parentNode.removeChild(sourceElement)
+        sourceElement = undefined
+    }
 }
 
 /** Go to your homepage(s)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -292,6 +292,13 @@ export function open(...urlarr: string[]) {
     window.location.href = forceURI(url)
 }
 
+//#content
+export function viewsource(url = "") {
+    if (url === "")
+        url = window.location.href
+    window.location.href = "view-source:" + window.location.href
+}
+
 /** Go to your homepage(s)
 
     @param all

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -307,7 +307,7 @@ export function viewsource(url = "") {
         sourceElement = executeWithoutCommandLine(() => {
             let pre = document.createElement("pre")
             pre.id = "TridactylViewsourceElement"
-            pre.className = "cleanslate"
+            pre.className = "cleanslate " + config.get("theme")
             pre.innerText = document.documentElement.innerHTML
             document.documentElement.appendChild(pre)
             return pre

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -300,7 +300,7 @@ export function viewsource(url = "") {
     if (url === "")
         url = window.location.href
     if (config.get("viewsource") === "default") {
-        window.location.href = "view-source:" + window.location.href
+        window.location.href = "view-source:" + url
         return
     }
     if (!sourceElement) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -27,7 +27,8 @@
                 "static/cleanslate.css",
                 "static/content.css",
                 "static/content-dark.css",
-                "static/hint.css"
+                "static/hint.css",
+                "static/viewsource.css"
             ],
             "run_at": "document_start",
             "match_about_blank": true

--- a/src/static/viewsource.css
+++ b/src/static/viewsource.css
@@ -1,0 +1,9 @@
+
+#TridactylViewsourceElement {
+  position: absolute !important;
+  top: 0px !important;
+  font-family: monospace !important;
+  background-color: #F0F0F2 !important;
+  white-space: pre !important;
+  width: 100% !important;
+}

--- a/src/static/viewsource.css
+++ b/src/static/viewsource.css
@@ -9,3 +9,8 @@
   white-space: pre !important;
   min-width: 100% !important;
 }
+
+#TridactylViewsourceElement.dark {
+  background: #111 !important;
+  color: #fff !important;
+}

--- a/src/static/viewsource.css
+++ b/src/static/viewsource.css
@@ -1,9 +1,11 @@
 
 #TridactylViewsourceElement {
   position: absolute !important;
+  /* This is the z-index of hint.css and content.css -1 */
+  z-index: 2147483646 !important;
   top: 0px !important;
   font-family: monospace !important;
-  background-color: #F0F0F2 !important;
+  background: white !important;
   white-space: pre !important;
-  width: 100% !important;
+  min-width: 100% !important;
 }


### PR DESCRIPTION
I  use Pentadactyl's `:viewsource` command from time to time. This is a re-implementation of this command. I added a `viewsource` setting which can be set either to `tridactyl`or to `default` in order to alleviate the pain of Tridactyl not loading on Firefox's `view-source` pages.
Fun fact, when `viewsource` is set to `default`, you can `:viewsource file:///home/user/file`. It works quite well with plaintext files and pictures, although Tridactyl obviously doesn't load on these pages.