### PR TITLE
native_{main.py,background.ts}: Improve profile detection

### DIFF
--- a/native/native_main.py
+++ b/native/native_main.py
@@ -8,8 +8,7 @@ import struct
 import subprocess
 import tempfile
 
-VERSION = "0.1.1"
-
+VERSION = "0.1.2"
 
 class NoConnectionError(Exception):
     """ Exception thrown when stdin cannot be read """

--- a/native/native_main.py
+++ b/native/native_main.py
@@ -22,10 +22,9 @@ def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, flush=True, **kwargs)
 
 
-def _getenv(variable, default):
+def getenv(variable, default):
     """ Get an environment variable value, or use the default provided """
     return os.environ.get(variable) or default
-
 
 def getMessage():
     """Read a message from stdin and decode it.
@@ -115,6 +114,9 @@ def handleMessage(message):
         with open(filepath, "w") as file:
             file.write(message["content"])
         reply['content'] = filepath
+
+    elif cmd == 'env':
+        reply['content'] = getenv(message["var"], "")
 
     else:
         reply = {'cmd': 'error', 'error': 'Unhandled message'}

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -218,8 +218,13 @@ export async function guiset(rule: string, option: string) {
     // Check for native messenger and make sure we have a plausible profile directory
     if (!await Native.nativegate("0.1.1")) return
     let profile_dir = ""
-    if (config.get("profiledir") === "auto" && ["linux", "openbsd", "mac"].includes((await browser.runtime.getPlatformInfo()).os)) profile_dir = await Native.getProfileDir()
-    else profile_dir = config.get("profiledir")
+    if (config.get("profiledir") === "auto" && ["linux", "openbsd", "mac"].includes((await browser.runtime.getPlatformInfo()).os)) {
+        try {
+            profile_dir = await Native.getProfileDir()
+        } catch (e) {}
+    } else {
+        profile_dir = config.get("profiledir")
+    }
     if (profile_dir == "") {
         fillcmdline("Please set your profile directory (found on about:support) via `set profiledir [profile directory]`")
         return

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -218,13 +218,12 @@ export async function guiset(rule: string, option: string) {
     // Check for native messenger and make sure we have a plausible profile directory
     if (!await Native.nativegate("0.1.1")) return
     let profile_dir = ""
-    if (config.get("profiledir") === "auto") {
-        if (["linux", "openbsd", "mac"].includes((await browser.runtime.getPlatformInfo()).os)) profile_dir = await Native.getProfileDir()
-        else {
-            fillcmdline("Please set your profile directory (found on about:support) via `set profiledir [profile directory]`")
-            return
-        }
-    } else profile_dir = config.get("profiledir")
+    if (config.get("profiledir") === "auto" && ["linux", "openbsd", "mac"].includes((await browser.runtime.getPlatformInfo()).os)) profile_dir = await Native.getProfileDir()
+    else profile_dir = config.get("profiledir")
+    if (profile_dir == "") {
+        fillcmdline("Please set your profile directory (found on about:support) via `set profiledir [profile directory]`")
+        return
+    }
 
     // Make backups
     await Native.mkdir(profile_dir + "/chrome", true)

--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -269,8 +269,10 @@ export async function getProfileDir() {
 
     // -P <profile>: Start with <profile>
     // -P          : Start with profile manager
+    // Apparently, this argument is case-insensitive
     let profileName = "*"
     prof = args.indexOf("-P")
+    if (prof < 0) prof = args.indexOf("-p")
     // args.length -1 because we need to make sure -P was given a value
     if (prof >= 0 && prof < args.length - 1) profileName = args[prof + 1]
 

--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -8,7 +8,15 @@ import Logger from "./logging"
 const logger = new Logger("native")
 
 const NATIVE_NAME = "tridactyl"
-type MessageCommand = "version" | "run" | "read" | "write" | "temp" | "mkdir"
+type MessageCommand =
+    | "version"
+    | "run"
+    | "read"
+    | "write"
+    | "temp"
+    | "mkdir"
+    | "eval"
+    | "env"
 interface MessageResp {
     cmd: string
     version: number | null
@@ -167,10 +175,26 @@ export async function mkdir(dir: string, exist_ok: boolean) {
 export async function temp(content: string) {
     return sendNativeMsg("temp", { content })
 }
+
 export async function run(command: string) {
     let msg = await sendNativeMsg("run", { command })
     logger.info(msg)
     return msg
+}
+
+export async function getenv(variable: string) {
+    return (await sendNativeMsg("env", { var: variable })).content
+}
+
+export async function ffargs() {
+    // Using ' and + rather that ` because we don't want newlines
+    let output = await sendNativeMsg("eval", {
+        command:
+            "handleMessage(" +
+            '{"cmd": "run", "command": "ps -p " + str(os.getppid()) + " -o' +
+            'args="})["content"]',
+    })
+    return output.content.trim().split(" ")
 }
 
 export async function getProfileDir() {

--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -275,9 +275,12 @@ export async function getProfileDir() {
     if (prof >= 0 && prof < args.length - 1) profileName = args[prof + 1]
 
     // Find active profile directory automatically by seeing where the lock exists
-    // We can't use a relative path because ~/.local (the directory where the
-    // native messenger currently sits) might actually be a symlink to another dir
-    let home = await getenv("HOME")
+    let home = "../../.."
+    try {
+        // We try not to use a relative path because ~/.local (the directory where
+        // the native messenger currently sits) might actually be a symlink
+        home = await getenv("HOME")
+    } catch (e) {}
     let hacky_profile_finder = `find "${home}/.mozilla/firefox" -maxdepth 2 -path '*.${profileName}/lock'`
     if ((await browser.runtime.getPlatformInfo()).os === "mac")
         hacky_profile_finder =

--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -186,7 +186,9 @@ export async function getenv(variable: string) {
     return (await sendNativeMsg("env", { var: variable })).content
 }
 
-export async function ffargs() {
+/** This returns the commandline that was used to start firefox.
+ You'll get both firefox binary (not necessarily an absolute path) and flags */
+export async function ffargs(): Promise<string[]> {
     // Using ' and + rather that ` because we don't want newlines
     let output = await sendNativeMsg("eval", {
         command:


### PR DESCRIPTION
I encountered two issues with profile detection: the first one was that my `~/.local` is actually a symlink to `~/.dotfiles/default/.local`. This means that `../../../.mozilla` didn't exist and find failed to find my profile. I fixed it by looking for `$HOME/.mozilla` instead since Firefox doesn't obey XDG rules as far as I can tell.

The second issue was that when I work on Tridactyl, I usually have multiple Firefox instances open with different profiles. This means that `find` would find two different `.lock` files. I fixed this by looking for the current profile in the arguments given to Firefox and then trying to find a `.lock` file in this profile directory.

I tried to stay compatible with OSX as best as I could but I couldn't test whether this PR actually breaks anything.