### PR TITLE
completions.ts: Make sure selected completion options are visible

### DIFF
--- a/src/completions.ts
+++ b/src/completions.ts
@@ -76,6 +76,7 @@ abstract class CompletionOptionHTML extends CompletionOption {
         switch (newstate) {
             case "focused":
                 this.html.classList.add("focused")
+                this.html.scrollIntoView()
                 this.html.classList.remove("hidden")
                 break
             case "normal":
@@ -296,8 +297,7 @@ abstract class CompletionSourceFuse extends CompletionSource {
             // visopts.length + 1 because we want an empty completion at the end
             let max = visopts.length + 1
             let opt = visopts[(currind + inc + max) % max]
-            if (opt)
-                this.select(opt)
+            if (opt) this.select(opt)
             return true
         } else return false
     }


### PR DESCRIPTION
This makes sure the selected completion option is always visible. This could be considered a fix to (adding a few words to prevent github from automatically closing the issue) https://github.com/cmcaine/tridactyl/issues/27 , although a [user mentions wanting a specific "scrolloff" setting](https://github.com/cmcaine/tridactyl/issues/27#issuecomment-357533100), which would require a bit more thinking and might not be worth implementing since everything will eventually be rewritten.