### PR TITLE
[RFC] Allow `composite` to pipe return values and add `js` eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Tridactyl changelog
 
-## Release 1.12.1 / Unreleased
+## Release 1.13.0 / Unreleased
 
 - `editor` now includes the hostname of the site you are on in the temporary filename
     - this is mostly so that you can set up syntax highlighting in Vim, e.g,
     - `au BufReadPost *github.com* set syntax=pandoc`
+
+- **Potentially breaking change**: pipes in `composite` now send return values to the following ex command. Use semi-colons if you want the old behaviour back (see `bind D`).
 
 ## Release 1.12.0 / 2018-05-13
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6353,7 +6353,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -177,6 +177,7 @@ const DEFAULTS = o({
         colorscheme: "set theme",
         colors: "set theme",
         "!js": "js",
+        current_url: "composite get_current_url | fillcmdline_notrail ",
     }),
     followpagepatterns: o({
         next: "^(next|newer)\\b|»|>>|more",

--- a/src/config.ts
+++ b/src/config.ts
@@ -176,6 +176,7 @@ const DEFAULTS = o({
         "!s": "exclaim_quiet",
         colorscheme: "set theme",
         colors: "set theme",
+        "!js": "js",
     }),
     followpagepatterns: o({
         next: "^(next|newer)\\b|»|>>|more",

--- a/src/config.ts
+++ b/src/config.ts
@@ -76,7 +76,7 @@ const DEFAULTS = o({
         "<c-o>": "back",
         "<c-i>": "forward",
         d: "tabclose",
-        D: "composite tabprev | sleep 100 | tabclose #",
+        D: "composite tabprev; sleep 100; tabclose #",
         gx0: "tabclosealltoleft",
         gx$: "tabclosealltoright",
         u: "undo",

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -97,14 +97,14 @@ export function acceptKey(keyevent: MsgSafeKeyboardEvent) {
 }
 
 /** Parse and execute ExCmds */
-export async function acceptExCmd(exstr: string) {
+export async function acceptExCmd(exstr: string): Promise<any> {
     // TODO: Errors should go to CommandLine.
     try {
         let [func, args] = exmode_parser(exstr)
         // Stop the repeat excmd from recursing.
         if (func !== repeat) state.last_ex_str = exstr
         try {
-            await func(...args)
+            return await func(...args)
         } catch (e) {
             // Errors from func are caught here (e.g. no next tab)
             logger.error(e)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1597,13 +1597,22 @@ export function repeat(n = 1, ...exstr: string[]) {
  * `composite echo yes | fillcmdline` becomes `fillcmdline yes`. A more complicated example is the ex alias, `command current_url composite get_current_url | fillcmdline_notrail `, which is used in, e.g. `bind T current_url tabopen`.
  *
  * Workaround: this should clearly be in the parser, but we haven't come up with a good way to deal with |s in URLs, search terms, etc. yet.
+ *
+ * `cmds` are also split with semicolons (;) and don't pass things along to each other.
+ *
+ * The behaviour of combining ; and | in the same composite command is left as an exercise for the reader.
  */
 //#background
 export async function composite(...cmds: string[]) {
     cmds = cmds.join(" ").split("|")
     let val = ""
     for (let c of cmds) {
-        val = await controller.acceptExCmd(c + val)
+        let dmds = c.split(";")
+        if (dmds.length > 1) {
+            for (let d of dmds) {
+                await controller.acceptExCmd(d)
+            }
+        } else val = await controller.acceptExCmd(dmds[0] + val)
         try {
             if (val == undefined || val.includes("undefined")) val = ""
             else val = " " + val

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1591,15 +1591,19 @@ export function repeat(n = 1, ...exstr: string[]) {
     for (let i = 0; i < n; i++) controller.acceptExCmd(cmd)
 }
 
-/** Split `cmds` on pipes (|) and treat each as its own command.
-
-    Workaround: this should clearly be in the parser, but we haven't come up with a good way to deal with |s in URLs, search terms, etc. yet.
-*/
+/**
+ * Split `cmds` on pipes (|) and treat each as its own command. Return values are cast to strings and passed to the next ex command.
+ *
+ * Workaround: this should clearly be in the parser, but we haven't come up with a good way to deal with |s in URLs, search terms, etc. yet.
+ */
 //#background
 export async function composite(...cmds: string[]) {
     cmds = cmds.join(" ").split("|")
+    let val = ""
     for (let c of cmds) {
-        await controller.acceptExCmd(c)
+        val = await controller.acceptExCmd(c + val)
+        if (val == undefined || val.includes("undefined")) val = ""
+        else val = " " + val
     }
 }
 
@@ -2329,6 +2333,24 @@ export async function bmark(url?: string, ...titlearr: string[]) {
     }
 
     browser.bookmarks.create({ url, title })
+}
+
+//#background
+export async function echo(...str: string[]) {
+    return str.join(" ")
+}
+
+/**
+ * Lets you execute JavaScript in the page context. If you want to get the result back, use `composite js ... | fillcmdline`
+ *
+ * About as dangerous as opening the web console.
+ *
+ * Currently, Tridactyl functions are not accessible from `js`.
+ *
+ */
+//#content
+export async function js(...str: string[]) {
+    return eval(str.join(" "))
 }
 
 /**  Open a welcome page on first install.

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -31,7 +31,7 @@
 
     A "splat" operator (...) means that the excmd will accept any number of space-delimited arguments into that parameter.
 
-    You do not need to worry about types.
+    You do not need to worry about types. Return values which are promises will turn into whatever they promise to when used in [[composite]].
 
     At the bottom of each function's help page, you can click on a link that will take you straight to that function's definition in our code. This is especially recommended for browsing the [config](/static/docs/modules/_config_.html#defaults) which is nigh-on unreadable on these pages.
 
@@ -1592,7 +1592,9 @@ export function repeat(n = 1, ...exstr: string[]) {
 }
 
 /**
- * Split `cmds` on pipes (|) and treat each as its own command. Return values are cast to strings and passed to the next ex command.
+ * Split `cmds` on pipes (|) and treat each as its own command. Return values are cast to strings and passed to the appended to the arguments of the next ex command, e.g,
+ *
+ * `composite echo yes | fillcmdline` becomes `fillcmdline yes`. A more complicated example is the ex alias, `command current_url composite get_current_url | fillcmdline_notrail `, which is used in, e.g. `bind T current_url tabopen`.
  *
  * Workaround: this should clearly be in the parser, but we haven't come up with a good way to deal with |s in URLs, search terms, etc. yet.
  */
@@ -1635,13 +1637,12 @@ export function fillcmdline_notrail(...strarr: string[]) {
     messageActiveTab("commandline_frame", "fillcmdline", [str, trailspace])
 }
 
-/** Equivalent to `fillcmdline_notrail <yourargs><current URL>`
-
-    See also [[fillcmdline_notrail]]
-*/
+/**
+ * Returns the current URL. For use with [[composite]].
+ */
 //#background
-export async function current_url(...strarr: string[]) {
-    fillcmdline_notrail(...strarr, (await activeTab()).url)
+export async function get_current_url() {
+    return (await activeTab()).url
 }
 
 /** Use the system clipboard.

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1604,8 +1604,14 @@ export async function composite(...cmds: string[]) {
     let val = ""
     for (let c of cmds) {
         val = await controller.acceptExCmd(c + val)
-        if (val == undefined || val.includes("undefined")) val = ""
-        else val = " " + val
+        try {
+            if (val == undefined || val.includes("undefined")) val = ""
+            else val = " " + val
+        } catch (e) {
+            if (e instanceof TypeError) {
+                val = " " + val
+            } else throw e
+        }
     }
 }
 
@@ -2344,9 +2350,9 @@ export async function echo(...str: string[]) {
 /**
  * Lets you execute JavaScript in the page context. If you want to get the result back, use `composite js ... | fillcmdline`
  *
- * About as dangerous as opening the web console.
+ * Some of Tridactyl's functions are accessible here via the `tri` object. Just do `console.log(tri)` in the web console on the new tab page to see what's available.
  *
- * Currently, Tridactyl functions are not accessible from `js`.
+ * Aliased to `!js`
  *
  */
 //#content

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -289,7 +289,7 @@ export async function exclaim(...str: string[]) {
  */
 //#background
 export async function exclaim_quiet(...str: string[]) {
-    ;(await Native.run(str.join(" "))).content
+    return (await Native.run(str.join(" "))).content
 }
 
 /**

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -34,6 +34,7 @@
             "match_about_blank": true
         }
     ],
+    "content_security_policy": "script-src 'unsafe-eval' 'self'; object-src 'self'",
     "web_accessible_resources": [
         "static/commandline.html",
         "static/defaultFavicon"

--- a/src/static/newtab.md
+++ b/src/static/newtab.md
@@ -12,6 +12,7 @@ Tridactyl has to override your new tab page due to WebExtension limitations. You
 
 - If you're enjoying Tridactyl (or not), please leave a review on [addons.mozilla.org][amo].
 
+- **Breaking change to `composite`:** composite now tries to pass the return value from each preceding function to its ancestor. This might break some of your binds to composite, or cause them to act in unexpected ways.
 - **NB:** Tridactyl can now run external programs on Linux and OSX if you decide to install an additional executable. Just run `:installnative` to get going, and then Ctrl-i `<C-i>` in a text box to open your editor.
 
 

--- a/src/static/typedoc/assets/css/main.css
+++ b/src/static/typedoc/assets/css/main.css
@@ -869,7 +869,7 @@ img { max-width: 100%; }
   margin-top: 0px;
 }
 
-/* Hide return values as they are unused */
+/* Unhide return values as they can be used in composite now*/
 .tsd-returns-title {
     display: none;
 }

--- a/src/static/typedoc/assets/css/main.css
+++ b/src/static/typedoc/assets/css/main.css
@@ -871,7 +871,7 @@ img { max-width: 100%; }
 
 /* Unhide return values as they can be used in composite now*/
 .tsd-returns-title {
-    display: none;
+    /* display: none; */
 }
 
 body {


### PR DESCRIPTION
- Is `js` particularly dangerous? Does it just live in the document scope like I think it does?
- How can we allow Tridactyl commands to be called from js?
   - If we let that happen, are we 500% sure that websites can't just run arbitrary code in userspace via the native messenger?
- Does composite break much stuff? `D` still works.

Todo:
- [ ] give most ex commands sensible return values
- [ ] rewrite hinting to use pipes as far as possible
- [ ] Tangential: native messenger `source` (check for overlap with #314)