### PR TITLE
[WIP] Implement autocommand TabSwitch command

### DIFF
--- a/src/autocmd_background.ts
+++ b/src/autocmd_background.ts
@@ -1,0 +1,24 @@
+import * as Config from './config'
+import * as Messaging from './messaging'
+import * as Util from './utils'
+import * as CmdlineBg from './commandline_background'
+
+// Register listeners to trigger the autocommands
+browser.tabs.onActivated.addListener(arg => runTabSwitchAcmds(arg.tabId))
+
+async function runTabSwitchAcmds(tid: number): Promise<void> {
+    console.log(`Running TabSwitch autocmds`)
+
+    const tab = await browser.tabs.get(tid)
+    const acmds = await Config.getAsync('autocmds', 'TabSwitch')
+    if(!acmds) return
+    // Again, the lazy way, but it'll get changed. I swear.
+    const sites = Object.keys(acmds)
+    const firstMatch = sites.find(e => tab.url.includes(e))
+
+    if(firstMatch) {
+        const cmd = acmds[firstMatch]
+        console.log(`Running aucmd for '${firstMatch}': ${cmd}`)
+        CmdlineBg.recvExStr(cmd)
+    }
+}

--- a/src/autocmd_content.ts
+++ b/src/autocmd_content.ts
@@ -1,0 +1,20 @@
+import * as Config from './config'
+import * as Messaging from './messaging'
+import * as Util from './utils'
+
+loadDocstartAucmds()
+
+async function loadDocstartAucmds(): Promise<void> {
+    console.log(`Running DocStart autocmds`)
+
+    const docstartCmds = await Config.getAsync('autocmds', 'DocStart')
+    const ausites = Object.keys(docstartCmds)
+    // This is the lazy way; switch to matching later
+    const matching = ausites.find(e => document.location.href.includes(e))
+
+    if(matching) {
+        const cmd = docstartCmds[matching]
+        console.log(`Running aucmd for '${matching}': ${cmd}`)
+        Messaging.message('commandline_background', 'recvExStr', [cmd])
+    }
+}

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,8 +1,8 @@
 /** Background script entry point. */
 
-import * as Controller from "./controller"
-import * as keydown_background from "./keydown_background"
-import * as CommandLine from "./commandline_background"
+import * as Controller from './controller'
+import * as keydown_background from './keydown_background'
+import * as CommandLine from './commandline_background'
 import './lib/browser_proxy_background'
 
 // Send keys to controller
@@ -31,7 +31,10 @@ import * as msgsafe from './msgsafe'
 import state from './state'
 import * as webext from './lib/webext'
 
-(window as any).tri = Object.assign(Object.create(null), {
+// Load autocommand triggers
+import './autocmd_background'
+
+;(window as any).tri = Object.assign(Object.create(null), {
     messaging,
     excmds,
     commandline_background,

--- a/src/commandline_background.ts
+++ b/src/commandline_background.ts
@@ -16,7 +16,7 @@ export const onLine = {
 const listeners = new Set<onLineCallback>()
 
 /** Receive events from commandline_frame and pass to listeners */
-function recvExStr(exstr: string) {
+export function recvExStr(exstr: string) {
     for (let listener of listeners) {
         listener(exstr)
     }

--- a/src/content.ts
+++ b/src/content.ts
@@ -3,13 +3,13 @@
 // Be careful: typescript elides imports that appear not to be used if they're
 // assigned to a name.  If you want an import just for its side effects, make
 // sure you import it like this:
-import "./lib/html-tagged-template"
+import './lib/html-tagged-template'
 /* import "./keydown_content" */
 /* import "./commandline_content" */
 /* import "./excmds_content" */
 /* import "./hinting" */
 
-console.log("Tridactyl content script loaded, boss!")
+console.log('Tridactyl content script loaded, boss!')
 
 // Add various useful modules to the window for debugging
 import * as commandline_content from './commandline_content'
@@ -19,13 +19,17 @@ import * as dom from './dom'
 import * as excmds from './excmds_content'
 import * as hinting_content from './hinting'
 import * as itertools from './itertools'
-import * as keydown_content from "./keydown_content"
+import * as keydown_content from './keydown_content'
 import * as messaging from './messaging'
 import * as msgsafe from './msgsafe'
 import state from './state'
 import * as webext from './lib/webext'
+import * as Aucmd from './autocmd_content'
 
-(window as any).tri = Object.assign(Object.create(null), {
+// Load autocommand triggers
+import './autocmd_content'
+
+;(window as any).tri = Object.assign(Object.create(null), {
     browserBg: webext.browserBg,
     commandline_content,
     convert,
@@ -42,9 +46,12 @@ import * as webext from './lib/webext'
     l: prom => prom.then(console.log).catch(console.error),
 })
 
-if (window.location.protocol === "moz-extension:" && window.location.pathname === "/static/newtab.html") {
-    (window as any).tri.config.getAsync("newtab").then((newtab) => {
-        if (newtab !== "")
+if (
+    window.location.protocol === 'moz-extension:' &&
+    window.location.pathname === '/static/newtab.html'
+) {
+    ;(window as any).tri.config.getAsync('newtab').then(newtab => {
+        if (newtab !== '')
             window.location.href = (window as any).tri.excmds.forceURI(newtab)
     })
 }

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -361,7 +361,7 @@ function selectLast(selector: string): HTMLElement | null {
 /** Find a likely next/previous link and follow it
 
     If a link or anchor element with rel=rel exists, use that, otherwise fall back to:
-    
+
         1) find the last anchor on the page with innerText matching the appropriate `followpagepattern`.
         2) call [[urlincrement]] with 1 or -1
 
@@ -591,26 +591,6 @@ export async function reader() {
     } // else {
     //  // once a statusbar exists an error can be displayed there
     // }
-    }
-}
-
-//@hidden
-//#content_helper
-loadaucmds()
-
-//@hidden
-//#content
-export async function loadaucmds(){
-    console.log("AUCMDS TRIED TO RUN")
-    // for some reason, this never changes from the default, even when there is user config (e.g. set via `aucmd bbc.co.uk mode ignore`)
-    let aucmds = await config.getAsync("autocmds", "DocStart")
-    console.log(aucmds)
-    const ausites = Object.keys(aucmds)
-    // yes, this is lazy
-    const aukey = ausites.find(e=>window.document.location.href.includes(e))
-    if (aukey !== undefined){
-        console.log(aukey)
-        Messaging.message("commandline_background", "recvExStr", [aucmds[aukey]])
     }
 }
 
@@ -1393,6 +1373,11 @@ export function set(key: string, ...values: string[]) {
     }
 }
 
+const validAcmdTriggers = [
+    'DocStart',
+    'TabSwitch'
+]
+
 /** Set autocmds to run when certain events happen.
 
  @param event Curently, only 'DocStart' is supported.
@@ -1404,10 +1389,10 @@ export function set(key: string, ...values: string[]) {
 */
 //#background
 export function autocmd(event: string, url: string, ...excmd: string[]){
-    // rudimentary run time type checking
-    // TODO: Decide on autocmd event names
-    if(!['DocStart'].includes(event)) throw (event + " is not a supported event.")
-    config.set("autocmds", event, url, excmd.join(" "))
+    if(! validAcmdTriggers.includes(event))
+        throw `${event} is not supported.`
+
+    config.set('autocmds', event, url, excmd.join(' '))
 }
 
 /** Unbind a sequence of keys so that they do nothing at all.

--- a/src/url_util.ts
+++ b/src/url_util.ts
@@ -374,3 +374,68 @@ export function interpolateSearchItem(urlPattern: URL, query: string): URL {
         return new URL(urlPattern.href + query)
     }
 }
+
+/**
+ * Transforms a valid match pattern into a regular expression
+ * which matches all URLs included by that pattern.
+ * Copied from https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Match_patterns
+ *
+ * @param  {string}  pattern  The pattern to transform.
+ * @return {RegExp}           The pattern's equivalent as a RegExp.
+ * @throws {TypeError}        If the pattern is not a valid MatchPattern
+ */
+function matchPatternToRegExp(pattern: string): RegExp {
+    if (pattern === '') {
+        return (/^(?:http|https|file|ftp|app):\/\//);
+    }
+
+    const schemeSegment = '(\\*|http|https|file|ftp)';
+    const hostSegment = '(\\*|(?:\\*\\.)?(?:[^/*]+))?';
+    const pathSegment = '(.*)';
+    const matchPatternRegExp = new RegExp(
+        `^${schemeSegment}://${hostSegment}/${pathSegment}$`
+    );
+
+    let match = matchPatternRegExp.exec(pattern);
+    if (!match) {
+         throw new TypeError(`"${pattern}" is not a valid MatchPattern`);
+    }
+
+    let [, scheme, host, path] = match;
+    if (!host) {
+        throw new TypeError(`"${pattern}" does not have a valid host`);
+    }
+
+    let regex = '^';
+
+    if (scheme === '*') {
+        regex += '(http|https)';
+    } else {
+        regex += scheme;
+    }
+
+    regex += '://';
+
+    if (host && host === '*') {
+        regex += '[^/]+?';
+    } else if (host) {
+        if (host.match(/^\*\./)) {
+            regex += '[^/]*?';
+            host = host.substring(2);
+        }
+        regex += host.replace(/\./g, '\\.');
+    }
+
+    if (path) {
+        if (path === '*') {
+            regex += '(/.*)?';
+        } else if (path.charAt(0) !== '/') {
+            regex += '/';
+            regex += path.replace(/\./g, '\\.').replace(/\*/g, '.*?');
+            regex += '/?';
+        }
+    }
+
+    regex += '$';
+    return new RegExp(regex);
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,3 @@
+export function isContentScript(): boolean {
+    return !('tabs' in browser)
+}


### PR DESCRIPTION
Adds a TabSwitch trigger for `:autocmd`. Also refactor autocmds to be more extensible for more events. This is, at most, a temporary workaround for the implementation of page-local state objects, but in the meantime, it will have to do. 

Fixes #158 by adding a TabSwitch trigger.
Fixes partially #57 (worded to not auto-close the issue) by allowing page-local state, which will allow something like `:autocmd TabSwitch pattern passthrough <keystopassthrough>`