### PR TITLE
Fix #423 disable indicator text selection

### DIFF
--- a/src/static/content.css
+++ b/src/static/content.css
@@ -25,4 +25,8 @@
     bottom: 2px !important;
     z-index: 2147483646 !important; /* this is one less than the command line so that it is hidden by it */
     line-height: initial !important; /* cleanslate doesn't seem to set this correctly */
+    -webkit-user-select: none !important;
+    -moz-user-select: none !important;
+    -ms-user-select: none !important;
+    user-select: none !important;
 }


### PR DESCRIPTION
An alternative, more general solution would be to add all of the `user-select` properties to their own class and add that to the indicator span programatically in [content.ts](https://github.com/cmcaine/tridactyl/blob/e9f6afeb9c06d3f1f902088eaabd486aecd2db4a/src/content.ts#L76). Open to suggestions and happy to implement as you see fit. Thank you.