### PR TITLE
pre-commit: Fix hook asking to prettify pretty files, warn on console.log

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -3,14 +3,23 @@
 jsfiles=$(git diff --cached --name-only --diff-filter=ACM "*.js" "*.jsx" "*.ts" "*.tsx" | tr '\n' ' ')
 [ -z "$jsfiles" ] && exit 0
 
-# Check if any of the files are ugly
+# Check if any of the files are ugly or contain a console.log call
 uglyFiles=()
+consoleFiles=""
 for jsfile in $jsfiles; do
     diff "$jsfile" <($(npm bin)/prettier "$jsfile") >/dev/null || uglyFiles+=("$jsfile")
+    if [ "$(git diff --cached "$jsfile" | grep '^+.*console.log' -c)" -gt '0' ] ; then
+        consoleFiles="$consoleFiles '$jsfile'"
+    fi
 done
 
-if [ -n $uglyFiles ]; then
+if [ -n "$uglyFiles" ]; then
     echo "Prettify your files first:"
     echo '$(npm bin)/prettier --write' "${uglyFiles[@]}"
     exit 1
+fi
+
+if [ -n "$consoleFiles" ]; then
+    echo "Warning: adding console.log calls in$consoleFiles"
+    echo 'Did you mean to use logger.debug?'
 fi


### PR DESCRIPTION
The commit hook was asking me to run prettify on an empty list of files. adding quotes around "$uglyFiles" in the `if [ -n` check fixed this for me.

I also added a warning when console.log calls are added to the source code because I keep on forgetting to remove them before committing my code.