### PR TITLE
Nativemessenger

### DIFF
--- a/native/install.sh
+++ b/native/install.sh
@@ -38,3 +38,15 @@ native_file_escaped=$(sed 's/[&/\]/\\&/g' <<< "$native_file")
 
 sed -i.bak "s/REPLACE_ME_WITH_SED/$native_file_escaped/" "$manifest_file"
 chmod +x $native_file
+
+# Requirements for native messenger
+python_path=$(which python3)
+pip_path=$(which pip3)
+if [[ -x "$python_path" ]] && [[ -x "$pip_path" ]]; then
+    echo "Python 3 and pip found."
+    # pip3 install --user tinycss2
+    # put dependencies here
+else
+    echo "Error: Python 3 and pip3 must exist in PATH."
+    echo "Please install them and run this script again."
+fi

--- a/native/install.sh
+++ b/native/install.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# To install, curl -fsSl 'url to this script' | sh
+
+XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config/tridactyl}"
+XDG_DATA_HOME="${XDG_LOCAL_HOME:-$HOME/.local/share/tridactyl}"
+manifest_loc="https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/tridactyl.json"
+native_loc="https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/native_main.py"
+
+# Decide where to put the manifest based on OS
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    manifest_home="$HOME/.mozilla/native-messaging-hosts/"
+    echo 'Linux system detected'
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    manifest_home="$HOME/Library/Application Support/Mozilla/NativeMessagingHosts/"
+    echo 'macOS system detected'
+fi
+
+mkdir -p "$manifest_home" "$XDG_DATA_HOME"
+
+manifest_file="$manifest_home/tridactyl.json"
+native_file="$XDG_DATA_HOME/native_main.py"
+
+echo "Manifest home: $manifest_home"
+echo "XDG_DATA_HOME: $XDG_DATA_HOME"
+
+# Download the files using curl since macOS doesn't ship with wget for
+# inexplicable reasons
+# Until this PR is merged into master, we'll be copying the local version over
+# instead of downloading it
+# curl --create-dirs -o $manifest_file $manifest_loc
+# curl --create-dirs -o $native_file $native_loc
+cp -f tridactyl.json "$manifest_file"
+cp -f native_main.py "$native_file"
+
+native_file_escaped=$(sed 's/[&/\]/\\&/g' <<< "$native_file")
+
+sed -i.bak "s/REPLACE_ME_WITH_SED/$native_file_escaped/" "$manifest_file"
+chmod +x $native_file

--- a/native/install.sh
+++ b/native/install.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-# To install, curl -fsSl 'url to this script' | sh
+# To install, curl -fsSl 'url to this script' | bash
 
 XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config/tridactyl}"
 XDG_DATA_HOME="${XDG_LOCAL_HOME:-$HOME/.local/share/tridactyl}"
@@ -24,8 +24,6 @@ native_file="$XDG_DATA_HOME/native_main.py"
 echo "Manifest home: $manifest_home"
 echo "XDG_DATA_HOME: $XDG_DATA_HOME"
 
-# Download the files using curl since macOS doesn't ship with wget for
-# inexplicable reasons
 # Until this PR is merged into master, we'll be copying the local version over
 # instead of downloading it
 if [[ "$1" == "local" ]]; then

--- a/native/install.sh
+++ b/native/install.sh
@@ -28,10 +28,13 @@ echo "XDG_DATA_HOME: $XDG_DATA_HOME"
 # inexplicable reasons
 # Until this PR is merged into master, we'll be copying the local version over
 # instead of downloading it
-# curl --create-dirs -o $manifest_file $manifest_loc
-# curl --create-dirs -o $native_file $native_loc
-cp -f tridactyl.json "$manifest_file"
-cp -f native_main.py "$native_file"
+if [[ "$1" == "local" ]]; then
+    cp -f native/tridactyl.json "$manifest_file"
+    cp -f native/native_main.py "$native_file"
+else
+    curl --create-dirs -o $manifest_file $manifest_loc
+    curl --create-dirs -o $native_file $native_loc
+fi
 
 native_file_escaped=$(sed 's/[&/\]/\\&/g' <<< "$native_file")
 

--- a/native/native_main.py
+++ b/native/native_main.py
@@ -70,18 +70,15 @@ def handleMessage(message):
         reply = {'version': VERSION}
 
     elif cmd == 'run':
-        if "|" in message["command"]:
-            commands = message["command"].split("|")
-            p1 = subprocess.Popen(commands[0].split(" "),stdout=subprocess.PIPE)
-            p2 = p1
-            for command in commands[1:]:
-                command = list(filter(None,command.split(" ")))
-                p2 = subprocess.Popen(command,stdin=p1.stdout,stdout=subprocess.PIPE)
-                p1.stdout.close()
-                p1 = p2
-            output = p2.communicate()[0].decode("utf-8")
-        else:
-            output = subprocess.check_output(message["command"].split(" ")).decode("utf-8")
+        commands = message["command"].split("|")
+        p1 = subprocess.Popen(commands[0].split(" "),stderr=subprocess.STDOUT,stdout=subprocess.PIPE)
+        p2 = p1
+        for command in commands[1:]:
+            command = list(filter(None,command.split(" ")))
+            p2 = subprocess.Popen(command,stdin=p1.stdout,stderr=subprocess.STDOUT,stdout=subprocess.PIPE)
+            p1.stdout.close()
+            p1 = p2
+        output = p2.communicate()[0].decode("utf-8")
         reply['content'] = output if output else ""
 
     elif cmd == 'eval':

--- a/native/native_main.py
+++ b/native/native_main.py
@@ -69,7 +69,7 @@ def handleMessage(message):
         reply = {'version': VERSION}
 
     elif cmd == 'run':
-        output = subprocess.check_output(message["command"].split(" "))
+        output = subprocess.check_output(message["command"].split(" ")).decode("utf-8")
         reply['content'] = output if output else ""
 
     elif cmd == 'eval':

--- a/native/native_main.py
+++ b/native/native_main.py
@@ -5,6 +5,7 @@ import sys
 import os
 import json
 import struct
+import subprocess
 
 VERSION = "0.1.1"
 
@@ -105,6 +106,19 @@ def handleMessage(message):
             reply['content'] = file_content
         else:
             reply['error'] = 'File not found'
+
+    elif cmd == 'run':
+        output = subprocess.check_output(message["command"].split(" "))
+        reply['content'] = output if output else ""
+
+    elif cmd == 'read':
+        with open(message["file"],"r") as file:
+            reply['content'] = file.read()
+
+    elif cmd == 'write':
+        with open(message["file"],"w") as file:
+            file.write(message["content"])
+
 
     else:
         reply = {'cmd': 'error', 'error': 'Unhandled message'}

--- a/native/native_main.py
+++ b/native/native_main.py
@@ -6,6 +6,7 @@ import os
 import json
 import struct
 import subprocess
+import tempfile
 
 VERSION = "0.1.0"
 
@@ -83,6 +84,12 @@ def handleMessage(message):
     elif cmd == 'write':
         with open(message["file"],"w") as file:
             file.write(message["content"])
+
+    elif cmd == 'temp':
+        (handle,filepath) = tempfile.mkstemp()
+        with open(filepath,"w") as file:
+            file.write(message["content"])
+        reply['content'] = filepath
 
     else:
         reply = {'cmd': 'error', 'error': 'Unhandled message'}

--- a/native/native_main.py
+++ b/native/native_main.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sys
+import os
+import json
+import struct
+
+VERSION = "0.1.1"
+
+
+class NoConnectionError(Exception):
+    """ Exception thrown when stdin cannot be read """
+
+
+def eprint(*args, **kwargs):
+    """ Print to stderr, which gets echoed in the browser console when run
+    by Firefox
+    """
+    print(*args, file=sys.stderr, flush=True, **kwargs)
+
+
+def _getenv(variable, default):
+    """ Get an environment variable value, or use the default provided """
+    return os.environ.get(variable) or default
+
+
+def getMessage():
+    """ Read a message from stdin and decode it."""
+    rawLength = sys.stdin.buffer.read(4)
+    if len(rawLength) == 0:
+        sys.exit(0)
+    messageLength = struct.unpack('@I', rawLength)[0]
+    message = sys.stdin.buffer.read(messageLength).decode('utf-8')
+    return json.loads(message)
+
+
+# Encode a message for transmission,
+# given its content.
+def encodeMessage(messageContent):
+    """ Encode a message for transmission, given its content."""
+    encodedContent = json.dumps(messageContent).encode('utf-8')
+    encodedLength = struct.pack('@I', len(encodedContent))
+    return {'length': encodedLength, 'content': encodedContent}
+
+
+# Send an encoded message to stdout
+def sendMessage(encodedMessage):
+    """ Send an encoded message to stdout."""
+    sys.stdout.buffer.write(encodedMessage['length'])
+    sys.stdout.buffer.write(encodedMessage['content'])
+    sys.stdout.buffer.flush()
+
+
+def findUserConfigFile():
+    """ Find a user config file, if it exists. Return the file path, or None
+    if not found
+    """
+    home = os.path.expanduser('~')
+    config_dir = _getenv('XDG_CONFIG_HOME', os.path.expanduser('~/.config'))
+
+    # Will search for files in this order
+    candidate_files = [
+        os.path.join(config_dir, "tridactyl", "tridactylrc"),
+        os.path.join(home, '.tridactylrc')
+    ]
+
+    eprint(candidate_files)
+    config_path = None
+
+    # find the first path in the list that exists
+    for path in candidate_files:
+        eprint("Checking file {}".format(path))
+        if os.path.isfile(path):
+            config_path = path
+            break
+
+    return config_path
+
+
+def getUserConfig():
+    # look it up freshly each time - the user could have moved or killed it
+    cfg_file = findUserConfigFile()
+
+    # no file, return
+    if not cfg_file:
+        return None
+
+    # for now, this is a simple file read, but if the files can
+    # include other files, that will need more work
+    return open(cfg_file, 'r').read()
+
+
+def handleMessage(message):
+    """ Generate reply from incoming message. """
+    cmd = message["cmd"]
+    reply = {'cmd': cmd}
+
+    if cmd == 'version':
+        reply = {'version': VERSION}
+
+    elif cmd == 'getconfig':
+        file_content = getUserConfig()
+        if file_content:
+            reply['content'] = file_content
+        else:
+            reply['error'] = 'File not found'
+
+    else:
+        reply = {'cmd': 'error', 'error': 'Unhandled message'}
+        eprint('Unhandled message: {}'.format(message))
+
+    return reply
+
+
+eprint('Starting Native Messenger')
+while True:
+    message = getMessage()
+    reply = handleMessage(message)
+    sendMessage(encodeMessage(reply))

--- a/native/native_main.py
+++ b/native/native_main.py
@@ -70,7 +70,18 @@ def handleMessage(message):
         reply = {'version': VERSION}
 
     elif cmd == 'run':
-        output = subprocess.check_output(message["command"].split(" ")).decode("utf-8")
+        if "|" in message["command"]:
+            commands = message["command"].split("|")
+            p1 = subprocess.Popen(commands[0].split(" "),stdout=subprocess.PIPE)
+            p2 = p1
+            for command in commands[1:]:
+                command = list(filter(None,command.split(" ")))
+                p2 = subprocess.Popen(command,stdin=p1.stdout,stdout=subprocess.PIPE)
+                p1.stdout.close()
+                p1 = p2
+            output = p2.communicate()[0].decode("utf-8")
+        else:
+            output = subprocess.check_output(message["command"].split(" ")).decode("utf-8")
         reply['content'] = output if output else ""
 
     elif cmd == 'eval':

--- a/native/tridactyl.json
+++ b/native/tridactyl.json
@@ -1,0 +1,7 @@
+{
+    "name": "tridactyl",
+    "description": "Tridactyl native command handler",
+    "path": "REPLACE_ME_WITH_SED",
+    "type": "stdio",
+    "allowed_extensions": [ "tridactyl.vim@cmcaine.co.uk" ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7616,6 +7616,11 @@
       "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "dev": true
     },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+    },
     "semver-diff": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "0.1.0",
   "description": "Vimperator/Pentadactyl successor",
   "dependencies": {
+    "@types/nearley": "^2.11.0",
     "fuse.js": "^3.2.0",
     "mark.js": "^8.11.1",
-    "@types/nearley": "^2.11.0",
-    "nearley": "^2.11.0"
+    "nearley": "^2.11.0",
+    "semver-compare": "^1.0.0"
   },
   "devDependencies": {
     "@types/jest": "^21.1.4",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,6 +13,7 @@ scripts/newtab.md.sh
 scripts/make_tutorial.sh
 scripts/make_docs.sh &
 nearleyc src/grammars/bracketexpr.ne > src/grammars/.bracketexpr.generated.ts
+native/install.sh local
 
 (webpack --display errors-only && scripts/git_version.sh)&
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -238,7 +238,10 @@ const DEFAULTS = o({
 
     // Native messenger settings
     // This has to be a command that stays in the foreground for the whole editing session
-    editorcmd: "gvim -f",
+    // "auto" will attempt to find a sane editor in your path.
+    // Please send your requests to have your favourite terminal moved further up the list to /dev/null.
+    //          (but we are probably happy to add your terminal to the list if it isn't already there).
+    editorcmd: "auto",
     browser: "firefox",
     nativeinstallcmd:
         "curl -fsSl https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/install.sh | bash",

--- a/src/config.ts
+++ b/src/config.ts
@@ -160,6 +160,7 @@ const DEFAULTS = o({
         tutorial: "tutor",
         h: "help",
         openwith: "hint -W",
+        "!": "exclaim",
     }),
     followpagepatterns: o({
         next: "^(next|newer)\\b|»|>>|more",

--- a/src/config.ts
+++ b/src/config.ts
@@ -232,8 +232,10 @@ const DEFAULTS = o({
         state: 2,
         excmd: 1,
     }),
-
     noiframeon: [],
+
+    // This has to be a command that stays in the foreground for the whole editing session
+    editorcmd: "gvim -f",
 })
 
 /** Given an object and a target, extract the target if it exists, else return undefined

--- a/src/config.ts
+++ b/src/config.ts
@@ -240,6 +240,8 @@ const DEFAULTS = o({
     // This has to be a command that stays in the foreground for the whole editing session
     editorcmd: "gvim -f",
     browser: "firefox",
+    nativeinstallcmd:
+        "curl -fsSl https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/install.sh | bash",
 })
 
 /** Given an object and a target, extract the target if it exists, else return undefined

--- a/src/config.ts
+++ b/src/config.ts
@@ -235,8 +235,10 @@ const DEFAULTS = o({
     }),
     noiframeon: [],
 
+    // Native messenger settings
     // This has to be a command that stays in the foreground for the whole editing session
     editorcmd: "gvim -f",
+    browser: "firefox",
 })
 
 /** Given an object and a target, extract the target if it exists, else return undefined

--- a/src/config.ts
+++ b/src/config.ts
@@ -117,6 +117,7 @@ const DEFAULTS = o({
         ";A": "hint -A",
         ";;": "hint -;",
         ";#": "hint -#",
+        ";v": "hint -W exclaim mpv",
         I: "mode ignore",
         a: "current_url bmark",
         A: "bmark",

--- a/src/content.ts
+++ b/src/content.ts
@@ -28,6 +28,7 @@ import state from "./state"
 import * as webext from "./lib/webext"
 import Mark from "mark.js"
 import * as keyseq from "./keyseq"
+import * as native from "./native_background"
 ;(window as any).tri = Object.assign(Object.create(null), {
     browserBg: webext.browserBg,
     commandline_content,
@@ -47,6 +48,7 @@ import * as keyseq from "./keyseq"
     state,
     webext,
     l: prom => prom.then(console.log).catch(console.error),
+    native,
 })
 
 // Don't hijack on the newtab page.

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -222,7 +222,7 @@ export async function native() {
  */
 //#background
 export async function installnative() {
-    const installstr = "curl -fsSl https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/install.sh | bash"
+    const installstr = await config.get("nativeinstallcmd")
     await clipboard("yank", installstr)
     fillcmdline("# Installation command copied to clipboard. Please paste and run it in your shell to install the native messenger.")
 }
@@ -230,7 +230,8 @@ export async function installnative() {
 //#background
 export async function updatenative() {
     if (await nativegate()) {
-        Native.run("curl -fsSl https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/install.sh | bash")
+        await Native.run(await config.get("nativeinstallcmd"))
+        native()
     }
 }
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -174,6 +174,11 @@ export async function editor() {
 }
 
 //#background
+export async function exclaim(...str: string[]) {
+    fillcmdline((await Native.run(str.join(" "))).content)
+}
+
+//#background
 export async function native() {
     const version = await Native.getNativeMessengerVersion()
     if (version !== undefined) fillcmdline("# Native messenger is correctly installed, version " + version)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -117,11 +117,24 @@ import * as keydown from "./keydown_background"
 import { activeTab, firefoxVersionAtLeast, openInNewTab } from "./lib/webext"
 import * as CommandLineBackground from "./commandline_background"
 
+//#background_helper
+import * as Native from "./native_background"
+
 /** @hidden */
 export const cmd_params = new Map<string, Map<string, string>>()
 // }
 
 // }}}
+
+//#background
+export async function getNativeVersion(): Promise<void> {
+    Native.getNativeMessengerVersion()
+}
+
+//#background
+export async function getFilesystemRc(): Promise<string> {
+    return Native.getFilesystemUserConfig()
+}
 
 /** @hidden */
 function hasScheme(uri: string) {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -167,8 +167,8 @@ export async function getinput() {
 //#background
 export async function editor() {
     if (!await nativegate()) return
-    const file = "/tmp/tridactyledit" + Math.floor(Math.random() * 1000)
-    fillinput((await Native.editor(file, await getinput())).content)
+    const file = (await Native.temp(await getinput())).content
+    fillinput((await Native.editor(file)).content)
     // TODO: add annoying "This message was written with [Tridactyl](https://addons.mozilla.org/en-US/firefox/addon/tridactyl-vim/)"
     // to everything written using editor
 }

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -176,7 +176,7 @@ export async function editor() {
 //#background
 export async function exclaim(...str: string[]) {
     fillcmdline((await Native.run(str.join(" "))).content)
-}
+} // should consider how to give option to fillcmdline or not. We need flags.
 
 //#background
 export async function native() {
@@ -1922,7 +1922,7 @@ import * as hinting from "./hinting_background"
           - `bind ;c hint -c [class*="expand"],[class="togg"]` works particularly well on reddit and HN
         - -w open in new window
             -wp open in new private window
-        - `-W excmd...` append hint href to excmd and execute, e.g, `hint -W open` and other such bad ideas.
+        - `-W excmd...` append hint href to excmd and execute, e.g, `hint -W exclaim mpv` to open YouTube videos
 
     Excepting the custom selector mode and background hint mode, each of these
     hint modes is available by default as `;<option character>`, so e.g. `;y`

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -229,7 +229,7 @@ export async function installnative() {
 
 //#background
 export async function updatenative(interactive = true) {
-    if (await nativegate()) {
+    if (await nativegate("0", interactive)) {
         await Native.run(await config.get("nativeinstallcmd"))
         if (interactive) native()
     }
@@ -2176,6 +2176,7 @@ export async function errorfg(msg: string) {
 //#background_helper
 browser.runtime.onInstalled.addListener(details => {
     if (details.reason == "install") tutor("newtab")
+    else if (details.reason == "update") updatenative(false)
     // could add elif "update" and show a changelog. Hide it behind a setting to make it less annoying?
 })
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -196,7 +196,7 @@ export async function nativegate(version = "0"): Promise<Boolean> {
     const actualVersion = await Native.getNativeMessengerVersion()
     if (actualVersion !== undefined) {
         if (semverCompare(version, actualVersion) > 0) {
-            fillcmdline("# Native messenger is installed, version " + actualVersion + " but the command you just tried to use needs version " + version)
+            fillcmdline("# Please update to native messenger " + version + ", for example by running `:updatenative`.")
             // TODO: add update procedure and document here.
             return false
         }
@@ -224,7 +224,14 @@ export async function native() {
 export async function installnative() {
     const installstr = "curl -fsSl https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/install.sh | bash"
     await clipboard("yank", installstr)
-    fillcmdline("# Installation command copied to clipboard. Please paste and run it in your shell to install the native messenger")
+    fillcmdline("# Installation command copied to clipboard. Please paste and run it in your shell to install the native messenger.")
+}
+
+//#background
+export async function updatenative() {
+    if (await nativegate()) {
+        Native.run("curl -fsSl https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/install.sh | bash")
+    }
 }
 
 // }}}

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -126,21 +126,12 @@ export const cmd_params = new Map<string, Map<string, string>>()
 
 // }}}
 
-// Native messenger stuff
+// {{{ Native messenger stuff
 
 /** @hidden **/
 //#background
 export async function getNativeVersion(): Promise<void> {
     Native.getNativeMessengerVersion()
-}
-
-/**
- * Get RC from filesystem. Currently unused.
- * @hidden
- */
-//#background
-export async function getFilesystemRc(): Promise<string> {
-    return Native.getFilesystemUserConfig()
 }
 
 /**
@@ -164,13 +155,16 @@ export async function getinput() {
 
 /**
  * Opens your favourite editor (which is currently gVim) and fills the last used input with whatever you write into that file.
- * **Requires that the native messenger is installed, see [[native]]**.
+ * **Requires that the native messenger is installed, see [[native]] and [[installnative]]**.
+ *
+ * Uses the `editorcmd` config option, default = `gvim -f`. `urxvt -e nvim` works well for nvim users.
+ *
+ * The editorcmd needs to accept a filename, stay in the foreground while it's edited, save the file and exit.
  *
  * You're probably better off using the default insert mode bind of <C-e> to access this.
  */
 //#background
 export async function editor() {
-    // need to figure out how to get that into background
     const version = await Native.getNativeMessengerVersion()
     if (version === undefined) native()
     const file = "/tmp/tridactyledit" + Math.floor(Math.random() * 1000)
@@ -187,14 +181,17 @@ export async function native() {
 }
 
 /**
- * Simply copies "curl -fsSl https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/install.sh | sh" to the clipboard and tells the user to run it.
+ * Simply copies "curl -fsSl https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/install.sh | bash" to the clipboard and tells the user to run it.
  */
 //#background
 export async function installnative() {
-    const installstr = "curl -fsSl https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/install.sh | sh"
+    const installstr = "curl -fsSl https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/install.sh | bash"
     await clipboard("yank", installstr)
     fillcmdline("# Installation command copied to clipboard. Please paste and run it in your shell to install the native messenger")
 }
+
+// }}}
+
 /** @hidden */
 function hasScheme(uri: string) {
     return uri.match(/^([\w-]+):/)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -193,6 +193,10 @@ export async function nativeopen(url: string, ...firefoxArgs: string[]) {
  */
 //#background
 export async function nativegate(version = "0", interactive = true): Promise<Boolean> {
+    if (["win", "android"].includes((await browser.runtime.getPlatformInfo()).os)) {
+        if (interactive == true) fillcmdline("# Tridactyl's native messenger doesn't support your operating system, yet.")
+        return false
+    }
     const actualVersion = await Native.getNativeMessengerVersion()
     if (actualVersion !== undefined) {
         if (semverCompare(version, actualVersion) > 0) {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -192,16 +192,16 @@ export async function nativeopen(url: string, ...firefoxArgs: string[]) {
  * Used internally to gate off functions that use the native messenger. Gives a helpful error message in the command line if the native messenger is not installed, or is the wrong version.
  */
 //#background
-export async function nativegate(version = "0"): Promise<Boolean> {
+export async function nativegate(version = "0", interactive = true): Promise<Boolean> {
     const actualVersion = await Native.getNativeMessengerVersion()
     if (actualVersion !== undefined) {
         if (semverCompare(version, actualVersion) > 0) {
-            fillcmdline("# Please update to native messenger " + version + ", for example by running `:updatenative`.")
+            if (interactive == true) fillcmdline("# Please update to native messenger " + version + ", for example by running `:updatenative`.")
             // TODO: add update procedure and document here.
             return false
         }
         return true
-    } else fillcmdline("# Native messenger not found. Please run `:installnative` and follow the instructions.")
+    } else if (interactive == true) fillcmdline("# Native messenger not found. Please run `:installnative` and follow the instructions.")
     return false
 }
 
@@ -228,10 +228,10 @@ export async function installnative() {
 }
 
 //#background
-export async function updatenative() {
+export async function updatenative(interactive = true) {
     if (await nativegate()) {
         await Native.run(await config.get("nativeinstallcmd"))
-        native()
+        if (interactive) native()
     }
 }
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -126,16 +126,75 @@ export const cmd_params = new Map<string, Map<string, string>>()
 
 // }}}
 
+// Native messenger stuff
+
+/** @hidden **/
 //#background
 export async function getNativeVersion(): Promise<void> {
     Native.getNativeMessengerVersion()
 }
 
+/**
+ * Get RC from filesystem. Currently unused.
+ * @hidden
+ */
 //#background
 export async function getFilesystemRc(): Promise<string> {
     return Native.getFilesystemUserConfig()
 }
 
+/**
+ * Fills the last used input box with content. You probably don't want this; it's used internally for [[editor]].
+ *
+ * That said, `bind gs fillinput [Tridactyl](https://addons.mozilla.org/en-US/firefox/addon/tridactyl-vim/) is my favourite add-on` could probably come in handy.
+ */
+//#content
+export async function fillinput(...content: string[]) {
+    let inputToFill = DOM.getLastUsedInput() as HTMLInputElement
+    inputToFill.value = content.join(" ")
+}
+
+/** @hidden */
+//#content
+export async function getinput() {
+    // this should probably be subsumed by the focusinput code
+    let input = DOM.getLastUsedInput() as HTMLInputElement
+    return input.value
+}
+
+/**
+ * Opens your favourite editor (which is currently gVim) and fills the last used input with whatever you write into that file.
+ * **Requires that the native messenger is installed, see [[native]]**.
+ *
+ * You're probably better off using the default insert mode bind of <C-e> to access this.
+ */
+//#background
+export async function editor() {
+    // need to figure out how to get that into background
+    const version = await Native.getNativeMessengerVersion()
+    if (version === undefined) native()
+    const file = "/tmp/tridactyledit" + Math.floor(Math.random() * 1000)
+    fillinput((await Native.editor(file, await getinput())).content)
+    // TODO: add annoying "This message was written with [Tridactyl](https://addons.mozilla.org/en-US/firefox/addon/tridactyl-vim/)"
+    // to everything written using editor
+}
+
+//#background
+export async function native() {
+    const version = await Native.getNativeMessengerVersion()
+    if (version !== undefined) fillcmdline("# Native messenger is correctly installed, version " + version)
+    else fillcmdline("# Native messenger not found. Please run `:installnative` and follow the instructions.")
+}
+
+/**
+ * Simply copies "curl -fsSl https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/install.sh | sh" to the clipboard and tells the user to run it.
+ */
+//#background
+export async function installnative() {
+    const installstr = "curl -fsSl https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/install.sh | sh"
+    await clipboard("yank", installstr)
+    fillcmdline("# Installation command copied to clipboard. Please paste and run it in your shell to install the native messenger")
+}
 /** @hidden */
 function hasScheme(uri: string) {
     return uri.match(/^([\w-]+):/)

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -51,6 +51,7 @@
         "storage",
         "tabs",
         "topSites",
+        "nativeMessaging",
         "webNavigation",
         "webRequest",
         "webRequestBlocking",

--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -6,7 +6,7 @@ const GET_CFG_CMD = "getconfig"
 const GET_VER_CMD = "version"
 
 const NATIVE_NAME = "tridactyl"
-type MessageCommand = "getconfig" | "version"
+type MessageCommand = "getconfig" | "version" | "run" | "read" | "write"
 interface MessageResp {
     cmd: string
     version: number | null
@@ -54,4 +54,28 @@ export async function getNativeMessengerVersion(): Promise<number> {
         return res.version
     }
     throw `Error retrieving version: ${res.error}`
+}
+
+export async function editor(file: string, content?: string) {
+    // -f makes gvim stay in foreground so that we know when it is exited
+    // does this mean that the native messenger can't be used for anything
+    // till it returns?
+    // should probably think about this harder.
+    if (content !== undefined) await write(file, content)
+    await run("gvim -f " + file)
+    return await read(file)
+}
+
+export async function read(file: string) {
+    return sendNativeMsg("read", { file })
+}
+
+export async function write(file: string, content: string) {
+    return sendNativeMsg("write", { file, content })
+}
+
+export async function run(command: string) {
+    const res = await sendNativeMsg("run", { command })
+    console.log("command finished")
+    return res
 }

--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -46,9 +46,86 @@ export async function getNativeMessengerVersion(): Promise<number> {
     throw `Error retrieving version: ${res.error}`
 }
 
+export async function getBestEditor(): Promise<string> {
+    // Tempted to put this behind another config setting: prefergui
+    const gui_candidates = [
+        "gvim -f",
+        // "emacs",
+        // "gedit",
+        // "kate",
+        // "abiword",
+        // "shutdown computer now",
+        // "sublime"
+        // "cd ~; rm -rf *"
+        // "atom -w",
+    ]
+
+    // we generally try to give the terminal the class "tridactyl_editor" so that
+    // it can be made floating, e.g in i3:
+    // for_window [class="tridactyl_editor"] floating enable border pixel 1
+    const term_emulators = [
+        "st -c tridactyl_editor",
+        "xterm -class tridactyl_editor -e",
+        "uxterm -class tridactyl_editor -e",
+        "urxvt -e",
+        // "terminator -e", // NB: requires command to be in quotes, which breaks the others
+        // so terminator is not supported.
+        "alacritty -e", // alacritty is nice but takes ages to start and doesn't support class
+        "dbus-launch gnome-terminal --",
+        "cool-retro-term -e",
+        // I wanted to put hyper.js here as a joke but you can't start it running a command,
+        // which is a far better joke: a terminal emulator that you can't send commands to.
+        // You win this time, web artisans.
+    ]
+
+    const tui_editors = ["vim", "nvim", "nano", "emacs -nw"]
+
+    let ind = 0
+    let cmd = gui_candidates[ind]
+    let tuicmd = ""
+
+    // Consider GUI editors
+    while (!await inpath(cmd.split(" ")[0])) {
+        ind++
+        cmd = gui_candidates[ind]
+        if (cmd === undefined) {
+            ind = 0
+            cmd = term_emulators[ind]
+            // Try to find a terminal emulator
+            while (!await inpath(cmd.split(" ")[0])) {
+                ind++
+                cmd = term_emulators[ind]
+                if (cmd === undefined) break
+            }
+            if (cmd === undefined) break
+            ind[0]
+            tuicmd = tui_editors[ind]
+            // Try to find a text editor
+            while (!await inpath(tuicmd.split(" ")[0])) {
+                ind++
+                tuicmd = tui_editors[ind]
+                if (tuicmd === undefined) break
+            }
+            cmd = cmd + " " + tuicmd
+            break
+        }
+    }
+    return cmd
+}
+
+export async function inpath(cmd) {
+    return !(await run("which " + cmd.split(" ")[0])).content.includes(
+        "which: no ",
+    )
+}
+
 export async function editor(file: string, content?: string) {
     if (content !== undefined) await write(file, content)
-    await run(config.get("editorcmd") + " " + file)
+    const editorcmd =
+        config.get("editorcmd") == "auto"
+            ? await getBestEditor()
+            : config.get("editorcmd")
+    await run(editorcmd + " " + file)
     return await read(file)
 }
 
@@ -64,5 +141,6 @@ export async function temp(content: string) {
     return sendNativeMsg("temp", { content })
 }
 export async function run(command: string) {
-    return sendNativeMsg("run", { command })
+    let msg = await sendNativeMsg("run", { command })
+    return msg
 }

--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -1,0 +1,57 @@
+/**
+ * Background functions for the native messenger interface
+ */
+
+const GET_CFG_CMD = "getconfig"
+const GET_VER_CMD = "version"
+
+const NATIVE_NAME = "tridactyl"
+type MessageCommand = "getconfig" | "version"
+interface MessageResp {
+    cmd: string
+    version: number | null
+    content: string | null
+    error: string | null
+}
+
+/**
+ * Posts using the one-time message API; native is killed after message returns
+ */
+async function sendNativeMsg(
+    cmd: MessageCommand,
+    opts: object,
+): Promise<MessageResp> {
+    const send = Object.assign({ cmd }, opts)
+    let resp
+    console.log(`Sending message: ${JSON.stringify(send)}`)
+
+    try {
+        resp = await browser.runtime.sendNativeMessage(NATIVE_NAME, send)
+        console.log(`Received response:`, resp)
+        return resp as MessageResp
+    } catch (e) {
+        console.error(`Error sending native message:`, e)
+        throw e
+    }
+}
+
+export async function getFilesystemUserConfig(): Promise<string> {
+    const res = await sendNativeMsg("getconfig", {})
+
+    if (res.content && !res.error) {
+        console.info(`Successfully retrieved fs config:\n${res.content}`)
+        return res.content
+    } else {
+        console.error(`Error in retrieving config: ${res.error}`)
+        throw Error(`Error retrieving config: ${res.error}`)
+    }
+}
+
+export async function getNativeMessengerVersion(): Promise<number> {
+    const res = await sendNativeMsg("version", {})
+    if (res.version && !res.error) {
+        console.info(`Native version: ${res.version}`)
+        return res.version
+    }
+    throw `Error retrieving version: ${res.error}`
+}

--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -47,6 +47,8 @@ export async function getNativeMessengerVersion(): Promise<number> {
 }
 
 export async function getBestEditor(): Promise<string> {
+    if ((await browser.runtime.getPlatformInfo()).os === "mac")
+        return "open -nWt"
     // Tempted to put this behind another config setting: prefergui
     const gui_candidates = [
         "gvim -f",

--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -8,7 +8,7 @@ import Logger from "./logging"
 const logger = new Logger("native")
 
 const NATIVE_NAME = "tridactyl"
-type MessageCommand = "version" | "run" | "read" | "write"
+type MessageCommand = "version" | "run" | "read" | "write" | "temp"
 interface MessageResp {
     cmd: string
     version: number | null
@@ -60,6 +60,9 @@ export async function write(file: string, content: string) {
     return sendNativeMsg("write", { file, content })
 }
 
+export async function temp(content: string) {
+    return sendNativeMsg("temp", { content })
+}
 export async function run(command: string) {
     return sendNativeMsg("run", { command })
 }

--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -48,7 +48,7 @@ export async function getNativeMessengerVersion(): Promise<number> {
 
 export async function editor(file: string, content?: string) {
     if (content !== undefined) await write(file, content)
-    await run(config.get("editorcmd") + file)
+    await run(config.get("editorcmd") + " " + file)
     return await read(file)
 }
 

--- a/src/parsers/inputmode.ts
+++ b/src/parsers/inputmode.ts
@@ -14,6 +14,7 @@ export function parser(keys: MsgSafeKeyboardEvent[]) {
     } else if (key === "Tab") {
         if (keys[0].shiftKey) return { keys: [], exstr: "focusinput -N" }
         else return { keys: [], exstr: "focusinput -n" }
-    }
+    } else if (key === "e" && keys[0].ctrlKey)
+        return { keys: [], exstr: "editor" }
     return { keys: [], exstr: "" }
 }

--- a/src/parsers/insertmode.ts
+++ b/src/parsers/insertmode.ts
@@ -3,10 +3,12 @@ import { hasModifiers } from "../keyseq"
 // Placeholder - should be moved into generic parser
 export function parser(keys) {
     const response = { keys: [], exstr: undefined }
-    if (!hasModifiers(keys[0])) {
-        if (keys[0].key === "Escape") {
+    const key = keys[0]
+    if (!hasModifiers(key)) {
+        if (key.key === "Escape") {
             return { keys: [], exstr: "unfocus" }
         }
-    }
+    } else if (key.key === "e" && key.ctrlKey)
+        return { keys: [], exstr: "editor" }
     return { keys: [], exstr: undefined }
 }


### PR DESCRIPTION
Features:

- C-e to open text area in gvim/whatever
- Install script for native messenger

Todo:

- [x] Better tmp file location for multiuser systems
- [ ] Unique input element -> filename mapping (e.g. url + https://github.com/ericclemmons/unique-selector)
- [x] Credit John and Isaac in the commit log
- [x] Sensible defaults for VISUAL (gvim -f, TERM -e neovim, TERM -e vim, nano, atom, ed, emacs)
- [x] Tridactyl config value for editor cmdline
- [x] Merge input mode with insert mode
- [x] Fix buildbot errors
- [x] Updator method for nativemessenger
- [ ] Check through Isaac's changes to John's code (https://github.com/cmcaine/tridactyl/pull/314/commits/3e5e6147167d4fbd650e4e1b45d3abd951aed323)

Later:

- Make python async (commands are blocking atm)
- Expose run as `!`