### PR TITLE
Implement functions to read and write to preference files

### DIFF
--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -322,3 +322,78 @@ export async function getProfileDir() {
         }
     }
 }
+
+/** When given the name of a firefox preference file, will load said file and
+ *  return a promise for an object the keys of which correspond to preference
+ *  names and the values of which correspond to preference values.
+ *  When the file couldn't be loaded or doesn't contain any preferences, will
+ *  return a promise for an empty object.
+ */
+export async function loadPrefs(filename): Promise<{ [key: string]: string }> {
+    const result = await read(filename)
+    if (result.code == 2) return {}
+    //  This RegExp currently only deals with " but for correctness it should
+    //  also deal with ' and `
+    //  We could also just give up on parsing and eval() the whole thing
+    const regex = new RegExp(
+        /^(user_|sticky_|lock)?[pP]ref\("([^"]+)",\s*"?([^\)]+?)"\);$/,
+    )
+    // Fragile parsing
+    let allPrefs = result.content.split("\n").reduce((prefs, line) => {
+        let matches = line.match(regex)
+        if (!matches) {
+            return prefs
+        }
+        const key = matches[2]
+        let value = matches[3]
+        // value = "" means that it should be an empty string
+        if (value == '"') value = ""
+        prefs[key] = value
+        return prefs
+    }, {})
+    return allPrefs
+}
+
+/** Returns a promise for an object that should contain every about:config
+ *  setting. If performance is slow, it might be a good idea to cache the
+ *  results of this function: the preference files do not change while firefox
+ *  is running.
+ */
+export async function getPrefs(): Promise<{ [key: string]: string }> {
+    const profile = (await getProfileDir()) + "/"
+    const prefFiles = [
+        // Debian has these
+        "/etc/firefox/firefox.js",
+        "/usr/share/firefox/browser/defaults/preferences/firefox.js",
+        "/usr/share/firefox/browser/defaults/preferences/debugger.js",
+        "/usr/share/firefox/browser/defaults/preferences/devtools-startup-prefs.js",
+        "/usr/share/firefox/browser/defaults/preferences/devtools.js",
+        "/usr/share/firefox/browser/defaults/preferences/firefox-branding.js",
+        "/usr/share/firefox/browser/defaults/preferences/vendor.js",
+        "/usr/share/firefox/browser/defaults/preferences/firefox.js",
+        // Pref files can be found here:
+        // https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/A_brief_guide_to_Mozilla_preferences
+        profile + "grepref.js",
+        profile + "services/common/services-common.js",
+        profile + "defaults/pref/services-sync.js",
+        profile + "browser/app/profile/channel-prefs.js",
+        profile + "browser/app/profile/firefox.js",
+        profile + "browser/app/profile/firefox-branding.js",
+        profile + "browser/defaults/preferences/firefox-l10n.js",
+        profile + "prefs.js",
+        profile + "user.js",
+    ]
+    let promises = []
+    let prers = {}
+    // Starting all promises before awaiting because we want the calls to be
+    // made in parallel
+    for (let file of prefFiles) {
+        promises.push(loadPrefs(file))
+    }
+    return promises.reduce(async (a, b) => Object.assign(await a, await b))
+}
+
+/** Returns the value for the corresponding about:config setting */
+export async function getPref(name: string): Promise<string> {
+    return (await getPrefs())[name]
+}


### PR DESCRIPTION
This implements reading about:config preferences. I still need to implement writing to user.js for https://github.com/cmcaine/tridactyl/issues/468 to be fixed (I believe we can't [write to prefs.js though](https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/A_brief_guide_to_Mozilla_preferences#Preferences_Saving)).
Another relevant issue is https://github.com/cmcaine/tridactyl/issues/527 , but I'm not sure how to tackle it.