### PR TITLE
Fix native_main for python < 3.5.0

### DIFF
--- a/native/native_main.py
+++ b/native/native_main.py
@@ -171,8 +171,9 @@ def handleMessage(message):
 
     elif cmd == 'temp':
         prefix = message.get('prefix')
-        if prefix is not None:
-            prefix = 'tmp_{}_'.format(sanitizeFilename(prefix))
+        if prefix is None:
+            prefix = ''
+        prefix = 'tmp_{}_'.format(sanitizeFilename(prefix))
 
         (handle, filepath) = tempfile.mkstemp(prefix=prefix)
         with os.fdopen(handle, "w") as file:

--- a/native/native_main.py
+++ b/native/native_main.py
@@ -10,7 +10,7 @@ import subprocess
 import tempfile
 import unicodedata
 
-VERSION = "0.1.4"
+VERSION = "0.1.5"
 
 
 class NoConnectionError(Exception):


### PR DESCRIPTION
We are passing None value to mkstemp which is only possible since python
3.5.0 [1]. Let's use our own mask with empty string as the prefix when
None is given. That works with both python API versions.

[1]
https://github.com/python/cpython/commit/ad577b938b367da53ee19d6d5021b19e50b92873