### PR TITLE
keyseq.ts: Fix empty mappings being returned

### DIFF
--- a/src/keyseq.ts
+++ b/src/keyseq.ts
@@ -144,7 +144,8 @@ function prefixes(seq1: KeyEventLike[], seq2: MinimalKey[]) {
 export function completions(keyseq: KeyEventLike[], map: KeyMap): KeyMap {
     const possibleMappings = new Map() as KeyMap
     for (const [ks, maptarget] of map.entries()) {
-        if (prefixes(keyseq, ks)) {
+        // maptarget might be "" because of unbound keys, ignore such case
+        if (maptarget && prefixes(keyseq, ks)) {
             possibleMappings.set(ks, maptarget)
         }
     }


### PR DESCRIPTION
I believe this fixes https://github.com/cmcaine/tridactyl/issues/401