### PR TITLE
{amo,newtab}.md: Explain what nativemessenger is, mention it's optional

### DIFF
--- a/doc/amo.md
+++ b/doc/amo.md
@@ -41,6 +41,14 @@ permissions and why we need them.
    * This is Mozilla's way of saying that Tridactyl can read the content of web
      pages. This is necessary in order to e.g. find the links you can follow
      with the `:hint` command (bound to `f` by default).
+ - Exchange messages with programs other than Firefox
+   * This permission is required for Tridactyl to interact with your
+     operating system (opening your editor to edit text areas, sending links to
+     your video player, reading a configuration file from your disk...). This
+     is possible thanks to an external executable we provide. If you feel this
+     gives Tridactyl too much power you can chose not to install the external
+     executable: Tridactyl will still work but won't be able to start external
+     programs.
  - Read and modify bookmarks:
    * Tridactyl's command line has a powerful autocompletion mechanism. In
      order to be able to autocomplete your bookmarks, Tridactyl needs to read

--- a/src/static/newtab.md
+++ b/src/static/newtab.md
@@ -14,7 +14,7 @@ Tridactyl has to override your new tab page due to WebExtension limitations. You
 
 - **Breaking change to default settings:** ignore mode is now bound to `<S-Insert>` for both entering and leaving the mode. Previous binds are unbound.
 
-- **NB:** Tridactyl now supports a native messenger on Linux and OSX. Just run `:installnative` to get going, and then Ctrl-i `<C-i>` in a text box to open your editor.
+- **NB:** Tridactyl can now run external programs on Linux and OSX if you decide to install an additional executable. Just run `:installnative` to get going, and then Ctrl-i `<C-i>` in a text box to open your editor.
 
 
 REPLACE_ME_WITH_THE_CHANGE_LOG_USING_SED
@@ -42,7 +42,7 @@ REPLACE_ME_WITH_THE_CHANGE_LOG_USING_SED
 
 ## Important limitations due to WebExtensions
 
-- You can only navigate to most about:*\file:* pages if you have the native messenger installed.
+- You can only navigate to most about:*\file:* pages if you have Tridactyl's native executable installed.
 - Firefox will not load Tridactyl on addons.mozilla.org, about:\*, some file:\* URIs, view-source:\*, or data:\*. On these pages Ctrl-L (or F6), Ctrl-Tab and Ctrl-W are your escape hatches.
 - Tridactyl does not currently support changing/hiding the Firefox GUI, but you can do it yourself by changing your userChrome. There is an example file available on our repository [[2]].
 - Tridactyl cannot capture key presses until web pages are loaded. You can use `:reloadall` to reload all tabs to make life more bearable, or flip `browser.sessionstore.restore_tabs_lazily` to false in `about:config`.


### PR DESCRIPTION
A user thought that the native messenger was a chat program and this made me realize that the "native messenger" terminology could be confusing to people unfamiliar with webextension development.