### PR TITLE
Turn functions into aliases

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -160,6 +160,8 @@ const DEFAULTS = o({
         tlast: "tablast",
         bd: "tabclose",
         bdelete: "tabclose",
+        quit: "tabclose",
+        q: "tabclose",
         sanitize: "sanitise",
         tutorial: "tutor",
         h: "help",

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1405,18 +1405,6 @@ export async function undo() {
     }
 }
 
-/** Synonym for [[tabclose]]. */
-//#background
-export async function quit() {
-    tabclose()
-}
-
-/** Convenience shortcut for [[quit]]. */
-//#background
-export async function q() {
-    tabclose()
-}
-
 /** Move the current tab to be just in front of the index specified.
 
     Known bug: This supports relative movement, but autocomple doesn't know


### PR DESCRIPTION
I believe these functions were created before the alias mechanism was implemented and are thus not needed anymore.