### PR TITLE
Newtab: Display nothing until we know the user wants tridactyl's newtab

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -67,7 +67,14 @@ if (
     window.location.protocol === "moz-extension:" &&
     window.location.pathname === "/static/newtab.html"
 ) {
-    config.getAsync("newtab").then(newtab => newtab && excmds.open(newtab))
+    config.getAsync("newtab").then(newtab => {
+        if (newtab) {
+            excmds.open(newtab)
+        } else {
+            document.documentElement.style.display = "block"
+            document.title = "Tridactyl Top Tips & New Tab Page"
+        }
+    })
 }
 
 // Really bad status indicator

--- a/src/static/newtab.template.html
+++ b/src/static/newtab.template.html
@@ -1,5 +1,6 @@
-<html lang="en">
+<html lang="en" style="display: none;">
     <head>
+        <script src="newtab.js"></script>
         <meta charset="utf-8">
         <link rel="stylesheet" href="newtab.css">
         <link rel="stylesheet" href="content.css">
@@ -8,7 +9,7 @@
         <link rel="stylesheet" href="viewsource.css">
         <link rel="shortcut icon" href="logo/Tridactyl_64px.png">
     </head>
-    <title>Tridactyl Top Tips & New Tab Page</title>
+    <title>&nbsp;</title>
     <body>
         REPLACETHIS
     </body>


### PR DESCRIPTION
In https://github.com/cmcaine/tridactyl/issues/384 , users complained about seeing Tridactyl's newtab page before their actual newtab page was loaded. Bovine3dom suggested that we look at how the New Tab Override extension manages to load the user's newtab page with less jank. It looks like they open a [new tab with the right url and close the newtab page itself](https://github.com/cadeyrn/newtaboverride/blob/87d9b5fe9b0946c7eff9015db128006deb7fe621/src/js/core/newtab.js#L79). This feels kinda hacky to me so I went with another solution: by default, the content of the newtab page is invisible. When it is loaded, if the user has set their `newtab` setting to something else, it is loaded, otherwise the content of the newtab page is made visible and the title is set.
I chose to move the config-reading code from content.js to its own file to make sure that Firefox doesn't waste precious milliseconds reading and parsing Tridactyl's content code if it isn't needed.