### PR TITLE
Handle (well, ignore) an extra colon before any excmd

### DIFF
--- a/src/aliases.ts
+++ b/src/aliases.ts
@@ -3,8 +3,9 @@ import * as config from "./config"
 /**
  * Expands the alias in the provided exstr recursively. Does nothing if
  * the command is not aliased, including when the command is invalid.
+ * Returns another string.
  *
- * @param exstr :exstr typed by the user on the commantd line
+ * @param exstr :exstr typed by the user on the command line
  */
 export function expandExstr(
     exstr: string,
@@ -12,11 +13,37 @@ export function expandExstr(
     prevExpansions: string[] = [],
 ): string {
     // Split on whitespace
-    const [command, ...args] = exstr.trim().split(/\s+/)
+    let [command, ...args] = exstr.trim().split(/ +/)
+
+    // Handle initial (extra) colon
+    if (command[0] === ":") {
+        command = command.substring(1)
+    }
+
+    return expandExarr([command, ...args]).join(" ")
+}
+
+/**
+ * Expands the alias in the provided exstr recursively. Does nothing if
+ * the command is not aliased, including when the command is invalid.
+ * Expects, and returns, an array of `command, ...args`.
+ *
+ * @param exstr :exstr typed by the user on the command line
+ */
+export function expandExarr(
+    exstr: string | string[],
+    aliases = config.get("exaliases"),
+    prevExpansions: string[] = [],
+): string[] {
+    const exarr: string[] =
+        typeof exstr === "string" ? exstr.trim().split(/ +/) : exstr
+
+    const command = exarr[0],
+        expansion = aliases[command]
 
     // Base case: alias not found; return original command
-    if (aliases[command] === undefined) {
-        return exstr
+    if (expansion === undefined) {
+        return exarr
     }
 
     // Infinite loop detected
@@ -27,10 +54,10 @@ export function expandExstr(
     // Add command to expansions used so far
     prevExpansions.push(command)
 
+    // Remove the current command being expanded, and replace it with
+    // the command expansion (possibly exploded into multiple words.)
+    exarr.splice(0, 1, ...expansion.trim().split(/ +/))
+
     // Alias exists; expand it recursively
-    return expandExstr(
-        exstr.replace(command, aliases[command]),
-        aliases,
-        prevExpansions,
-    )
+    return expandExarr(exarr, aliases, prevExpansions)
 }

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -279,7 +279,7 @@ function process() {
 
     hide_and_clear()
 
-    const [func, ...args] = command.trim().split(/\s+/)
+    const [func, ...args] = command.trim().split(/ +/)
 
     if (func.length === 0 || func.startsWith("#")) {
         return

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -631,7 +631,7 @@ export class BufferCompletionSource extends CompletionSourceFuse {
 
     /** Score with fuse unless query is a single # or looks like a buffer index */
     scoredOptions(query: string, options = this.options): ScoredOption[] {
-        const args = query.trim().split(/\s+/gu)
+        const args = query.trim().split(/ +/gu)
         if (args.length === 1) {
             // if query is an integer n and |n| < options.length
             if (Number.isInteger(Number(args[0]))) {

--- a/src/parsers/exmode.ts
+++ b/src/parsers/exmode.ts
@@ -47,14 +47,13 @@ function convertArgs(params, argv) {
 // TODO: Abbreviated commands
 export function parser(exstr: string): any[] {
     // Expand aliases
-    const expandedExstr = aliases.expandExstr(exstr)
-    const [func, ...args] = expandedExstr.trim().split(/\s+/)
+    const [command, ...args] = aliases.expandExarr(exstr)
 
-    if (ExCmds.cmd_params.has(func)) {
+    if (ExCmds.cmd_params.has(command)) {
         try {
             return [
-                ExCmds[func],
-                convertArgs(ExCmds.cmd_params.get(func), args),
+                ExCmds[command],
+                convertArgs(ExCmds.cmd_params.get(command), args),
             ]
         } catch (e) {
             logger.error("Error executing or parsing:", exstr, e)
@@ -62,6 +61,6 @@ export function parser(exstr: string): any[] {
         }
     } else {
         logger.error("Not an excmd:", exstr)
-        throw `Not an excmd: ${func}`
+        throw `Not an excmd: ${command}`
     }
 }


### PR DESCRIPTION
In Vim proper, initial `:` entered before a command-line are entirely ignored. This has a few benefits:

 - When new users see an example command on the web (“Use the command `:set searchengine duckduckgo` to …”), they may not understand that the initial colon is intended as an activation-key, instead as a part of the command that they are to paste into their command-line. With this change, the command will still work as-intended.

 - When I'm trying to construct a more complex command (at least in Vim-proper), I often open the command-line *while thinking*; then, occasionally, I forget that I'd done so, when I finally settle on an approach to the problem at hand, and thus reflexively begin my complicated ex-command with a colon, intended to open the command-line.

This patch, my first to y'all's project, is a simple one to address this. Initial colons are ignored in the ex-mode command-line.

I tried to fairly-thoroughly test this by hand, after building the extension. Let me know if you want me to exercise it in some automated fashion.

As this is my first, I'd love some feedback before you merge — similarly, my commits were small and granular; but this is a very small work, so I'm likely to push these squashed into a single commit once you give me the go-ahead! `<3`