### PR TITLE
Implement jumplist

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -73,8 +73,8 @@ const DEFAULTS = o({
         "<c-6>": "buffer #",
         H: "back",
         L: "forward",
-        "<c-o>": "back",
-        "<c-i>": "forward",
+        "<c-o>": "jumpprev",
+        "<c-i>": "jumpnext",
         d: "tabclose",
         D: "composite tabprev; sleep 100; tabclose #",
         gx0: "tabclosealltoleft",
@@ -252,7 +252,7 @@ const DEFAULTS = o({
     theme: "default", // currently available: "default", "dark"
     modeindicator: "true",
 
-    "jumpdelay": 1000, // Delay before registering a scroll in the jumplist
+    jumpdelay: 1000, // Delay before registering a scroll in the jumplist
 
     // Default logging levels - 2 === WARNING
     logging: o({

--- a/src/config.ts
+++ b/src/config.ts
@@ -252,6 +252,8 @@ const DEFAULTS = o({
     theme: "default", // currently available: "default", "dark"
     modeindicator: "true",
 
+    "jumpdelay": 1000, // Delay before registering a scroll in the jumplist
+
     // Default logging levels - 2 === WARNING
     logging: o({
         messaging: 2,

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -513,6 +513,56 @@ export function loggingsetlevel(logModule: string, level: string) {
 
 // {{{ PAGE CONTEXT
 
+//#content_helper
+export let JUMPLIST = []
+//#content_helper
+export let JUMPCURRENT : number
+//#content_helper
+export let JUMPTIMEOUT : number
+//#content_helper
+export let JUMPED : boolean
+
+//#content
+export function jumpnext(n = 1) {
+    jumpback(-n)
+}
+
+/** Similar to Pentadactyl or vim's jump list.
+    Should be bound to <C-o> when modifiers are implemented
+*/
+//#content
+export function jumpback(n = 1) {
+    JUMPCURRENT = (JUMPCURRENT - n).clamp(0, JUMPLIST.length - 1)
+    let p = JUMPLIST[JUMPCURRENT]
+    JUMPED = true
+    window.scrollTo(p.x, p.y)
+}
+
+/** Called on 'scroll' events.
+    If you want to have a function that moves within the page but doesn't add a
+    location to the jumplist, make sure to set JUMPED to true before moving
+    around.
+    The setTimeout call is required because sometimes a user wants to move
+    somewhere by pressing 'j' multiple times and we don't want to add the
+    in-between locations to the jump list
+*/
+//#content_helper
+export function addJump(scrollEvent: UIEvent) {
+    if (JUMPED) {
+        JUMPED = false
+        return
+    }
+    clearTimeout(JUMPTIMEOUT)
+    JUMPTIMEOUT = setTimeout(() => {
+        JUMPLIST.push({'x': scrollEvent.pageX, 'y': scrollEvent.pageY})
+        JUMPCURRENT = JUMPLIST.length - 1
+    } , config.get("jumpdelay"))
+}
+
+//#content_helper
+document.addEventListener("scroll", addJump); addJump(new UIEvent("scroll"))
+
+
 /** Blur (unfocus) the active element */
 //#content
 export function unfocus() {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -516,23 +516,25 @@ export function loggingsetlevel(logModule: string, level: string) {
 //#content_helper
 export let JUMPLIST = []
 //#content_helper
-export let JUMPCURRENT : number
+export let JUMPCURRENT: number
 //#content_helper
-export let JUMPTIMEOUT : number
+export let JUMPTIMEOUT: number
 //#content_helper
-export let JUMPED : boolean
+export let JUMPED: boolean
 
 //#content
 export function jumpnext(n = 1) {
-    jumpback(-n)
+    jumpprev(-n)
 }
 
 /** Similar to Pentadactyl or vim's jump list.
     Should be bound to <C-o> when modifiers are implemented
 */
 //#content
-export function jumpback(n = 1) {
-    JUMPCURRENT = (JUMPCURRENT - n).clamp(0, JUMPLIST.length - 1)
+export function jumpprev(n = 1) {
+    JUMPCURRENT -= n
+    if (JUMPCURRENT < 0) return back(-JUMPCURRENT)
+    else if (JUMPCURRENT >= JUMPLIST.length) return forward(JUMPCURRENT - JUMPLIST.length + 1)
     let p = JUMPLIST[JUMPCURRENT]
     JUMPED = true
     window.scrollTo(p.x, p.y)
@@ -554,14 +556,14 @@ export function addJump(scrollEvent: UIEvent) {
     }
     clearTimeout(JUMPTIMEOUT)
     JUMPTIMEOUT = setTimeout(() => {
-        JUMPLIST.push({'x': scrollEvent.pageX, 'y': scrollEvent.pageY})
+        JUMPLIST.push({ x: scrollEvent.pageX, y: scrollEvent.pageY })
         JUMPCURRENT = JUMPLIST.length - 1
-    } , config.get("jumpdelay"))
+    }, config.get("jumpdelay"))
 }
 
 //#content_helper
-document.addEventListener("scroll", addJump); addJump(new UIEvent("scroll"))
-
+document.addEventListener("scroll", addJump)
+addJump(new UIEvent("scroll"))
 
 /** Blur (unfocus) the active element */
 //#content

--- a/src/tridactyl.d.ts
+++ b/src/tridactyl.d.ts
@@ -16,6 +16,12 @@ interface Window {
     eval(str: string): any
 }
 
+// Again, firefox-specific
+interface UIEvent {
+    pageX: number
+    pageY: number
+}
+
 interface HTMLElement {
     // Let's be future proof:
     // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus


### PR DESCRIPTION
This implements a jumplist similar to the one that can be found in vimperator/pentadactyl (bound to `<C-i>`/`<C-o>`).
The main difference is that reaching the end or the beginning of the jumplist won't load the previous/next page. This behavior seems more intuitive to me and is easier to implement.

I think we should bind jumpback and jumpnext to `<C-i>` and `<C-o>` once modifiers are supported.