### PR TITLE
Fix path to docs in :help command

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -759,7 +759,7 @@ export function home(all: "false" | "true" = "false") {
 */
 //#background
 export async function help(excmd?: string) {
-    const docpage = browser.extension.getURL("static/docs/modules/_excmds_.html")
+    const docpage = browser.extension.getURL("static/docs/modules/_src_excmds_.html")
     if (excmd === undefined) excmd = ""
     if ((await activeTab()).url.startsWith(docpage)) {
         open(docpage + "#" + excmd)


### PR DESCRIPTION
I just installed Tridactyl and noticed that, when I use the `:help` ex-command, I'm taken to a page with with this error message:

```
Firefox can’t find the file at moz-extension://<snip>/static/docs/modules/_excmds_.html#.
```

This PR fixes the issue by opening `_src_excmds_.html` instead. I've tested it manually and it seems to work!