### PR TITLE
{background,config}.ts: Turn rc-loading into an autocmd

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -80,18 +80,20 @@ browser.storage.onChanged.addListener((changes, areaname) => {
 // Prevent Tridactyl from being updated while it is running in the hope of fixing #290
 browser.runtime.onUpdateAvailable.addListener(_ => {})
 
-config.getAsync("autocmds", "TriStart").then(aucmds => {
-    let hosts = Object.keys(aucmds)
-    // If there's only one rule and it's "all", no need to check the hostname
-    if (hosts.length == 1 && hosts[0] == ".*") {
-        Controller.acceptExCmd(aucmds[hosts[0]])
-    } else {
-        native.run("hostname").then(hostname => {
-            for (let host of hosts) {
-                if (hostname.content.match(host)) {
-                    Controller.acceptExCmd(aucmds[host])
+browser.runtime.onStartup.addListener(_ => {
+    config.getAsync("autocmds", "TriStart").then(aucmds => {
+        let hosts = Object.keys(aucmds)
+        // If there's only one rule and it's "all", no need to check the hostname
+        if (hosts.length == 1 && hosts[0] == ".*") {
+            Controller.acceptExCmd(aucmds[hosts[0]])
+        } else {
+            native.run("hostname").then(hostname => {
+                for (let host of hosts) {
+                    if (hostname.content.match(host)) {
+                        Controller.acceptExCmd(aucmds[host])
+                    }
                 }
-            }
-        })
-    }
+            })
+        }
+    })
 })

--- a/src/background.ts
+++ b/src/background.ts
@@ -80,5 +80,18 @@ browser.storage.onChanged.addListener((changes, areaname) => {
 // Prevent Tridactyl from being updated while it is running in the hope of fixing #290
 browser.runtime.onUpdateAvailable.addListener(_ => {})
 
-// Try to load an RC file
-excmds.source_quiet()
+config.getAsync("autocmds", "TriStart").then(aucmds => {
+    let hosts = Object.keys(aucmds)
+    // If there's only one rule and it's "all", no need to check the hostname
+    if (hosts.length == 1 && hosts[0] == ".*") {
+        Controller.acceptExCmd(aucmds[hosts[0]])
+    } else {
+        native.run("hostname").then(hostname => {
+            for (let host of hosts) {
+                if (hostname.content.match(host)) {
+                    Controller.acceptExCmd(aucmds[host])
+                }
+            }
+        })
+    }
+})

--- a/src/config.ts
+++ b/src/config.ts
@@ -138,6 +138,9 @@ const DEFAULTS = o({
         DocStart: o({
             "addons.mozilla.org": "mode ignore",
         }),
+        TriStart: o({
+            ".*": "source_quiet",
+        }),
     }),
     exaliases: o({
         alias: "command",

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1876,9 +1876,15 @@ export function set(key: string, ...values: string[]) {
 
 /** Set autocmds to run when certain events happen.
 
- @param event Curently, only 'DocStart' is supported.
+ @param event Curently, only 'TriStart' and 'DocStart' are supported.
 
- @param url The URL on which the events will trigger (currently just uses "contains")
+ @param url For DocStart: the URL on which the events will trigger (currently
+ just uses "contains").
+
+ For TriStart: A regular expression that matches the hostname of the computer
+ the autocmd should be run on. This requires the native messenger to be
+ installed, except for the ".*" regular expression which will always be
+ triggered, even without the native messenger.
 
  @param excmd The excmd to run (use [[composite]] to run multiple commands)
 
@@ -1887,7 +1893,7 @@ export function set(key: string, ...values: string[]) {
 export function autocmd(event: string, url: string, ...excmd: string[]) {
     // rudimentary run time type checking
     // TODO: Decide on autocmd event names
-    if (!["DocStart"].includes(event)) throw event + " is not a supported event."
+    if (!["DocStart", "TriStart"].includes(event)) throw event + " is not a supported event."
     config.set("autocmds", event, url, excmd.join(" "))
 }
 


### PR DESCRIPTION
Use cases for this autocmd: opening a few tabs on browser start without having installed the native messenger.
Actually the autocmd could still be triggered if Tridactyl updates, but in practice this shouldn't happen much since Tridactyl doesn't silently auto-update while browsing anymore.