### PR TITLE
native_main.py: close file desciptor returned by mkstemp

### DIFF
--- a/native/native_main.py
+++ b/native/native_main.py
@@ -154,7 +154,7 @@ def handleMessage(message):
 
     elif cmd == 'temp':
         (handle, filepath) = tempfile.mkstemp()
-        with open(filepath, "w") as file:
+        with os.fdopen(handle, "w") as file:
             file.write(message["content"])
         reply['content'] = filepath
 


### PR DESCRIPTION
Python's tempfile.mkstemp method returns an open file descriptor, but
native_main.py was ignoring that and re-opening the file.  This commit
modifies the code to use os.fdopen so that the file descriptor is
closed when exiting the 'with ...' context manager.