### PR TITLE
Move cursor to the end of selected input elements

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -177,6 +177,10 @@ const DEFAULTS = o({
     // If firefox, <Tab> selects the next selectable element, e.g. a link
     "gimode": "nextinput", // either "nextinput" or "firefox"
 
+    // either "beginning" or "end"
+    // Decides where to place the cursor when selecting non-empty input fields
+    "cursorpos": "end",
+
     "theme": "default",     // currently available: "default", "dark"
 
     // Default logging levels - 2 === WARNING

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -1,4 +1,5 @@
 import {MsgSafeNode} from './msgsafe'
+import * as config from './config'
 // From saka-key lib/dom.js, under Apachev2
 
 /**
@@ -360,3 +361,16 @@ export function hijackPageListenerFunctions(): void {
 
    window.eval(eval_str + `;delete ${exportedName}`)
 }
+
+/** Focuses an input element and makes sure the cursor is put at the end of the input */
+export function focus(e: HTMLElement): void {
+   e.focus()
+   if (e instanceof HTMLInputElement) {
+      let pos = 0
+      if (config.get("cursorpos") === "end")
+         pos = e.value.length
+      e.selectionStart = pos
+      e.selectionEnd = e.selectionStart
+   }
+}
+

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -779,7 +779,7 @@ export function focusinput(nth: number|string) {
     }
 
     if (inputToFocus) {
-        inputToFocus.focus()
+        DOM.focus(inputToFocus)
         if (config.get('gimode') === 'nextinput' && state.mode !== 'input') {
             state.mode = 'input'
         }

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -522,8 +522,8 @@ function simulateClick(target: HTMLElement) {
         openInNewTab((target as HTMLAnchorElement).href, {related: true})
     } else {
         DOM.mouseEvent(target, "click")
-        // Sometimes clicking the element doesn't focus it sufficiently.
-        target.focus()
+        // DOM.focus has additional logic for focusing inputs
+        DOM.focus(target)
     }
 }
 


### PR DESCRIPTION
Very small patch for automatically moving the cursor to the end of a selected input or textarea. This is in my opinion more intuitive than the current behavior which is to put it at the beginning.
I tested this with `f` and `gi`. I don't know if there are other ways to select an input element.
Since this modifies the "selection" of an input element I also tested whether this overwrote the content of X11's selection buffer and it doesn't.