### PR TITLE
provide hostname hint in editor temporary files

### DIFF
--- a/native/native_main.py
+++ b/native/native_main.py
@@ -154,7 +154,7 @@ def handleMessage(message):
 
     elif cmd == 'temp':
         (handle, filepath) = tempfile.mkstemp()
-        with open(filepath, "w") as file:
+        with os.fdopen(handle, "w") as file:
             file.write(message["content"])
         reply['content'] = filepath
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -167,8 +167,9 @@ export async function getinput() {
  */
 //#background
 export async function editor() {
+    let url = new URL((await activeTab()).url)
     if (!await Native.nativegate()) return
-    const file = (await Native.temp(await getinput())).content
+    const file = (await Native.temp(await getinput(), url.hostname)).content
     fillinput((await Native.editor(file)).content)
     // TODO: add annoying "This message was written with [Tridactyl](https://addons.mozilla.org/en-US/firefox/addon/tridactyl-vim/)"
     // to everything written using editor

--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -238,8 +238,8 @@ export async function mkdir(dir: string, exist_ok: boolean) {
     return sendNativeMsg("mkdir", { dir, exist_ok })
 }
 
-export async function temp(content: string) {
-    return sendNativeMsg("temp", { content })
+export async function temp(content: string, prefix: string) {
+    return sendNativeMsg("temp", { content, prefix })
 }
 
 export async function run(command: string) {


### PR DESCRIPTION
when calling an external editor, include the hostname of the remote site in
the generated temporary filename.

This is built on top of #519.