### PR TITLE
excmds.ts: Fix scrollto(0/100,y) not working on some websites

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -391,7 +391,7 @@ export function scrollpx(a: number, b: number) {
 //#content
 export function scrollto(a: number, b: number | "x" | "y" = "y") {
     a = Number(a)
-    let elem = window.document.scrollingElement
+    let elem = window.document.scrollingElement || window.document.body
     let percentage = a.clamp(0, 100)
     if (b === "y") {
         let top = elem.getClientRects()[0].top


### PR DESCRIPTION
According to https://drafts.csswg.org/cssom-view/#dom-document-scrollingelement
scrollingElement can be null. This happened on http://www.angelfire.com/super/badwebs/ . This caused `elem` to be null and resulted in an error when pressing G/gg.