### PR TITLE
Fix #341 `:tabclose #`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src/excmds_content.ts
 generated
 web-ext-artifacts
 yarn.lock
+.vscode/


### PR DESCRIPTION
Fixes #341: `tabclose #` now works as expected.

I don't know debugged to see why `composite tabprev | tabclose #` doesn't work as expected (from #337), so it's unfixed here.