### PR TITLE
Prettier compliance for documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,355 +2,374 @@
 
 ## Release 1.13.0 / Unreleased
 
-- `fixamo` added: you can now use Tridactyl on addons.mozilla.org. Requires a `restart`.
+*   `fixamo` added: you can now use Tridactyl on addons.mozilla.org. Requires a `restart`.
 
-- `editor` now includes the hostname of the site you are on in the temporary filename
-    - this is mostly so that you can set up syntax highlighting in Vim, e.g,
-    - `au BufReadPost *github.com* set syntax=pandoc`
+*   `editor` now includes the hostname of the site you are on in the temporary filename
 
-- `native` support for Windows: just do what `installnative` tells you to
-    - you'll probably want to make sure `gvim` is on your path
+    *   this is mostly so that you can set up syntax highlighting in Vim, e.g,
+    *   `au BufReadPost *github.com* set syntax=pandoc`
 
-- **Potentially breaking changes**
-    - pipes in `composite` now send return values to the following ex command. Use semi-colons if you want the old behaviour back (see `bind D`).
-    - the `DocStart` now uses `String.prototype.search` for matching, so you can use regular expressions such as `/www\.amazon\.co.*/`
+*   `native` support for Windows: just do what `installnative` tells you to
 
-- Add internal functions for editing `user.js` - we'll probably add a nice interface to this some day.
+    *   you'll probably want to make sure `gvim` is on your path
 
-- Add `restart` command to restart Firefox.
+*   **Potentially breaking changes**
 
-- Add new themes
-    - `shydactyl` and `greenmat`, covering both ends of the design spectrum.
+    *   pipes in `composite` now send return values to the following ex command. Use semi-colons if you want the old behaviour back (see `bind D`).
+    *   the `DocStart` now uses `String.prototype.search` for matching, so you can use regular expressions such as `/www\.amazon\.co.*/`
 
-- Make themes apply to {newtab, mode indicator, tutor}
+*   Add internal functions for editing `user.js` - we'll probably add a nice interface to this some day.
 
-- Add new internal structure for themes - check out contributing.md on the repository if you want to add your own
-    - Adding themes at runtime is planned but some way off.
+*   Add `restart` command to restart Firefox.
+
+*   Add new themes
+
+    *   `shydactyl` and `greenmat`, covering both ends of the design spectrum.
+
+*   Make themes apply to {newtab, mode indicator, tutor}
+
+*   Add new internal structure for themes - check out contributing.md on the repository if you want to add your own
+    *   Adding themes at runtime is planned but some way off.
 
 ## Release 1.12.0 / 2018-05-13
 
-- Add container support
-    - `hint` will now open links in the current container
-    - there is a new setting, `set tabopencontaineraware [false|true]`, which will make `tabopen` open new tabs in the current container
-- Add extra `<CA-Esc>` bind to toggle ignore mode by popular demand
-- Fix errors related to missing native messenger on Firefox launch
+*   Add container support
+    *   `hint` will now open links in the current container
+    *   there is a new setting, `set tabopencontaineraware [false|true]`, which will make `tabopen` open new tabs in the current container
+*   Add extra `<CA-Esc>` bind to toggle ignore mode by popular demand
+*   Fix errors related to missing native messenger on Firefox launch
 
 ## Release 1.11.2 / 2018-05-11
 
-- Hotfix to prevent "config undefined" errors on browser start if no rc file was found
-    - It was mysteriously only reproducible sometimes...
-- Make newtab changelog a bit wider
+*   Hotfix to prevent "config undefined" errors on browser start if no rc file was found
+    *   It was mysteriously only reproducible sometimes...
+*   Make newtab changelog a bit wider
 
 ## Release 1.11.1 / 2018-05-11
 
-- **Add "tridactylrc" support**
-    - Stick a bunch of commands you want to run at startup in one of:
-        - `$XDG_CONFIG_DIR/tridactyl/tridactylrc`
-        - `~/.config/tridactyl/tridactylrc`
-        - `~/.tridactylrc`
-    - [Example file available here](https://github.com/cmcaine/tridactyl/blob/master/.tridactylrc)
-    - You can run any file you want with `source [absolute path to file]`. Bonus points if you can think of something sensible to do with `source` in an `autocmd`.
-    - If you want vim-style configuration where nothing persists except that which is in the rc file, simply add `sanitise tridactyllocal tridactylsync` to the top of your rc file.
-    - Only whole-line comments are supported at the moment, in the VimL style where lines start with a quote mark: "
+*   **Add "tridactylrc" support**
 
-- Native messenger updated to 0.1.3
-    - Add rc file reader
-    - Add ability to read environment variables
-    - Make read understand ~ and environment variables (used in `source`)
+    *   Stick a bunch of commands you want to run at startup in one of:
+        *   `$XDG_CONFIG_DIR/tridactyl/tridactylrc`
+        *   `~/.config/tridactyl/tridactylrc`
+        *   `~/.tridactylrc`
+    *   [Example file available here](https://github.com/cmcaine/tridactyl/blob/master/.tridactylrc)
+    *   You can run any file you want with `source [absolute path to file]`. Bonus points if you can think of something sensible to do with `source` in an `autocmd`.
+    *   If you want vim-style configuration where nothing persists except that which is in the rc file, simply add `sanitise tridactyllocal tridactylsync` to the top of your rc file.
+    *   Only whole-line comments are supported at the moment, in the VimL style where lines start with a quote mark: "
 
-- Readme updated
-    - Add statistics page and `guiset`
+*   Native messenger updated to 0.1.3
 
-- Bug fixes
-    - `guiset` can now cope with multiple Firefox instances running simultaneously provided they are started with profiles explicitly via the command line.
+    *   Add rc file reader
+    *   Add ability to read environment variables
+    *   Make read understand ~ and environment variables (used in `source`)
 
-- Deprecations
-    - Remove buffers,tabs as promised
-    - Inform people pressing `I` of the new bind
+*   Readme updated
+
+    *   Add statistics page and `guiset`
+
+*   Bug fixes
+
+    *   `guiset` can now cope with multiple Firefox instances running simultaneously provided they are started with profiles explicitly via the command line.
+
+*   Deprecations
+    *   Remove buffers,tabs as promised
+    *   Inform people pressing `I` of the new bind
 
 ## Release 1.11.0 / 2018-05-09
 
-- You can now edit the Firefox GUI from Tridactyl with `guiset`. You must restart Firefox after using `guiset` to see the effects.
-    - e.g, `guiset gui none` or `guiset gui full`.
-    - see all the options with `help guiset` and following the links.
-    - **Only minimally tested. Back up your precious userChrome.css if you care about it!**
+*   You can now edit the Firefox GUI from Tridactyl with `guiset`. You must restart Firefox after using `guiset` to see the effects.
 
-- You can now choose to bypass [CSP](https://en.wikipedia.org/wiki/Content_Security_Policy) on all sites with `set csp clobber`. If you change your mind, just `unset csp`, and restart your browser.
-    - This, for example, allows Tridactyl to run on pages such as https://raw.githubusercontent.com/cmcaine/tridactyl/master/CHANGELOG.md, but it could also allow other scripts to run on pages, making the Internet as dangerous as it was about 2 or 3 years ago before CSP was introduced.
-    - Once this [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1267027) in Firefox is fixed, you won't have to clobber CSP.
+    *   e.g, `guiset gui none` or `guiset gui full`.
+    *   see all the options with `help guiset` and following the links.
+    *   **Only minimally tested. Back up your precious userChrome.css if you care about it!**
 
-- Tridactyl will no longer update while the browser is running in an attempt to fix issues where the add-on would be unresponsive after an update; instead, it will only update on browser launch.
-    - This includes manual updates via `about:addons`. You'll need to restart the browser after clicking "Check for updates".
+*   You can now choose to bypass [CSP](https://en.wikipedia.org/wiki/Content_Security_Policy) on all sites with `set csp clobber`. If you change your mind, just `unset csp`, and restart your browser.
 
-- `set newtab news.bbc.co.uk` etc. now looks much less janky
+    *   This, for example, allows Tridactyl to run on pages such as https://raw.githubusercontent.com/cmcaine/tridactyl/master/CHANGELOG.md, but it could also allow other scripts to run on pages, making the Internet as dangerous as it was about 2 or 3 years ago before CSP was introduced.
+    *   Once this [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1267027) in Firefox is fixed, you won't have to clobber CSP.
 
-- Minor new features
-    - Add !s alias for silent exclaim
-    - `termite` and `terminator` support with `set editorcmd auto`
-    - Allow binding <Esc> (not recommended...)
-    - AMO explains why we need each new permission
-    - Native messenger documentation improved, making it clear that we haven't reimplemented IRC in the browser.
+*   Tridactyl will no longer update while the browser is running in an attempt to fix issues where the add-on would be unresponsive after an update; instead, it will only update on browser launch.
 
-- Minor bug fixes
-    - Remove pixel gap under command bar (#442)
-    - Native installer no longer requires pip and supports Debian's `which`
-    - Help page links are more legible on rubbish screens
-    - Turn 'q' and 'qall' into aliases
-    - Fix typo regarding binding of special keys on help page
-    - `focusinput` is now better at finding elements to focus
+    *   This includes manual updates via `about:addons`. You'll need to restart the browser after clicking "Check for updates".
+
+*   `set newtab news.bbc.co.uk` etc. now looks much less janky
+
+*   Minor new features
+
+    *   Add !s alias for silent exclaim
+    *   `termite` and `terminator` support with `set editorcmd auto`
+    *   Allow binding <Esc> (not recommended...)
+    *   AMO explains why we need each new permission
+    *   Native messenger documentation improved, making it clear that we haven't reimplemented IRC in the browser.
+
+*   Minor bug fixes
+    *   Remove pixel gap under command bar (#442)
+    *   Native installer no longer requires pip and supports Debian's `which`
+    *   Help page links are more legible on rubbish screens
+    *   Turn 'q' and 'qall' into aliases
+    *   Fix typo regarding binding of special keys on help page
+    *   `focusinput` is now better at finding elements to focus
 
 ## Release 1.10.1 / 2018-05-04
 
-- Add tabcloseallto{right,left} bound to `gx0` and `gx$`
-- Update tab page and other documentation to reflect new ignore mode binding
-- Fix #474: you can open a handful of about:* pages without the native messenger again
-- Improve feedback when native messenger is not correctly installed   
+*   Add tabcloseallto{right,left} bound to `gx0` and `gx$`
+*   Update tab page and other documentation to reflect new ignore mode binding
+*   Fix #474: you can open a handful of about:\* pages without the native messenger again
+*   Improve feedback when native messenger is not correctly installed
 
 ## Release 1.10.0 / 2018-05-03
 
-- Native messenger (for OSX/Linux only, for now)! On Linux/OSXRun `:installnative` to install, then:
-    - `<Ctrl-I>` in a text field will open Vim, probably. Set it with `set editorcmd` but make sure that the command stays in the foreground till the programme is exited.
-    - Not all text fields work yet (esp CodeMirror), so make sure you test it before writing war and peace.
-    - `:! [shell command]` or `:exclaim [shell command]` will run the command and give you STDOUT/STDERR back in the command line.
-        - You can't use composite and shell pipes together yet.
-        - Anything that works in `/bin/sh` should work
-            - If you want to use a different shell, just make your own alias:
-                -  `command ! exclaim fish -c` (but be aware that some shells require quotes around arguments given to -c)
-    - Requires a new permission to use the native messenger (and to use Tridactyl at all, unfortunately)
-    - `nativeopen` will try to open a new tab or window using the native messenger. It is used in `{,win,tab}open` automatically when you try to open about:* or file:* URIs.
+*   Native messenger (for OSX/Linux only, for now)! On Linux/OSXRun `:installnative` to install, then:
 
-- Add `hint -W [exstr]` to execute exstr on hint's href
-    - `hint -W exclaim_quiet mpv` works particularly well.
+    *   `<Ctrl-I>` in a text field will open Vim, probably. Set it with `set editorcmd` but make sure that the command stays in the foreground till the programme is exited.
+    *   Not all text fields work yet (esp CodeMirror), so make sure you test it before writing war and peace.
+    *   `:! [shell command]` or `:exclaim [shell command]` will run the command and give you STDOUT/STDERR back in the command line.
+        *   You can't use composite and shell pipes together yet.
+        *   Anything that works in `/bin/sh` should work
+            *   If you want to use a different shell, just make your own alias:
+                *   `command ! exclaim fish -c` (but be aware that some shells require quotes around arguments given to -c)
+    *   Requires a new permission to use the native messenger (and to use Tridactyl at all, unfortunately)
+    *   `nativeopen` will try to open a new tab or window using the native messenger. It is used in `{,win,tab}open` automatically when you try to open about:_ or file:_ URIs.
 
-- **Breaking change**: change ignore mode binds to be symmetric and resolve Jupyter conflict
-    - Ignore mode is now bound to `<S-Insert>` to enter and leave it.
-    - Previous binds of `I` and `<S-Esc>` are unbound
+*   Add `hint -W [exstr]` to execute exstr on hint's href
 
-- More scrolling fixes
-    - `G`/`gg` will now work on more sites
+    *   `hint -W exclaim_quiet mpv` works particularly well.
 
-- Completion improvements
-    - History completion performance improved
-        - If you find you are getting worse results than usual, increase `set historyresults` to, e.g, 500.
-    - Fix #446: you can now edit completions you select with space
-    - Completions will now pan to show you what you have selected
+*   **Breaking change**: change ignore mode binds to be symmetric and resolve Jupyter conflict
 
-- Mode indicator is now print friendly (#453)!
+    *   Ignore mode is now bound to `<S-Insert>` to enter and leave it.
+    *   Previous binds of `I` and `<S-Esc>` are unbound
 
-- Fiddled with `help` theme
-    - We've tried to make it look a bit more like the old Vimperator help pages and have hidden some useless or misleading bits that TypeDoc produced, such as the return values.
+*   More scrolling fixes
 
-- `viewsource` improved
-    - Now bound to `gf` by default
-    - Fix viewsource elem not always covering the whole page
-    - Remove viewsource elem on spa history changes
+    *   `G`/`gg` will now work on more sites
 
-- Bind help to F1
+*   Completion improvements
 
-- Changelog changelog:
-    - Change changelog date format
-    - Changelog: use standard case: changelog.md -> CHANGELOG.md
-    - Changelog: move to the standard location
-    - Changelog: add dates
+    *   History completion performance improved
+        *   If you find you are getting worse results than usual, increase `set historyresults` to, e.g, 500.
+    *   Fix #446: you can now edit completions you select with space
+    *   Completions will now pan to show you what you have selected
 
-- Misc fixes
-    - Fix :open <empty string>. Fixes #421
-    - Filter AltGraph keys. Fixes #430
-    - Explain that the hint tags are typed in lowercase even though they are displayed in uppercase
+*   Mode indicator is now print friendly (#453)!
 
+*   Fiddled with `help` theme
+
+    *   We've tried to make it look a bit more like the old Vimperator help pages and have hidden some useless or misleading bits that TypeDoc produced, such as the return values.
+
+*   `viewsource` improved
+
+    *   Now bound to `gf` by default
+    *   Fix viewsource elem not always covering the whole page
+    *   Remove viewsource elem on spa history changes
+
+*   Bind help to F1
+
+*   Changelog changelog:
+
+    *   Change changelog date format
+    *   Changelog: use standard case: changelog.md -> CHANGELOG.md
+    *   Changelog: move to the standard location
+    *   Changelog: add dates
+
+*   Misc fixes
+    *   Fix :open <empty string>. Fixes #421
+    *   Filter AltGraph keys. Fixes #430
+    *   Explain that the hint tags are typed in lowercase even though they are displayed in uppercase
 
 ## Release 1.9.8 / 2018-04-26
 
-- Make error reporting to command line less fussy
-- Fix error reporting loop with `noiframeon`
+*   Make error reporting to command line less fussy
+*   Fix error reporting loop with `noiframeon`
 
 ## Release 1.9.7 / 2018-04-25
 
-- Load iframe more lazily to stop breakage on some sites
-- Add setting `noiframeon` for websites that are still broken by our iframe ("ServiceNow", for example: #279)
-    - Simply `set noiframeon [space separated URLs]` to blacklist URLs
-- This will hopefully be our final release before the native messenger for OSX and Linux is merged.
-    - If you'd like to help test it out, download our latest betas from [here](https://tridactyl.cmcaine.co.uk/betas) and run `:installnative` once you are in.
+*   Load iframe more lazily to stop breakage on some sites
+*   Add setting `noiframeon` for websites that are still broken by our iframe ("ServiceNow", for example: #279)
+    *   Simply `set noiframeon [space separated URLs]` to blacklist URLs
+*   This will hopefully be our final release before the native messenger for OSX and Linux is merged.
+    *   If you'd like to help test it out, download our latest betas from [here](https://tridactyl.cmcaine.co.uk/betas) and run `:installnative` once you are in.
 
 ## Release 1.9.6 / 2018-04-25
 
-- Scrolling improvements
-    - Faster (#395)
-    - `G`/`gg` work on more pages (#382)
-- Mode indicator improvements
-    - Can be disabled with `set modeindicator false`
-    - Text is not selectable to improve the lives of people who "Select All" a lot
-- Internal error messages are now displayed in the command line
-- New default alias `:h` for `:help`
-- Bug fixes
-    - Fix #418: keyseq is better at realising when a key combination is invalid
+*   Scrolling improvements
+    *   Faster (#395)
+    *   `G`/`gg` work on more pages (#382)
+*   Mode indicator improvements
+    *   Can be disabled with `set modeindicator false`
+    *   Text is not selectable to improve the lives of people who "Select All" a lot
+*   Internal error messages are now displayed in the command line
+*   New default alias `:h` for `:help`
+*   Bug fixes
+    *   Fix #418: keyseq is better at realising when a key combination is invalid
 
 ## Release 1.9.5 / 2018-04-22
 
-- Add mode indicator
-- Fix #337: Make `composite` and ex-parser more sequential
-    - Add `D` binding: close current tab and `tabprev`
-- Bug fixes
-    - Fix `tab` in inputmode
-    - Catch CSP exception when hijacking
+*   Add mode indicator
+*   Fix #337: Make `composite` and ex-parser more sequential
+    *   Add `D` binding: close current tab and `tabprev`
+*   Bug fixes
+    *   Fix `tab` in inputmode
+    *   Catch CSP exception when hijacking
 
 ## Release 1.9.4 / 2018-04-20
 
-- Add jumplist for inputs bound to `g;`
-    - Editor's impartial note: this is pretty cool
-- Add `hint -W [exstr]` to execute exstr on hint's href
-- Update new tab page:
-    - Add changelog
-    - Remove welcome to new users as we have `tutor` for that now
-    - Fix newtab redirection on `set newtab [url]`
-        - `set newtab about:blank` now works thanks to a Mozilla bug fix!
-    - Warn users about native messenger update
-- Bug fixes
-    - input-mode now correctly exits to normal mode on focus loss
-    - Stop treating "std::map" or "Error: foo" as URIs: searching for them will now work.
+*   Add jumplist for inputs bound to `g;`
+    *   Editor's impartial note: this is pretty cool
+*   Add `hint -W [exstr]` to execute exstr on hint's href
+*   Update new tab page:
+    *   Add changelog
+    *   Remove welcome to new users as we have `tutor` for that now
+    *   Fix newtab redirection on `set newtab [url]`
+        *   `set newtab about:blank` now works thanks to a Mozilla bug fix!
+    *   Warn users about native messenger update
+*   Bug fixes
+    *   input-mode now correctly exits to normal mode on focus loss
+    *   Stop treating "std::map" or "Error: foo" as URIs: searching for them will now work.
 
 ## Release 1.9.3 / 2018-04-19
 
-- Fix unbind issues
-- Add more default binds from Vimperator
-- Change the `^` bind to `<c-6>` (matches vim)
-- :bmark now supports folders
+*   Fix unbind issues
+*   Add more default binds from Vimperator
+*   Change the `^` bind to `<c-6>` (matches vim)
+*   :bmark now supports folders
 
 ## Release 1.9.2 / 2018-04-16
 
-- Fix #392 (bug with keyseq)
+*   Fix #392 (bug with keyseq)
 
 ## Release 1.9.1 / 2018-04-15
 
-- Fix buffer switch bind
+*   Fix buffer switch bind
 
 ## Release 1.9.0 / 2018-04-15
 
-- Allow binds with modifiers (e.g. `<C-u>`) and binds of special keys (e.g. `<F1>`) and both together (e.g. `<SA-Escape>`)
-- Normal mode now only hides keypresses that you've told it to listen to from the web page
-- Improve documentation
-    - Update readme
-    - Improve help on excmds.ts
-    - Update AMO text (includes explanation of why various permissions are demanded)
-    - Add tutorial on `tutor`
-        - Shown on first install of Tridactyl
-    - Add `viewconfig` command to open the current configuration in Firefox's native JSON viewer (which Tridactyl doesn't work in)
-- [Move betas to our own site](https://tridactyl.cmcaine.co.uk/betas) as addons.mozilla.org stopped supporting them (#307)
-    - Add automatic updates for betas
-        - If you downloaded a beta before pre778, you will need to update manually to a later beta.
-- Small new features
-    - Fix #370: add `clipboard yanktitle|yankmd`
-    - Add `fullscreen` command (not quite #376)
-    - Add `viewsource` command
-    - `set allowautofocus false` to stop pages stealing focus on load (#266, #369)
-    - `^` now switches to last used tab by default
-    - In command mode, `Space` now puts the URL from the selected completion into the command line (#224)
-    - Add find mode, left unbound by default
-        - Not ready for widespread usage: slow and probably buggy.
-    - `hint -wp` to open hint in a private window (#317)
-    - Configuration can now upgrade itself to allow us to rename settings
-    - Add dark theme: `set theme dark` (#230)
-    - Tab opening settings for `tabopen` (#342)
-        - `set {related,tab}openpos next|last`
-- Stuff only collaborators will care about
-    - Code is now run through the prettier formatter before each commit
-- Moderately large bug fixes
-    - Fix scrolling on sites that use frames (#372, #63, #107, #273, #218)
-    - Fix hinting on sites with frames (#67)
-    - Hijack event listeners to put hints on more JavaScript links (#204, #163, #215)
-- Small bug fixes
-    - Fix #276: ]] on Hacker News
-    - Support #/% index for tabs everywhere internally
-        - Fix #341: `tabclose #` now works
-    - Reduce logging
-    - Rename some config:
-        - Rename vimium-gi to gimode, default to firefox, version to configversion
-    - Fix hinting following JavaScript links because they look the same
-- Introduce new bugs
-    - Show useless hints on some sites (#225)
-    - and more!
+*   Allow binds with modifiers (e.g. `<C-u>`) and binds of special keys (e.g. `<F1>`) and both together (e.g. `<SA-Escape>`)
+*   Normal mode now only hides keypresses that you've told it to listen to from the web page
+*   Improve documentation
+    *   Update readme
+    *   Improve help on excmds.ts
+    *   Update AMO text (includes explanation of why various permissions are demanded)
+    *   Add tutorial on `tutor`
+        *   Shown on first install of Tridactyl
+    *   Add `viewconfig` command to open the current configuration in Firefox's native JSON viewer (which Tridactyl doesn't work in)
+*   [Move betas to our own site](https://tridactyl.cmcaine.co.uk/betas) as addons.mozilla.org stopped supporting them (#307)
+    *   Add automatic updates for betas
+        *   If you downloaded a beta before pre778, you will need to update manually to a later beta.
+*   Small new features
+    *   Fix #370: add `clipboard yanktitle|yankmd`
+    *   Add `fullscreen` command (not quite #376)
+    *   Add `viewsource` command
+    *   `set allowautofocus false` to stop pages stealing focus on load (#266, #369)
+    *   `^` now switches to last used tab by default
+    *   In command mode, `Space` now puts the URL from the selected completion into the command line (#224)
+    *   Add find mode, left unbound by default
+        *   Not ready for widespread usage: slow and probably buggy.
+    *   `hint -wp` to open hint in a private window (#317)
+    *   Configuration can now upgrade itself to allow us to rename settings
+    *   Add dark theme: `set theme dark` (#230)
+    *   Tab opening settings for `tabopen` (#342)
+        *   `set {related,tab}openpos next|last`
+*   Stuff only collaborators will care about
+    *   Code is now run through the prettier formatter before each commit
+*   Moderately large bug fixes
+    *   Fix scrolling on sites that use frames (#372, #63, #107, #273, #218)
+    *   Fix hinting on sites with frames (#67)
+    *   Hijack event listeners to put hints on more JavaScript links (#204, #163, #215)
+*   Small bug fixes
+    *   Fix #276: ]] on Hacker News
+    *   Support #/% index for tabs everywhere internally
+        *   Fix #341: `tabclose #` now works
+    *   Reduce logging
+    *   Rename some config:
+        *   Rename vimium-gi to gimode, default to firefox, version to configversion
+    *   Fix hinting following JavaScript links because they look the same
+*   Introduce new bugs
+    *   Show useless hints on some sites (#225)
+    *   and more!
 
 ## Release 1.8.2 / 2018-03-07
 
-- Improve config API
-    - `set key.subkey.subsubkey value` now works
-    - Add user feedback to `bind` and `get`
-- Add save link/img hint submode (;s, ;S, ;a, ;A) (#148)
-- Add `autocmd [event] [filter] [ex command]`
-    - Currently, only supports the event `DocStart`
-    - Most useful for entering ignore mode on certain websites: `autocmd DocStart mail.google.com mode ignore`
-- Add exmode aliases with `command [alias] [ex_command]`. Many aliases have been ported from Pentadactyl. (#236)
-- Add urlmodify command (#286, #298)
-- Support Emacs-style C-(a|e|k|u) in cmdline (#277)
-- Support changing followpage pattern used in `]]` and `[[` to allow use with foreign languages
-- Add logging levels and make logging less verbose by default (#206)
-- Support %s magic string for search providers (#253)
-- Add hintfiltermode config and new "vimperator, vimperator-reflow" hinting modes
-    - Make hintPage follow link if there's only 1 option
-- Fix high resource usage when typing under some circumstances (#311)
-- `set newtab foo.bar` now changes all new tab pages (#235)
-- Fix hints on some sites via cleanslate.css (#220)
-- Fix new config system (#321)
-- followpage now falls back to urlincrement
-- `tabopen` now opens tabs to the right of the current tab
-- Fix floating commandline iframe on some sites (#289)
-- Enter insert mode on drop down menus (#281)
-- Support hinting on some dodgy old websites (#287)
-- Make :reloadall only refresh current window tabs (#288)
-- Remove `xx` binding (#262)
-- Fix gu in directories (#256)
-- Fix various typos (#247, #228)
-- Add FAQ and other updates to readme.md (#232)
+*   Improve config API
+    *   `set key.subkey.subsubkey value` now works
+    *   Add user feedback to `bind` and `get`
+*   Add save link/img hint submode (;s, ;S, ;a, ;A) (#148)
+*   Add `autocmd [event] [filter] [ex command]`
+    *   Currently, only supports the event `DocStart`
+    *   Most useful for entering ignore mode on certain websites: `autocmd DocStart mail.google.com mode ignore`
+*   Add exmode aliases with `command [alias] [ex_command]`. Many aliases have been ported from Pentadactyl. (#236)
+*   Add urlmodify command (#286, #298)
+*   Support Emacs-style C-(a|e|k|u) in cmdline (#277)
+*   Support changing followpage pattern used in `]]` and `[[` to allow use with foreign languages
+*   Add logging levels and make logging less verbose by default (#206)
+*   Support %s magic string for search providers (#253)
+*   Add hintfiltermode config and new "vimperator, vimperator-reflow" hinting modes
+    *   Make hintPage follow link if there's only 1 option
+*   Fix high resource usage when typing under some circumstances (#311)
+*   `set newtab foo.bar` now changes all new tab pages (#235)
+*   Fix hints on some sites via cleanslate.css (#220)
+*   Fix new config system (#321)
+*   followpage now falls back to urlincrement
+*   `tabopen` now opens tabs to the right of the current tab
+*   Fix floating commandline iframe on some sites (#289)
+*   Enter insert mode on drop down menus (#281)
+*   Support hinting on some dodgy old websites (#287)
+*   Make :reloadall only refresh current window tabs (#288)
+*   Remove `xx` binding (#262)
+*   Fix gu in directories (#256)
+*   Fix various typos (#247, #228)
+*   Add FAQ and other updates to readme.md (#232)
 
 ## Release 1.7.3 / 2017-12-21
 
-- Hint tags are much better:
-    - Hint tags are now as short as possible
-    - Remove now disused `hintorder` setting
-- Add `.` to repeat last action
-- Add inputmode: `gi` and then `Tab` will cycle you between all input fields on a page
-- Add hint kill submode `;k` for removing elements of a webpage such as dickbars
-- Add relative zoom and `z{i,z,o}` binds
-- Add `sanitize` excmd for deleting browsing/Tridactyl data
-- Search engines:
-    - Add `searchsetkeyword [keyword] [url]`: define your own search engines (#194)
-    - Add Qwant and update startpage URL (#198)
-    - Add Google Scholar search engine
-- Fix problems where ignore mode would revert to normal mode on some websites with iframes (#176)
-- Add ^ and $ in normal mode for navigation to 0% or 100% in x-direction
-- Buffer completion fixes
-    - Use tab ID even if buffer has a trailing space (#223)
-    - completions: passthrough # in buffercompletion
-- Support multiple URLs for quickmarks
-- Blacklist default newtab url from history completions
-- Fix `set newtab` failing to set newtab
-- Add `q`, `qa`, and `quit` synonyms
-- Fix `unset` failing to take effect without reloading page
-- Minor improvements to `help` preface
-- Add <summary> tags to standard hinting
-- Log an error to browser console if no TTS voices are found
+*   Hint tags are much better:
+    *   Hint tags are now as short as possible
+    *   Remove now disused `hintorder` setting
+*   Add `.` to repeat last action
+*   Add inputmode: `gi` and then `Tab` will cycle you between all input fields on a page
+*   Add hint kill submode `;k` for removing elements of a webpage such as dickbars
+*   Add relative zoom and `z{i,z,o}` binds
+*   Add `sanitize` excmd for deleting browsing/Tridactyl data
+*   Search engines:
+    *   Add `searchsetkeyword [keyword] [url]`: define your own search engines (#194)
+    *   Add Qwant and update startpage URL (#198)
+    *   Add Google Scholar search engine
+*   Fix problems where ignore mode would revert to normal mode on some websites with iframes (#176)
+*   Add ^ and $ in normal mode for navigation to 0% or 100% in x-direction
+*   Buffer completion fixes
+    *   Use tab ID even if buffer has a trailing space (#223)
+    *   completions: passthrough # in buffercompletion
+*   Support multiple URLs for quickmarks
+*   Blacklist default newtab url from history completions
+*   Fix `set newtab` failing to set newtab
+*   Add `q`, `qa`, and `quit` synonyms
+*   Fix `unset` failing to take effect without reloading page
+*   Minor improvements to `help` preface
+*   Add <summary> tags to standard hinting
+*   Log an error to browser console if no TTS voices are found
 
 ## Release 1.7.0 / 2017-12-01
 
- - History completion is massively improved: much faster, more relevant results, and less janky as you type.
- - User configuration
-     - set [setting] without a value will inform you of the current value
-     - Add configuration options for hinting: `hintchars` and `hintorder`
-     - Add unset for resetting a bind to default
-     - You can now change default search engine with e.g, `set searchengine bing` (#60)
-     - The default new tab page can be replaced with any URL via `set newtab [url]` (#59)
-     - Add `gh` and `gH` and "homepages" setting (#96)
- - Shift-tab and tab now will cycle around completions correctly
- - `ys` now works on some older pages
- - Add bmarks command for searching through bookmarks (#167)
- - Add `hint -c [selector]`: add hints that match CSS selector
- - Add text-to-speech hint mode on `;r`
- - Allow `;p` to yank any element which contains text
- - Add `;#` hint yank anchor mode
- - Improve hint CSS by adding a border and making background semi-transparent
- - Add `tabonly` command
- - Fix hinting mysteriously not working on some pages (#168)
- - Fix issue where command line would invisibly cover up part of the screen (#170)
- - Bookmarks can now have spaces in their titles
- - Fix some hints on sites such as pcgamer.co.uk
- - Long page titles will no longer appear after URLs in completions
+*   History completion is massively improved: much faster, more relevant results, and less janky as you type.
+*   User configuration
+    *   set [setting] without a value will inform you of the current value
+    *   Add configuration options for hinting: `hintchars` and `hintorder`
+    *   Add unset for resetting a bind to default
+    *   You can now change default search engine with e.g, `set searchengine bing` (#60)
+    *   The default new tab page can be replaced with any URL via `set newtab [url]` (#59)
+    *   Add `gh` and `gH` and "homepages" setting (#96)
+*   Shift-tab and tab now will cycle around completions correctly
+*   `ys` now works on some older pages
+*   Add bmarks command for searching through bookmarks (#167)
+*   Add `hint -c [selector]`: add hints that match CSS selector
+*   Add text-to-speech hint mode on `;r`
+*   Allow `;p` to yank any element which contains text
+*   Add `;#` hint yank anchor mode
+*   Improve hint CSS by adding a border and making background semi-transparent
+*   Add `tabonly` command
+*   Fix hinting mysteriously not working on some pages (#168)
+*   Fix issue where command line would invisibly cover up part of the screen (#170)
+*   Bookmarks can now have spaces in their titles
+*   Fix some hints on sites such as pcgamer.co.uk
+*   Long page titles will no longer appear after URLs in completions

--- a/contributing.md
+++ b/contributing.md
@@ -6,42 +6,39 @@ Tridactyl is very lucky to have a wide base of contributors, 30 at the time of w
 
 ### Quick tasks (~10 minutes)
 
-- Leave a review on [addons.mozilla.org][amoreviews] (very few people do this :( )
-- Tell your friends about us :)
-- Read through [readme.md][readme], our [newtab.md][newtab] or our page on [addons.mozilla.org][amo] and see if anything looks out of date. If it does, file an issue or fork the repository (button in top right), fix it yourself (you can edit it using the pencil icon), and make a pull request.
+*   Leave a review on [addons.mozilla.org][amoreviews] (very few people do this :( )
+*   Tell your friends about us :)
+*   Read through [readme.md][readme], our [newtab.md][newtab] or our page on [addons.mozilla.org][amo] and see if anything looks out of date. If it does, file an issue or fork the repository (button in top right), fix it yourself (you can edit it using the pencil icon), and make a pull request.
 
 ### Quick tasks (~30 minutes)
 
-- Run through `:tutor` and [tell us what you think][tutor] or make changes directly.
+*   Run through `:tutor` and [tell us what you think][tutor] or make changes directly.
 
 ## Programming (1 hour+)
 
-- Take a look through the [open issues][issues] and then check with [pull requests][prs] to make sure that someone isn't already working on it. Please post in an issue to say that you're working on it.
-    - If you don't have much experience with JavaScript or WebExtensions, we purposefully leave some particularly simple issues open so that people can get started, and give them the tag [good first issue][easyissues]. Feel free to ask us any questions about the build process on [Matrix][Matrix].
-    - If you have experience with JavaScript or WebExtensions, please look through the issues tagged [help wanted][helpus] as we're really stuck on them.
-- You could work on some feature that you really want to see in Tridactyl that we haven't even thought of yet.
-- Our build process is a bit convoluted, but [excmds.ts][excmds] is probably where you want to start. Most of the business happens there.
-- We use TypeDoc to produce the `:help` page. Look at the other functions in [excmds.ts][excmds] to get an idea of how to use it; if your function is not supposed to called from the command line, then please add `/** @hidden */` above it to prevent it being shown on the help page.
-- Our pre-commit hook runs prettier to format your code. Please don't circumvent it.
+*   Take a look through the [open issues][issues] and then check with [pull requests][prs] to make sure that someone isn't already working on it. Please post in an issue to say that you're working on it.
+    *   If you don't have much experience with JavaScript or WebExtensions, we purposefully leave some particularly simple issues open so that people can get started, and give them the tag [good first issue][easyissues]. Feel free to ask us any questions about the build process on [Matrix][matrix].
+    *   If you have experience with JavaScript or WebExtensions, please look through the issues tagged [help wanted][helpus] as we're really stuck on them.
+*   You could work on some feature that you really want to see in Tridactyl that we haven't even thought of yet.
+*   Our build process is a bit convoluted, but [excmds.ts][excmds] is probably where you want to start. Most of the business happens there.
+*   We use TypeDoc to produce the `:help` page. Look at the other functions in [excmds.ts][excmds] to get an idea of how to use it; if your function is not supposed to called from the command line, then please add `/** @hidden */` above it to prevent it being shown on the help page.
+*   Our pre-commit hook runs prettier to format your code. Please don't circumvent it.
 
-If you are making a substantial or potentially controversial change, your first port of call should be to stop by and chat to us on [Matrix][Matrix] or file an issue to discuss what you would like to change. We really don't want you to waste time on a pull request (GitHub jargon for a contribution) that has no chance of being merged; that said, we are probably happy to gate even the most controversial changes behind an option. 
+If you are making a substantial or potentially controversial change, your first port of call should be to stop by and chat to us on [Matrix][matrix] or file an issue to discuss what you would like to change. We really don't want you to waste time on a pull request (GitHub jargon for a contribution) that has no chance of being merged; that said, we are probably happy to gate even the most controversial changes behind an option.
 
 # Add another theme (30 minutes+)
 
 Take a look in src/static/themes to get an idea of what to do. There is a reasonable amount of magic going on:
 
-- All of your styles must be prefixed with `:root.TridactylTheme[Name]`. If your theme is called `bobstheme`, the selector mentioned must be `:root.TridactylThemeBobstheme` (note the capitalisation).
-    - All of your CSS will be injected into all pages, so it is important that is fenced off in this manner.
-- `default.css` has loads of variables that you can use to make it easier for you to style things, and for your theme to apply to new elements that did not exist when you wrote your theme. It is advised that you make as much use of these as possible.
-
+*   All of your styles must be prefixed with `:root.TridactylTheme[Name]`. If your theme is called `bobstheme`, the selector mentioned must be `:root.TridactylThemeBobstheme` (note the capitalisation).
+    *   All of your CSS will be injected into all pages, so it is important that is fenced off in this manner.
+*   `default.css` has loads of variables that you can use to make it easier for you to style things, and for your theme to apply to new elements that did not exist when you wrote your theme. It is advised that you make as much use of these as possible.
 
 # Code of conduct
 
 [Queensberry rules](https://en.oxforddictionaries.com/definition/queensberry_rules).
 
-
-
-[Matrix]: https://riot.im/app/#/room/#tridactyl:matrix.org
+[matrix]: https://riot.im/app/#/room/#tridactyl:matrix.org
 [issues]: https://github.com/cmcaine/tridactyl/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+
 [easyissues]: https://github.com/cmcaine/tridactyl/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
 [helpus]: https://github.com/cmcaine/tridactyl/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22

--- a/doc/amo.md
+++ b/doc/amo.md
@@ -1,86 +1,58 @@
-## Control your browser with your keyboard *only*.
+## Control your browser with your keyboard _only_.
 
-Replace Firefox's control mechanism with one modelled on VIM. This is a "Firefox Quantum" replacement for VimFX, Vimperator and Pentadactyl.
-Most common tasks you want your browser to perform are bound to a single key
-press:
+Replace Firefox's control mechanism with one modelled on VIM. This is a "Firefox Quantum" replacement for VimFX, Vimperator and Pentadactyl. Most common tasks you want your browser to perform are bound to a single key press:
 
-- You want to open a new tab? Hit `t`.
-- You want to follow that link? Hit `f` and type the displayed label. (Note: hint characters should be typed in lowercase.)
-- You want to go to the bottom of the page? Hit `G`. Or the top? `gg`.
-- You want to focus the text field on Wikipedia to search for another term? `gi`.
-- Switch to the next tab? `gt`.
-- Go back in time? `H`.
-- Notice that this tab is rubbish and you want to close it? `d`.
-- Regret that decision? `u` restores it.
-- Want to write something in Vim? `Ctrl-i` in a text box opens it in Vim, if 
-you have `:native` working.
-- Temporarily disable all that magic because you can't stand it? `Shift-Insert`.
-- But how do you use your browser now? `Shift-Insert` again and we're back on.
+*   You want to open a new tab? Hit `t`.
+*   You want to follow that link? Hit `f` and type the displayed label. (Note: hint characters should be typed in lowercase.)
+*   You want to go to the bottom of the page? Hit `G`. Or the top? `gg`.
+*   You want to focus the text field on Wikipedia to search for another term? `gi`.
+*   Switch to the next tab? `gt`.
+*   Go back in time? `H`.
+*   Notice that this tab is rubbish and you want to close it? `d`.
+*   Regret that decision? `u` restores it.
+*   Want to write something in Vim? `Ctrl-i` in a text box opens it in Vim, if you have `:native` working.
+*   Temporarily disable all that magic because you can't stand it? `Shift-Insert`.
+*   But how do you use your browser now? `Shift-Insert` again and we're back on.
 
-The list could go on a bit here, but I guess you'll get the point. If you feel
-lost sometimes `:help` might help you a lot, and there's always `:tutor`.
+The list could go on a bit here, but I guess you'll get the point. If you feel lost sometimes `:help` might help you a lot, and there's always `:tutor`.
 
 **Highlighted features:**
 
- - follow any link on the site with just 2-3 key presses.
- - switch to any open tab by searching for its URL or title or entering its ID.
- - easy customizable search settings
- - bind any supported command or commands to the key (sequence) of your liking
- - great default bindings (if you're used to Pentadactyl or Vimperator)
+*   follow any link on the site with just 2-3 key presses.
+*   switch to any open tab by searching for its URL or title or entering its ID.
+*   easy customizable search settings
+*   bind any supported command or commands to the key (sequence) of your liking
+*   great default bindings (if you're used to Pentadactyl or Vimperator)
 
-This add-on is very usable, but is in an early stage of development. We intend
-to implement the majority of Vimperator's features.
+This add-on is very usable, but is in an early stage of development. We intend to implement the majority of Vimperator's features.
 
 You can get beta builds from [our website][betas].
 
 **Permissions:**
 
-Since Tridactyl aims to provide all the features Vimperator and Pentadactyl
-had, it requires quite a few permissions. Here we describe the specific
-permissions and why we need them.
+Since Tridactyl aims to provide all the features Vimperator and Pentadactyl had, it requires quite a few permissions. Here we describe the specific permissions and why we need them.
 
- - Access your data for all websites:
-   * This is Mozilla's way of saying that Tridactyl can read the content of web
-     pages. This is necessary in order to e.g. find the links you can follow
-     with the `:hint` command (bound to `f` by default).
- - Exchange messages with programs other than Firefox
-   * This permission is required for Tridactyl to interact with your
-     operating system (opening your editor to edit text areas, sending links to
-     your video player, reading a configuration file from your disk...). This
-     is possible thanks to an external executable we provide. If you feel this
-     gives Tridactyl too much power you can chose not to install the external
-     executable: Tridactyl will still work but won't be able to start external
-     programs.
- - Read and modify bookmarks:
-   * Tridactyl's command line has a powerful autocompletion mechanism. In
-     order to be able to autocomplete your bookmarks, Tridactyl needs to read
-     them.
- - Clear recent browsing history, cookies, and related data:
-   * Tridactyl implements the `:sanitise` command Vimperator and Pentadactyl
-     had. It works a bit like the "Clear All History" dialog you can access by
-     pressing `Ctrl+Shift+Del` on default Firefox.
- - Get data from the clipboard:
-   * If your clipboard contains a URL, pressing `p` will make Tridactyl follow
-     this URL in the current tab.
- - Input data to the clipboard:
-   * Tridactyl lets you copy various elements to the clipboard such as a page's
-     URL with `yy`, a link's URL with `;y` or the content of an HTML element
-     with `;p`.
- - Download files and read and modify the browser's download history:
-   * By pressing `;s`, `;S`, `;a` and `;A` you can save documents and pictures
-     from a page to your download folder.
- - Access browsing history:
-   * The URLs of websites you've visited previously can be suggested as
-     arguments for `:tabopen` and similar commands.
- - Access recently closed tabs:
-   * If you've accidentally closed a tab or window, Tridactyl will let you open
-     it again with the `:undo` command which is bound to `u` by default.
- - Access browser tabs:
-   * Tridactyl provides a quick tab-switching menu/command with the `:buffer`
-     command (bound to `b`). This permission is also required to close, move,
-     and pin tabs, amongst other things.
- - Access browser activity during navigation:
-   * This is needed for Tridactyl to be able to go back to normal mode every
-     time you open a new page. In the future we may use it for autocommands.
+*   Access your data for all websites:
+    *   This is Mozilla's way of saying that Tridactyl can read the content of web pages. This is necessary in order to e.g. find the links you can follow with the `:hint` command (bound to `f` by default).
+*   Exchange messages with programs other than Firefox
+    *   This permission is required for Tridactyl to interact with your operating system (opening your editor to edit text areas, sending links to your video player, reading a configuration file from your disk...). This is possible thanks to an external executable we provide. If you feel this gives Tridactyl too much power you can chose not to install the external executable: Tridactyl will still work but won't be able to start external programs.
+*   Read and modify bookmarks:
+    *   Tridactyl's command line has a powerful autocompletion mechanism. In order to be able to autocomplete your bookmarks, Tridactyl needs to read them.
+*   Clear recent browsing history, cookies, and related data:
+    *   Tridactyl implements the `:sanitise` command Vimperator and Pentadactyl had. It works a bit like the "Clear All History" dialog you can access by pressing `Ctrl+Shift+Del` on default Firefox.
+*   Get data from the clipboard:
+    *   If your clipboard contains a URL, pressing `p` will make Tridactyl follow this URL in the current tab.
+*   Input data to the clipboard:
+    *   Tridactyl lets you copy various elements to the clipboard such as a page's URL with `yy`, a link's URL with `;y` or the content of an HTML element with `;p`.
+*   Download files and read and modify the browser's download history:
+    *   By pressing `;s`, `;S`, `;a` and `;A` you can save documents and pictures from a page to your download folder.
+*   Access browsing history:
+    *   The URLs of websites you've visited previously can be suggested as arguments for `:tabopen` and similar commands.
+*   Access recently closed tabs:
+    *   If you've accidentally closed a tab or window, Tridactyl will let you open it again with the `:undo` command which is bound to `u` by default.
+*   Access browser tabs:
+    *   Tridactyl provides a quick tab-switching menu/command with the `:buffer` command (bound to `b`). This permission is also required to close, move, and pin tabs, amongst other things.
+*   Access browser activity during navigation:
+    *   This is needed for Tridactyl to be able to go back to normal mode every time you open a new page. In the future we may use it for autocommands.
 
 [betas]: https://tridactyl.cmcaine.co.uk/betas/?sort=time&order=desc

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -4,15 +4,14 @@
 
 A broad outline is thus:
 
-1. A user presses a key, triggering a keyEvent
-2. The parser picker chooses which parser to send it to based on the current mode
-3. The mode parser adds the key to its internal state, and can call an `update()` function to update, e.g, the status line / autocompletion
-4. Upon receiving a terminal character, the parser translates the series of keypresses into an `ex` string (e.g, ":scrollPage 1")
-5. This `ex` string is sent to the `ex str` parser, and converted into an internal Tridactyl function, e.g. `commmands.scrollPage(1)`, or if not possible, we report an error to the user
-6. These functions then interface with the WebExtensions API and will hide any message passing that needs to occur. If the function fails, it reports an error as in step 5.
+1.  A user presses a key, triggering a keyEvent
+2.  The parser picker chooses which parser to send it to based on the current mode
+3.  The mode parser adds the key to its internal state, and can call an `update()` function to update, e.g, the status line / autocompletion
+4.  Upon receiving a terminal character, the parser translates the series of keypresses into an `ex` string (e.g, ":scrollPage 1")
+5.  This `ex` string is sent to the `ex str` parser, and converted into an internal Tridactyl function, e.g. `commmands.scrollPage(1)`, or if not possible, we report an error to the user
+6.  These functions then interface with the WebExtensions API and will hide any message passing that needs to occur. If the function fails, it reports an error as in step 5.
 
-
-    browser -> keyEvents -> parser picker -> mode parser -> terminal character -> ex command -> "ex str" parser -> (function | error) -> browser
+        browser -> keyEvents -> parser picker -> mode parser -> terminal character -> ex command -> "ex str" parser -> (function | error) -> browser
 
 The process for "BrowserEvents", which occur when the user or some other code manipulates the browser through some non-Tridactyl method is similar, but we skip the parser picker step for now.
 

--- a/doc/archive.md
+++ b/doc/archive.md
@@ -2,15 +2,15 @@
 
 Non-objectives for v1:
 
-* insert mode (embedded (n)vim would be good for future)
-* caret or visual mode - I'm not good enough at vim to find these easier than selecting with the mouse, and they require text motions, which I would prefer to delegate to vim.
+*   insert mode (embedded (n)vim would be good for future)
+*   caret or visual mode - I'm not good enough at vim to find these easier than selecting with the mouse, and they require text motions, which I would prefer to delegate to vim.
 
 Prior art:
 
-* pentadactyl/vimperator - dying with XUL
-* cVim/vimium/saka-key
-* vimfx - transitioning to WebExtensions, but no ex commands
-* qutebrowser/jumanji - see [standalone.md](doc/standalone.md).
+*   pentadactyl/vimperator - dying with XUL
+*   cVim/vimium/saka-key
+*   vimfx - transitioning to WebExtensions, but no ex commands
+*   qutebrowser/jumanji - see [standalone.md](doc/standalone.md).
 
 ## WebExtensions
 
@@ -22,12 +22,12 @@ cVim and vimium implement some kind of vim experience using webextensions. Neith
 
 #### Common issues
 
-1. can't operate on some URLs (chrome store, chrome://, view-source://)
-2. can't escape location bar
-3. can't hide chrome UI
-4. can't suppress all chrome keybinds
-5. can't override some browser shortcuts
-6. bad js kills the UI (but the same bad js locks up the whole of firefox, so y'know...)
+1.  can't operate on some URLs (chrome store, chrome://, view-source://)
+2.  can't escape location bar
+3.  can't hide chrome UI
+4.  can't suppress all chrome keybinds
+5.  can't override some browser shortcuts
+6.  bad js kills the UI (but the same bad js locks up the whole of firefox, so y'know...)
 
 In conclusion, a privileged keyboard webextension will help with #1,2,4,5; #3,#1 (for visual changes) and maybe #2 need a ui API. #1 might not be applicable to ff content scripts.
 
@@ -39,15 +39,15 @@ Very lightweight, but what is there is actually really nice. Easily fixable issu
 
 Missing:
 
-* command mode
-* jumplist
-* :js
-* lots more.
+*   command mode
+*   jumplist
+*   :js
+*   lots more.
 
 Improvements over vimperator:
 
-* regex search
-* buffer switch between windows
+*   regex search
+*   buffer switch between windows
 
 #### vrome
 
@@ -57,12 +57,12 @@ Vim mode chromium plugin written at least partly in coffeescript. Source is not 
 
 Missing:
 
-* map!
-* sensible default maps
-* UI style
-* documentation for users or developers
-* plugin/eval support
-* jumplist, etc
+*   map!
+*   sensible default maps
+*   UI style
+*   documentation for users or developers
+*   plugin/eval support
+*   jumplist, etc
 
 May be worth taking code from, could consider forking it, but would need to review code more carefully for quality issues.
 
@@ -74,58 +74,58 @@ Written in uncommented javascript. But user experience is pretty good. Autocompl
 
 Missing:
 
-* decent documentation
-* can't map some characters that vimium can
-* jumplist
+*   decent documentation
+*   can't map some characters that vimium can
+*   jumplist
 
 Improvements over vimperator:
 
-* autocompletion is much faster
-* allegedly lets you edit with vim
+*   autocompletion is much faster
+*   allegedly lets you edit with vim
 
 ## Architecture
 
-*This is an early draft and may be entirely replaced.*
+_This is an early draft and may be entirely replaced._
 
 ex-commands as functions (typed and with helper functions in some other scope):
 
-* open(url)
-* scroll(x=+10)
-* mark(<elem>)
-* map(actions, keys)
-* ...
+*   open(url)
+*   scroll(x=+10)
+*   mark(<elem>)
+*   map(actions, keys)
+*   ...
 
 helper functions for actions:
 
-* scroll-x, scroll-y
-* jumplist.get/getrelative/store
-* undo-tab-deletion
+*   scroll-x, scroll-y
+*   jumplist.get/getrelative/store
+*   undo-tab-deletion
 
 Count and range:
 
-* given as arguments?
-* just repeat the call 'count' times?
+*   given as arguments?
+*   just repeat the call 'count' times?
 
 for default actions, a mapping from key to helper function.
 
 Generated parsers (command and normal mode):
 
-* command mode pretty conventional. Include type checking.
-* For auto-complete to work, need to be able to parse partial results sensibly.
-* actions will be a slightly weirder grammar:
-* More permissive
-* Time sensitive
+*   command mode pretty conventional. Include type checking.
+*   For auto-complete to work, need to be able to parse partial results sensibly.
+*   actions will be a slightly weirder grammar:
+*   More permissive
+*   Time sensitive
 
-* In vim, actions compose as you write them (d takes a motion as an argument, for example), I can't think of any examples of this in vimperator: actions sometimes take a count or argument, but that argument is never an action.
+*   In vim, actions compose as you write them (d takes a motion as an argument, for example), I can't think of any examples of this in vimperator: actions sometimes take a count or argument, but that argument is never an action.
 
-* If actions did compose, we would have to give them types, as vim does for motions, and the parsing would be less trivial.
+*   If actions did compose, we would have to give them types, as vim does for motions, and the parsing would be less trivial.
 
 Autocomplete functions for commands:
 
-* Split from implementation of command.
-* Could perhaps be automatic from command's parameter types?
+*   Split from implementation of command.
+*   Could perhaps be automatic from command's parameter types?
 
 Some actions have their own interactive mini-mode:
 
-* hints
-* searching
+*   hints
+*   searching

--- a/doc/bug-message.md
+++ b/doc/bug-message.md
@@ -2,7 +2,6 @@
 
 See also [content-scripts-bug.md](content-scripts-bug.md).
 
-
 Vimperator and pentadactyl are addons that replace most of the Firefox UX with a keyboard-focused interface inspired by Vim. They enjoy moderate popularity and are particularly highlighted as "interesting add-ons" for porting on the Mozilla wiki[0].
 
 From now on I'll just say "Vimperator" instead of "Vimperator and pentadactyl" or similar.
@@ -19,21 +18,21 @@ The main drawback of this approach is that the content scripts aren't injected i
 
 Users of Vimperator-like addons cannot:
 
-1. Use vimperator at all on some URLs (about:\*, addons.mozilla.org)
-    1. Show and control the command line
-    2. Use any keyboard shortcuts
-    3. Use any commands or shortcuts that need to access the page's DOM.
-        * Includes: history control, scrolling, searching, hint mode, etc.
-2. Hide UI elements
-    *  Vimperator aims to replace the entire UI, so the old Firefox UI is not used at all. This frees up valuable real estate on small screens, such as laptops.
-3. Escape from browser UI elements (especially the location bar)
-4. Suppress/shadow all browser keybinds
-5. Configure vimperator from the kind of config files they expect from other unix programs (and especially vim)
-    * In particular users expect to have something like ~/.vimperatorrc for their config and to be able to install additional plugins to something like ~/.vimperator/plugins; something like ~/.config/vimperator/ would also be acceptable.
+1.  Use vimperator at all on some URLs (about:\*, addons.mozilla.org)
+    1.  Show and control the command line
+    2.  Use any keyboard shortcuts
+    3.  Use any commands or shortcuts that need to access the page's DOM.
+        *   Includes: history control, scrolling, searching, hint mode, etc.
+2.  Hide UI elements
+    *   Vimperator aims to replace the entire UI, so the old Firefox UI is not used at all. This frees up valuable real estate on small screens, such as laptops.
+3.  Escape from browser UI elements (especially the location bar)
+4.  Suppress/shadow all browser keybinds
+5.  Configure vimperator from the kind of config files they expect from other unix programs (and especially vim)
+    *   In particular users expect to have something like ~/.vimperatorrc for their config and to be able to install additional plugins to something like ~/.vimperator/plugins; something like ~/.config/vimperator/ would also be acceptable.
 
 In Firefox there is a new, sixth problem:
 
-6. Vimperator cannot open certain restricted URLs
+6.  Vimperator cannot open certain restricted URLs
 
 The issues are in rough importance order, apart from 6, which should be higher.
 
@@ -63,8 +62,8 @@ Leechblock is another addon that has a legitimate reason to access a restricted 
 
 My understanding is that Firefox developers do not want to permit content scripts to run on restricted pages because of the possibility of privilege escalation. This is normally bad for two reasons:
 
-1. Security of the user
-2. Stability of the browser: addons using exposed APIs they shouldn't will break more on updates, etc.
+1.  Security of the user
+2.  Stability of the browser: addons using exposed APIs they shouldn't will break more on updates, etc.
 
 I don't think either of these issues matter for an addon like vimperator. Vimperator is expected and essentially required to be able to read every keystroke the user makes on every page, control network access, control ui (including display of URLs and https status), etc. Let's say running a content script in about:addons might let us privilege escalate to control the whole browser. The only new warning we need to give users is that this addon can potentially run arbitrary code as your user on the host system, which vimperator could do anyway in a slightly roundabout fashion by redirecting any executable or source code the user downloads to some malware.
 
@@ -76,11 +75,11 @@ Regarding stability, the risk of exposing APIs that shouldn't be used only reall
 
 If the Firefox developers are adamant that no addon be permitted to access the DOM of restricted pages, then we have to work around that limitation with new APIs. This is the best I can come up with, but it relies again on lydell's abandoned keyboard API:
 
-1. The command line/statusline moves into a toolbar. Toolbar must be permitted to expand or overlay page content to show autocompletion and to talk to content and background scripts.
-2. The proposed keyboard API allows vimperator to capture keypresses within restricted pages, so we can still call most vimperator functions, but any that need to access the DOM of the restricted page won't work.
-3. The keyboardshortcuts API also proposed by the vimFx developer ("simple functions to trigger standard Firefox keyboard shortcuts programmatically") will allow some of the simple features we otherwise need DOM access for to work, examples: scrolling, history navigation, stop loading, etc. More advanced features such as hint mode, marks, insert, visual and caret mode and searching will not work.
+1.  The command line/statusline moves into a toolbar. Toolbar must be permitted to expand or overlay page content to show autocompletion and to talk to content and background scripts.
+2.  The proposed keyboard API allows vimperator to capture keypresses within restricted pages, so we can still call most vimperator functions, but any that need to access the DOM of the restricted page won't work.
+3.  The keyboardshortcuts API also proposed by the vimFx developer ("simple functions to trigger standard Firefox keyboard shortcuts programmatically") will allow some of the simple features we otherwise need DOM access for to work, examples: scrolling, history navigation, stop loading, etc. More advanced features such as hint mode, marks, insert, visual and caret mode and searching will not work.
 
-These three fix the main problem in the chrome addons of getting stuck and having to use a different UI on some pages is mostly removed (remember, the whole point of vimperator is to replace the default UI/UX). It is important to highlight, however, that users losing hint mode on about: pages is a real UX hit because hint mode is the main way that users select and follow links in vimperator. 
+These three fix the main problem in the chrome addons of getting stuck and having to use a different UI on some pages is mostly removed (remember, the whole point of vimperator is to replace the default UI/UX). It is important to highlight, however, that users losing hint mode on about: pages is a real UX hit because hint mode is the main way that users select and follow links in vimperator.
 
 I can't think of an easy way of allowing hinting without DOM access. A built-in hinting API is probably the only sensible way; but seems like a high maintenance burden on Firefox (unless you want to enable hinting mode in normal Firefox, which would be cool). A less sensible proposal would be to tell us where and what the anchor tags are and let us overlay the page with just the labels in a new, mostly transparent window.
 
@@ -88,22 +87,22 @@ I can't think of an easy way of allowing hinting without DOM access. A built-in 
 
 ## List of new required WebExtension APIs
 
-* keyboard incl. function to escape browser location bar
-    * https://bugzilla.mozilla.org/show_bug.cgi?id=1215061
-* theming or some other API must support completely hiding most UI elements.
-* permission to programmatically navigate to restricted URLs
-    * https://bugzilla.mozilla.org/show_bug.cgi?id=1261289
-    * https://bugzilla.mozilla.org/show_bug.cgi?id=1298215
-* filesystem
-    * https://bugzilla.mozilla.org/show_bug.cgi?id=1246236
-* either:
-    * a permission allowing content scripts to run on restricted pages.
-    * or...
-        * keyboardshortcuts
-        * toolbar/custom html+css+js ui element with ability to expand or (preferably) overlay the tab window.
-            * https://bugzilla.mozilla.org/show_bug.cgi?id=1215064
-        * And for more functionality:
-            * hinting
+*   keyboard incl. function to escape browser location bar
+    *   https://bugzilla.mozilla.org/show_bug.cgi?id=1215061
+*   theming or some other API must support completely hiding most UI elements.
+*   permission to programmatically navigate to restricted URLs
+    *   https://bugzilla.mozilla.org/show_bug.cgi?id=1261289
+    *   https://bugzilla.mozilla.org/show_bug.cgi?id=1298215
+*   filesystem
+    *   https://bugzilla.mozilla.org/show_bug.cgi?id=1246236
+*   either:
+    *   a permission allowing content scripts to run on restricted pages.
+    *   or...
+        *   keyboardshortcuts
+        *   toolbar/custom html+css+js ui element with ability to expand or (preferably) overlay the tab window.
+            *   https://bugzilla.mozilla.org/show_bug.cgi?id=1215064
+        *   And for more functionality:
+            *   hinting
 
 ## What's this hint mode thing, anyway?
 

--- a/doc/content-scripts-bug.md
+++ b/doc/content-scripts-bug.md
@@ -4,14 +4,14 @@ Disallowing content scripts from running on certain pages is a big change from p
 
 ## Risks as we understand them
 
-1. Privilege escalation from WebExtension to full control of the browser allows:
-    1. Malicious addons to do more to the host system and to Firefox internals
-    2. Malware to target privileged addons
-    3. Addon developers to reduce the stability of Firefox by deliberately or accidentally but not maliciously escaping the sandbox
+1.  Privilege escalation from WebExtension to full control of the browser allows:
+    1.  Malicious addons to do more to the host system and to Firefox internals
+    2.  Malware to target privileged addons
+    3.  Addon developers to reduce the stability of Firefox by deliberately or accidentally but not maliciously escaping the sandbox
 
 ## Additional risks as articulated on #WebExtensions
 
-2. The necessary severe warnings to the user are problematic for usability, security and other reasons.
+2.  The necessary severe warnings to the user are problematic for usability, security and other reasons.
 
 Is this a fair characterisation of the risks?
 
@@ -21,18 +21,18 @@ From a security perspective, we believe the user suffers very little from the pr
 
 Without restricted pages:
 
-1. Inspect the value of all form fields
-    1. Steal all user credentials, typed or automatically entered.
-2. Rewrite download links
-    1. Fool users into installing malware.
+1.  Inspect the value of all form fields
+    1.  Steal all user credentials, typed or automatically entered.
+2.  Rewrite download links
+    1.  Fool users into installing malware.
 
 With privilege escalation, all the above plus:
 
-3. Control addon installation
-    1. Install more addons as it pleases
-    2. Prevent uninstallation of addons
-4. Access Firefox sync data and logins/password database
-5. Run arbitrary code as the Firefox process
+3.  Control addon installation
+    1.  Install more addons as it pleases
+    2.  Prevent uninstallation of addons
+4.  Access Firefox sync data and logins/password database
+5.  Run arbitrary code as the Firefox process
 
 Now, 3, 4 and 5 are bad, but they're only slightly worse for the user than 1 and 2.
 

--- a/doc/escalating-privilege.md
+++ b/doc/escalating-privilege.md
@@ -2,37 +2,40 @@
 
 Useful workarounds and methods to get the power we want in the brave new world of webextensions.
 
- - Function in newtab
-    - [chrome_url_overrides](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/chrome_url_overrides)
- - Function in home page
-    - [chrome_settings_overrides](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides)
- - (Downside for both is that we need to reimplement a useful home and newtab page)
+*   Function in newtab
+    *   [chrome_url_overrides](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/chrome_url_overrides)
+*   Function in home page
+    *   [chrome_settings_overrides](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides)
+*   (Downside for both is that we need to reimplement a useful home and newtab page)
 
- - Shell and write access to filesystem
-    - [Native_messaging](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging)
- - Hiding firefox chrome
-    - API proposal for hiding tabstrip (but not nav bar): [Bug 1332447](https://api-dev.bugzilla.mozilla.org/show_bug.cgi?id=1332447)
-        - :Gijs discusses why nav bar can't be hidden, but I still don't get why whatever happens in fullscreen can't just also happen in windowed mode.
-    - Hiding with userChrome.css
-        - http://kb.mozillazine.org/Chrome_element_names_and_IDs
-        - e.g. "#tabbrowser-tabs { visibility: collapse !important; }"
-        - requires restart, probably
+*   Shell and write access to filesystem
+    *   [Native_messaging](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging)
+*   Hiding firefox chrome
 
- - Commandline thru toolbar API
-    - [Bug 1215064](https://bugzilla.mozilla.org/show_bug.cgi?id=1215064)
-    - As currently envisioned, size is fixed, I think
- - Commandline thru HTML injection into webcontent
-    - Dangerous, see [Bug 1287590](https://bugzilla.mozilla.org/show_bug.cgi?id=1287590)
-    - Shadow DOM would probably be simpler than iframe, but not implemented yet [Bug 1205323](https://bugzilla.mozilla.org/show_bug.cgi?id=1205323)
- - Commandline thru search suggestions on the omnibar (this is a bit mad)
-    - [chrome_settings_overrides](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides)
+    *   API proposal for hiding tabstrip (but not nav bar): [Bug 1332447](https://api-dev.bugzilla.mozilla.org/show_bug.cgi?id=1332447)
+        *   :Gijs discusses why nav bar can't be hidden, but I still don't get why whatever happens in fullscreen can't just also happen in windowed mode.
+    *   Hiding with userChrome.css
+        *   http://kb.mozillazine.org/Chrome_element_names_and_IDs
+        *   e.g. "#tabbrowser-tabs { visibility: collapse !important; }"
+        *   requires restart, probably
 
- - [Find API](https://bug1332144.bmoattachments.org/attachment.cgi?id=8905651)
-    - [Bug 1332144](https://bugzilla.mozilla.org/show_bug.cgi?id=1332144)
-    - [Demo](https://github.com/Allasso/Find_API_demo_WE_advanced)
-    - How to replicate find links? Do we care?
-    - Can this be used to exfiltrate info about about pages?
+*   Commandline thru toolbar API
+    *   [Bug 1215064](https://bugzilla.mozilla.org/show_bug.cgi?id=1215064)
+    *   As currently envisioned, size is fixed, I think
+*   Commandline thru HTML injection into webcontent
+    *   Dangerous, see [Bug 1287590](https://bugzilla.mozilla.org/show_bug.cgi?id=1287590)
+    *   Shadow DOM would probably be simpler than iframe, but not implemented yet [Bug 1205323](https://bugzilla.mozilla.org/show_bug.cgi?id=1205323)
+*   Commandline thru search suggestions on the omnibar (this is a bit mad)
 
- - Can't navigate to restricted URLs
-    - [about:](https://bugzilla.mozilla.org/show_bug.cgi?id=1371793)
-    - [file:](https://bugzilla.mozilla.org/show_bug.cgi?id=1266960)
+    *   [chrome_settings_overrides](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides)
+
+*   [Find API](https://bug1332144.bmoattachments.org/attachment.cgi?id=8905651)
+
+    *   [Bug 1332144](https://bugzilla.mozilla.org/show_bug.cgi?id=1332144)
+    *   [Demo](https://github.com/Allasso/Find_API_demo_WE_advanced)
+    *   How to replicate find links? Do we care?
+    *   Can this be used to exfiltrate info about about pages?
+
+*   Can't navigate to restricted URLs
+    *   [about:](https://bugzilla.mozilla.org/show_bug.cgi?id=1371793)
+    *   [file:](https://bugzilla.mozilla.org/show_bug.cgi?id=1266960)

--- a/doc/hinting.md
+++ b/doc/hinting.md
@@ -1,21 +1,21 @@
 ## Components
 
- - Iterable of visible links on page
+*   Iterable of visible links on page
 
- - Algorithm for choosing hint characters for each link
+*   Algorithm for choosing hint characters for each link
 
- - Mode for controller and excmd to refine and select hints:
-     - I imagine `:hint` to start 
-     - `:hint j` to refine to only hints starting with j
-     - `:hint jk` to refine to hints starting with jk
-     - To make maps easier we can have `:hintaddchar j` and have the state of the current hintstr stored content-side.
+*   Mode for controller and excmd to refine and select hints:
+    *   I imagine `:hint` to start
+    *   `:hint j` to refine to only hints starting with j
+    *   `:hint jk` to refine to hints starting with jk
+    *   To make maps easier we can have `:hintaddchar j` and have the state of the current hintstr stored content-side.
 
 ## Improvements
 
 Hinting modes should be flexible on both
 
- 1. What is hinted (links, anchorpoints, frames, input elements, etc)
- 2. What is done with the selected link (follow, yank, focus)
+1.  What is hinted (links, anchorpoints, frames, input elements, etc)
+2.  What is done with the selected link (follow, yank, focus)
 
 ## Vimperator hint modes:
 
@@ -23,35 +23,35 @@ Hinting modes should be flexible on both
 
 ```
 string(default: //input[not(@type='hidden' or @disabled)] | //xhtml:input[not(@type='hidden')] | //a | //xhtml:a | //area | //xhtml:area | //iframe | //xhtml:iframe | //textarea | //xhtml:textarea | //button | //xhtml:button | //select | //xhtml:select | //\*[@onclick or @onmouseover or @onmousedown or @onmouseup or @oncommand or @role='link'or @role='button' or @role='checkbox' or @role='combobox' or @role='listbox' or @role='listitem' or @role='menuitem' or @role='menuitemcheckbox' or @role='menuitemradio' or @role='option' or @role='radio' or @role='scrollbar' or @role='slider' or @role='spinbutton' or @role='tab' or @role='textbox' or @role='treeitem' or @tabindex])
-        
+
 XPath string of hintable elements activated by f and F
 ```
 
 Extended hint modes:
 
 ```
-;  Focus hint 
-?  Show information for hint 
-s  Save link 
-S  Save object 
-a  Save link with prompt 
-A  Save object with prompt 
-f  Focus frame 
-o  Follow hint 
-t  Follow hint in a new tab 
-b  Follow hint in a background tab 
-w  Follow hint in a new window 
-F  Open multiple hints in tabs 
-O  Generate an ':open URL' using hint 
-T  Generate a ':tabopen URL' using hint 
-W  Generate a ':winopen URL' using hint 
-v  View hint source 
-V  View hint source in external editor 
-y  Yank hint location 
-Y  Yank hint description 
+;  Focus hint
+?  Show information for hint
+s  Save link
+S  Save object
+a  Save link with prompt
+A  Save object with prompt
+f  Focus frame
+o  Follow hint
+t  Follow hint in a new tab
+b  Follow hint in a background tab
+w  Follow hint in a new window
+F  Open multiple hints in tabs
+O  Generate an ':open URL' using hint
+T  Generate a ':tabopen URL' using hint
+W  Generate a ':winopen URL' using hint
+v  View hint source
+V  View hint source in external editor
+y  Yank hint location
+Y  Yank hint description
 #  Yank hint anchor URL
-c  Open context menu 
-i  Show media object 
-I  Show media object in a new tab 
+c  Open context menu
+i  Show media object
+I  Show media object in a new tab
 x  Show hint's title or alt text
 ```

--- a/doc/ideas.md
+++ b/doc/ideas.md
@@ -2,73 +2,60 @@
 
 Vimperator is going to die once Firefox deprecates XUL and switches webextensions. Needs fixing, or nobody will be able to use the internet any more.
 
-Valiant efforts have been begun to sort out some parts of Firefox's WebExtension implementation:
-https://bugzilla.mozilla.org/show_bug.cgi?id=1215061
+Valiant efforts have been begun to sort out some parts of Firefox's WebExtension implementation: https://bugzilla.mozilla.org/show_bug.cgi?id=1215061
 
 This only deals with the keyboard binding aspect. We need to think about the GUI / hinting etc: we need to make sure everything we want to have in Vimperator is possible using WebExtensions.
 
-
 Chrome et al. already use WebExtensions, and there are a few vim-like extensions for it, such as cVim/Vimium. It would make sense to look at how these extensions work and see what is not currently possible in Firefox. An obvious part of what they cannot do is change the GUI of the browser. Vimperator allows you to hide parts of the browser when they are not needed.
-
 
 It would also be sensible to have a list of ideal things that can't currently be done in Vimperator, e.g. embedding Vim client, that we would like. (look at Petrosaur)
 
-
-There is currently a magic console in Firefox that we could perhaps hijack, which is built on GCLI:
-https://developer.mozilla.org/en/docs/Tools/GCLI
-https://github.com/joewalker/gcli/blob/master/docs/index.md -- even says that it could be used as part of a browser extension
+There is currently a magic console in Firefox that we could perhaps hijack, which is built on GCLI: https://developer.mozilla.org/en/docs/Tools/GCLI https://github.com/joewalker/gcli/blob/master/docs/index.md -- even says that it could be used as part of a browser extension
 
 # Avoiding JavaScript:
-CoffeeScript; EMScripten, ELM, Node.js (interpretereter?)
-(broccoli)
-What is NPM? Browserify is dependency management
+
+CoffeeScript; EMScripten, ELM, Node.js (interpretereter?) (broccoli) What is NPM? Browserify is dependency management
 
 # Useful libraries
+
 PEG - parses stuff (e.g. command input)
 
 # cVim
+
 Code not well documented, could glean useful stuff from just stripping out what Chrome API is used
 
 ## Useful links:
+
 https://www.codementor.io/gmuresan/building-a-chrome-extension-reactjs-broccoli-sass-du1081zv0
 
-
-
 # Useful links
-https://developer.chrome.com/extensions/commands
-https://github.com/lydell/webextension-keyboard
-https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#Background_scripts
-https://github.com/shinglyu/QuantumVim - Vimium style stuff in WebExtensions
-https://github.com/mishoo/UglifyJS2 - Minify JS: check that compiling to Firefox addon doesn't already do this
-https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API
-http://arcturo.github.io/library/coffeescript/ - Coffee Script textbook
-https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext - web-ext will automatically reload a changed extension
 
+https://developer.chrome.com/extensions/commands https://github.com/lydell/webextension-keyboard https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#Background_scripts https://github.com/shinglyu/QuantumVim - Vimium style stuff in WebExtensions https://github.com/mishoo/UglifyJS2 - Minify JS: check that compiling to Firefox addon doesn't already do this https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API http://arcturo.github.io/library/coffeescript/ - Coffee Script textbook https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext - web-ext will automatically reload a changed extension
 
 # Names
+
 Tridactyl (like Pentadactyl, but worse, last cuturally relevant in 2005 like Salad Fingers)
 
 # Features we really really want
-- Hiding misc UI (tabs, menu, urlbar, etc.)
-- Interacting with other addons (simulating presses on buttons?)
-- ]][[ to inc/dec url
-- command line for opening tabs/completion/interacting with addons/changing settings
-- "buffer" tab searching / tab groups?
-- searching for tabs between windows?
+
+*   Hiding misc UI (tabs, menu, urlbar, etc.)
+*   Interacting with other addons (simulating presses on buttons?)
+*   ]][[ to inc/dec url
+*   command line for opening tabs/completion/interacting with addons/changing settings
+*   "buffer" tab searching / tab groups?
+*   searching for tabs between windows?
 
 # Features we need less?
-autocmds?
-macros?
 
+autocmds? macros?
 
 # Vimium notes
-Uses descriptors a lot - what even are they?
-Loading into firefox doesn't give any errors / doesn't seem to expose any functions?
 
+Uses descriptors a lot - what even are they? Loading into firefox doesn't give any errors / doesn't seem to expose any functions?
 
 # Other stuff
-Would be nice to have self-writing documentation, for autocmd use etc?
-Could use .litcoffee for markdown comments in code.
+
+Would be nice to have self-writing documentation, for autocmd use etc? Could use .litcoffee for markdown comments in code.
 
 History seems to be window.history.go(), presumably in a content script?
 

--- a/doc/mvp.md
+++ b/doc/mvp.md
@@ -25,12 +25,12 @@ Commands:
     buffer {N}
 
 ## modes
-    
+
     normal
     insert
     find {phrase} {direction=+/-1}
     hints {open|tabopen|winopen|yank}
 
-
 ## search-likes
+
     {page, google, amazon} {phrase}

--- a/doc/parser.md
+++ b/doc/parser.md
@@ -3,11 +3,11 @@
 We need to parse series of keypresses into `ex` commands, and then parse those commands into internal functions. We also need autocompletion of commands (maybe also in normal mode, qutebrowser style, to aid their discoverability), and the parser needs to change in real-time such that binds can be remapped.
 
 We are considering:
- - writing our own parser
- - Nearley: https://github.com/Hardmath123/nearley
-     - Upsides: uses Earley, can use CoffeeScript
- - PEG.js
-     - Downsides: uses PEG
 
+*   writing our own parser
+*   Nearley: https://github.com/Hardmath123/nearley
+    *   Upsides: uses Earley, can use CoffeeScript
+*   PEG.js
+    *   Downsides: uses PEG
 
 Currently, we are erring on the side of writing our own parser, as neither of the other options allow for changing the parser sensibly, and do not seem to support partial matches. Generally, neither seem to be written with the expectation of interactive uses.

--- a/doc/standalone.md
+++ b/doc/standalone.md
@@ -2,21 +2,21 @@
 
 Some small browsers exist that use webkit/webengine for the heavy lifting. Two notable examples even have vim-like interfaces: qutebrowser and jumanji.
 
-Extending them *might* be easy, depending on the quality of the existing code base. We also need to evaluate these projects for maintainability: they're obviously going to have much less development power.
+Extending them _might_ be easy, depending on the quality of the existing code base. We also need to evaluate these projects for maintainability: they're obviously going to have much less development power.
 
 If it's comparable to this project done in webextensions, then we might want to just build our own/fork/contribute.
 
-But what do we lose? What do the non-gecko bits of firefox do? What's left in the chrome repo if you remove webengine? I don't really know. 
+But what do we lose? What do the non-gecko bits of firefox do? What's left in the chrome repo if you remove webengine? I don't really know.
 
-* Kerning/font presentation code? (text in qutebrowser looks bad on Windows, don't know why)
-* Cross-platform OS shit
-* Firefox sync is neat and would be missed.
-* safebrowsing?
-* how much security stuff in engine/vs browser?
-* webm, webgl and similar? Presumably handled either by the engine or externally, but maybe picking and maintaining link to external thing is expensive.
-* flash handling?
-* What UI stuff are we not replacing?
-* developer tools (neat, but no reason for us to re-implement).
+*   Kerning/font presentation code? (text in qutebrowser looks bad on Windows, don't know why)
+*   Cross-platform OS shit
+*   Firefox sync is neat and would be missed.
+*   safebrowsing?
+*   how much security stuff in engine/vs browser?
+*   webm, webgl and similar? Presumably handled either by the engine or externally, but maybe picking and maintaining link to external thing is expensive.
+*   flash handling?
+*   What UI stuff are we not replacing?
+*   developer tools (neat, but no reason for us to re-implement).
 
 We also lose access to the existing addon/extension repos. Maybe if we implemented webextension support in our own browser we'd get them back? Don't know how difficult that is.
 
@@ -26,19 +26,18 @@ What addons do I use and would I miss them?
 
 Should be part of the browser anyway:
 
-* stylish --> :style, or maybe .vimperator/styles/ (with magic comments?)
-* greasemonkey --> builtin/extensions/autocmds
-* site blocker --> /etc/hosts
+*   stylish --> :style, or maybe .vimperator/styles/ (with magic comments?)
+*   greasemonkey --> builtin/extensions/autocmds
+*   site blocker --> /etc/hosts
 
 Maybe not:
 
-* element hiding rules (ublock) not supported
-* tree tabs --> better :buffer?
-* lazarus form recovery is brilliant...
-* noscript is shit anyway
-* hide fedora is neat, but maybe just an element hiding list? Maybe it does have to parse differently.
-    * example of neat addon that a smaller browser wouldn't have available, anyway.
-* ref control is neat, but the UI is pants. Would be easy to build an ex-mode interface.
-* pwgen is trivial
-* https everywhere --> builtin?
-
+*   element hiding rules (ublock) not supported
+*   tree tabs --> better :buffer?
+*   lazarus form recovery is brilliant...
+*   noscript is shit anyway
+*   hide fedora is neat, but maybe just an element hiding list? Maybe it does have to parse differently.
+    *   example of neat addon that a smaller browser wouldn't have available, anyway.
+*   ref control is neat, but the UI is pants. Would be easy to build an ex-mode interface.
+*   pwgen is trivial
+*   https everywhere --> builtin?

--- a/doc/wishlist.md
+++ b/doc/wishlist.md
@@ -1,8 +1,9 @@
 # Stuff we'd like but maybe we might not be able to do
 
- - Better link hinting
-    - One hint per identical link? (e.g. BBC News homepage works badly without this)
-    - Some links need simulated mouse click (e.g. JS)
+*   Better link hinting
 
- - Better normal mode motions
-    - e.g, "next heading"
+    *   One hint per identical link? (e.g. BBC News homepage works badly without this)
+    *   Some links need simulated mouse click (e.g. JS)
+
+*   Better normal mode motions
+    *   e.g, "next heading"

--- a/doc/workflow.md
+++ b/doc/workflow.md
@@ -1,18 +1,20 @@
 # Playing with Firefox background scripts
-1. about:debugging - load temporary addon
-2. click "debug"
-3. click "console"
-4. disable most things apart from logging
-5. have fun
 
+1.  about:debugging - load temporary addon
+2.  click "debug"
+3.  click "console"
+4.  disable most things apart from logging
+5.  have fun
 
 # Playing with content scripts
-1. about:debugging
-2. dunno the rest
+
+1.  about:debugging
+2.  dunno the rest
 
 # Experimental WebExtension API addons
-1. complicated, but Colin knows a bit.
 
+1.  complicated, but Colin knows a bit.
 
 # Compiling CoffeeScript
+
 coffee -c script.coffee

--- a/readme.md
+++ b/readme.md
@@ -20,122 +20,105 @@ If you're enjoying Tridactyl, or not, please leave a review on the [AMO](https:/
 
 ## Highlighted features
 
-Like Vim, Tridactyl is modal, with the default mode being "normal mode". In
-"normal mode", many functions are available using keybindings. In "command
-mode" (when the command line is shown), you can execute more complex commands,
-known as "ex-commands". All Tridactyl functionality can be accessed by
-ex-commands. You can bind any ex-command to a normal-mode shortcut. We also support a `.tridactylrc` file, of which there is an example in the root of this repository.
+Like Vim, Tridactyl is modal, with the default mode being "normal mode". In "normal mode", many functions are available using keybindings. In "command mode" (when the command line is shown), you can execute more complex commands, known as "ex-commands". All Tridactyl functionality can be accessed by ex-commands. You can bind any ex-command to a normal-mode shortcut. We also support a `.tridactylrc` file, of which there is an example in the root of this repository.
 
 ### Default normal-mode bindings
 
-This is a (non-exhaustive) list of the most common normal-mode bindings. Type
-`:help` to open the online help for more details.
+This is a (non-exhaustive) list of the most common normal-mode bindings. Type `:help` to open the online help for more details.
 
-- `:` — activate the command line
-- `Shift` + `Insert` — enter "ignore mode". Press `Shift` + `Insert` again to
-  return to "normal mode".
-- `ZZ` — close all tabs and windows, but only "save" them if your
-  about:preferences are set to "show your tabs and windows from last time"
-- `.` — repeat the last command
+*   `:` — activate the command line
+*   `Shift` + `Insert` — enter "ignore mode". Press `Shift` + `Insert` again to return to "normal mode".
+*   `ZZ` — close all tabs and windows, but only "save" them if your about:preferences are set to "show your tabs and windows from last time"
+*   `.` — repeat the last command
 
 #### Navigating with the current page
 
-- `j`/`k` — scroll down/up
-- `h`/`l` — scroll left/right
-- `^`/`$` — scroll to left/right margin
-- `gg`/`G` — scroll to start/end of page
-- `f`/`F` — enter "hint mode" to select a link to follow. `F` to open in a
-  background tab (note: hint characters should be typed in lowercase)
-- `gi` — scroll to and focus the last-used input on the page
-- `r`/`R` — reload page or hard reload page
-- `yy` — copy the current page URL to the clipboard
-- `[[`/`]]` — navigate forward/backward though paginated pages, for example
-  comics, multi-part articles, search result pages, etc.
-- `]c`/`[c` — increment/decrement the current URL by 1
-- `gu` — go to the parent of the current URL
-- `gU` — go to the root domain of the current URL
-- `gr` — open Firefox reader mode (note: Tridactyl will not work in this mode)
-- `zi`/`zo`/`zz` — zoom in/out/reset zoom
+*   `j`/`k` — scroll down/up
+*   `h`/`l` — scroll left/right
+*   `^`/`$` — scroll to left/right margin
+*   `gg`/`G` — scroll to start/end of page
+*   `f`/`F` — enter "hint mode" to select a link to follow. `F` to open in a background tab (note: hint characters should be typed in lowercase)
+*   `gi` — scroll to and focus the last-used input on the page
+*   `r`/`R` — reload page or hard reload page
+*   `yy` — copy the current page URL to the clipboard
+*   `[[`/`]]` — navigate forward/backward though paginated pages, for example comics, multi-part articles, search result pages, etc.
+*   `]c`/`[c` — increment/decrement the current URL by 1
+*   `gu` — go to the parent of the current URL
+*   `gU` — go to the root domain of the current URL
+*   `gr` — open Firefox reader mode (note: Tridactyl will not work in this mode)
+*   `zi`/`zo`/`zz` — zoom in/out/reset zoom
 
 #### Find mode
 
-Find mode is still incomplete and uses the built-in Firefox search. This will
-be improved eventually.
+Find mode is still incomplete and uses the built-in Firefox search. This will be improved eventually.
 
-- `/` — open the find search box
-- `C-g`/`C-G` — find the next/previous instance of the last find operation
-  (note: these are the standard Firefox shortcuts)
+*   `/` — open the find search box
+*   `C-g`/`C-G` — find the next/previous instance of the last find operation (note: these are the standard Firefox shortcuts)
 
 #### Bookmarks and quickmarks
 
-- `A` — bookmark the current page
-- `a` — bookmark the current page, but allow the URL to be modified first
-- `M<key>` — bind a quickmark to the given key
-- `go<key>`/`gn<key>`/`gw<key>` — open a given quickmark in current tab/new tab/new window
+*   `A` — bookmark the current page
+*   `a` — bookmark the current page, but allow the URL to be modified first
+*   `M<key>` — bind a quickmark to the given key
+*   `go<key>`/`gn<key>`/`gw<key>` — open a given quickmark in current tab/new tab/new window
 
 #### Navigating to new pages:
 
-- `o`/`O` — open a URL (or default search) in this tab (`O` to pre-load current URL)
-- `t`/`T` — open a URL (or default search) in a new tab (`T` to pre-load current URL)
-- `w`/`W` — open a URL (or default search) in a new window (`W` to pre-load current URL)
-- `p`/`P` — open the clipboard contents in the current/new tab
-- `s`/`S` — force a search using the default Tridactyl search engine, opening
-  in the current/new tab. This is useful when searching for something that
-  would otherwise be treated as a URL by `o` or `t`
-- `H`/`L` — go back/forward in the tab history
-- `gh`/`gH` — go to the home page (in a new tab)
+*   `o`/`O` — open a URL (or default search) in this tab (`O` to pre-load current URL)
+*   `t`/`T` — open a URL (or default search) in a new tab (`T` to pre-load current URL)
+*   `w`/`W` — open a URL (or default search) in a new window (`W` to pre-load current URL)
+*   `p`/`P` — open the clipboard contents in the current/new tab
+*   `s`/`S` — force a search using the default Tridactyl search engine, opening in the current/new tab. This is useful when searching for something that would otherwise be treated as a URL by `o` or `t`
+*   `H`/`L` — go back/forward in the tab history
+*   `gh`/`gH` — go to the home page (in a new tab)
 
 #### Handling tabs
 
-- `d` — close the current tab
-- `u` — undo the last tab/window closure
-- `gt`/`gT` — go to the next/previous tab
-- `g^`/`g$` — go to the first/last tab
-- `b` — bring up a list of open tabs in the current window; you can type the
-  tab ID or part of the title or URL to choose a tab
+*   `d` — close the current tab
+*   `u` — undo the last tab/window closure
+*   `gt`/`gT` — go to the next/previous tab
+*   `g^`/`g$` — go to the first/last tab
+*   `b` — bring up a list of open tabs in the current window; you can type the tab ID or part of the title or URL to choose a tab
 
 #### Extended hint mode
 
 Extended hint modes allow you to perform actions on page items:
 
-- `;i`/`;I` — open an image (in current/new tab)
-- `;s`/`;a` — save/save-as the linked resource
-- `;S`/`;A` — save/save-as the selected image
-- `;p` — copy an element's text to the clipboard
-- `;P` — copy an element's title/alt text to the clipboard
-- `;y` — copy an element's link URL to the clipboard
-- `;#` — copy an element's anchor URL to the clipboard
-- `;r` — read the element's text with text-to-speech
-- `;k` — delete an element from the page
-- `;;` — focus an element
+*   `;i`/`;I` — open an image (in current/new tab)
+*   `;s`/`;a` — save/save-as the linked resource
+*   `;S`/`;A` — save/save-as the selected image
+*   `;p` — copy an element's text to the clipboard
+*   `;P` — copy an element's title/alt text to the clipboard
+*   `;y` — copy an element's link URL to the clipboard
+*   `;#` — copy an element's anchor URL to the clipboard
+*   `;r` — read the element's text with text-to-speech
+*   `;k` — delete an element from the page
+*   `;;` — focus an element
 
-Additionally, you can bind to a custom CSS selector with `:hint -c [selector]`
-which is useful for site-specific versions of the standard `f` hint mode.
+Additionally, you can bind to a custom CSS selector with `:hint -c [selector]` which is useful for site-specific versions of the standard `f` hint mode.
 
 ### Binding custom commands
 
-You can bind your own shortcuts in normal mode with the `:bind` command.
-For example `:bind J tabprev` to bind `J` to switch to the previous tab.
-See `:help bind` for details about this command.
+You can bind your own shortcuts in normal mode with the `:bind` command. For example `:bind J tabprev` to bind `J` to switch to the previous tab. See `:help bind` for details about this command.
 
 ## WebExtension-related issues
 
-- Navigation to any about:\* pages using `:open` requires the native messenger.
-- Firefox will not load Tridactyl on about:\*, some file:\* URIs, view-source:\*, or data:\*. On these pages Ctrl-L (or F6), Ctrl-Tab and Ctrl-W are your escape hatches.
-    - addons.mozilla.org is now supported so long as you run `fixamo` first.
-- Tridactyl now supports changing the Firefox GUI if you have the native messenger installed via `guiset`. There's quite a few options available, but `guiset gui none` is probably what you want, perhaps followed up with `guiset tabs always`.
+*   Navigation to any about:\* pages using `:open` requires the native messenger.
+*   Firefox will not load Tridactyl on about:\*, some file:\* URIs, view-source:\*, or data:\*. On these pages Ctrl-L (or F6), Ctrl-Tab and Ctrl-W are your escape hatches.
+    *   addons.mozilla.org is now supported so long as you run `fixamo` first.
+*   Tridactyl now supports changing the Firefox GUI if you have the native messenger installed via `guiset`. There's quite a few options available, but `guiset gui none` is probably what you want, perhaps followed up with `guiset tabs always`.
 
 ## Frequently asked questions
 
-- Why doesn't Tridactyl respect my search engine settings?
+*   Why doesn't Tridactyl respect my search engine settings?
 
     It's a webextension limitation. Firefox doesn't allow reading user preferences.
 
-- How can I change the search engine?
+*   How can I change the search engine?
 
     `set searchengine duckduckgo`
 
-- How can I add a search engine?
+*   How can I add a search engine?
 
     `set searchurls.esa http://www.esa.int/esasearch?q=`
 
@@ -145,25 +128,25 @@ See `:help bind` for details about this command.
 
     after which `open phrasebook [fr|de|la|es|hi|it...]` will work as expected.
 
-- Can I import/export settings, and does Tridactyl use an external configuration file just like Vimperator?
+*   Can I import/export settings, and does Tridactyl use an external configuration file just like Vimperator?
 
     Yes, if you have `native` working, `$XDG_CONFIG_DIR/tridactyl/tridactylrc` or `~/.tridactylrc` will be read at startup via an `autocmd` and `source`. There is an [example file available on our repository](https://github.com/cmcaine/tridactyl/blob/master/.tridactylrc).
 
-    If you can't use the native messenger for some reason, there is a workaround: if you do `set storageloc local`, a JSON file will appear at `<your firefox profile>\browser-extension-data\tridactyl.vim@cmcaine.co.uk\storage.js`. You can find your profile folder by going to `about:support`. You can edit this file to your heart's content. 
+    If you can't use the native messenger for some reason, there is a workaround: if you do `set storageloc local`, a JSON file will appear at `<your firefox profile>\browser-extension-data\tridactyl.vim@cmcaine.co.uk\storage.js`. You can find your profile folder by going to `about:support`. You can edit this file to your heart's content.
 
-- I hate the light, can I get a dark theme/dark mode?
+*   I hate the light, can I get a dark theme/dark mode?
 
     Yes: `set theme dark` or `colors dark`. Thanks to @fugerf.
 
-- How can I pretend that I'm not a 1337 h4x0r?
+*   How can I pretend that I'm not a 1337 h4x0r?
 
     We cater for you, too! `set theme shydactyl`. Thanks to @atrnh.
 
-- How can I pretend that I'm a 1337 h4x0r?
+*   How can I pretend that I'm a 1337 h4x0r?
 
     We cater for you, too! `set theme greenmat`. Thanks to @caputchinefrobles.
 
-- How can I bind keys using the control/alt key modifiers (eg: `ctrl+^`)?
+*   How can I bind keys using the control/alt key modifiers (eg: `ctrl+^`)?
 
     `:bind <C-f> scrollpage 1`. Special keys can be bound too: `:bind <F3> set theme dark` and with modifiers: `:bind <S-F3> set theme default` and with multiple modifiers: `:bind <SA-F3> composite set hintchars 1234567890 | set hintfiltermode vimperator-reflow`
 
@@ -171,54 +154,53 @@ See `:help bind` for details about this command.
 
     If you want to bind <C-^> you'll find that you'll probably need to press Control+Shift+6 to trigger it. The default bind is <C-6> which does not require you to press shift.
 
-- How can I tab complete from bookmarks?
+*   How can I tab complete from bookmarks?
 
-    `bmarks `. Bookmarks are not currently supported on `*open`: see [issue #214](https://github.com/cmcaine/tridactyl/issues/214).
+    `bmarks`. Bookmarks are not currently supported on `*open`: see [issue #214](https://github.com/cmcaine/tridactyl/issues/214).
 
-- When I type 'f', can I type link names (like Vimperator) in order to narrow down the number of highlighted links?
+*   When I type 'f', can I type link names (like Vimperator) in order to narrow down the number of highlighted links?
 
     You can, thanks to @saulrh. First `set hintfiltermode vimperator` and then `set hintchars 1234567890`.
 
-- How to remap keybindings in both normal mode and ex mode?
+*   How to remap keybindings in both normal mode and ex mode?
 
     You cannot. We only support normal mode bindings for now, with `bind [key] [excmd]`
 
-- Where can I find a changelog for the different versions (to see what is new in the latest version)?
+*   Where can I find a changelog for the different versions (to see what is new in the latest version)?
 
     [Here.](https://github.com/cmcaine/tridactyl/blob/master/CHANGELOG.md)
 
-- Why can't I use my bookmark keywords?
+*   Why can't I use my bookmark keywords?
 
     Mozilla doesn't give us access to them. See [issue #73](https://github.com/cmcaine/tridactyl/issues/73).
 
-- Why doesn't Tridactyl work on websites with frames?
+*   Why doesn't Tridactyl work on websites with frames?
 
     It should work on some frames now. See [#122](https://github.com/cmcaine/tridactyl/issues/122).
 
-- Can I change proxy via commands?
+*   Can I change proxy via commands?
 
     Not yet, but this feature will eventually be implemented.
 
-- How do I disable Tridactyl on certain sites?
+*   How do I disable Tridactyl on certain sites?
 
     You can't yet, see [#158](https://github.com/cmcaine/tridactyl/issues/158).
 
-- How can I list the current bindings?
+*   How can I list the current bindings?
 
     `viewconfig nmaps` works OK, but Tridactyl commands won't work on the shown page for "security reasons". We'll eventually provide a better way. See [#98](https://github.com/cmcaine/tridactyl/issues/98).
 
-- Why doesn't Tridactyl work on some pages?
+*   Why doesn't Tridactyl work on some pages?
 
-    One possible reason is that the site has a strict content security policy. We can rewrite these to make Tridactyl work, but we do not want to worsen the security of sensitive pages, so it is taking us a little while. See [#112](https://github.com/cmcaine/tridactyl/issues/112).
+One possible reason is that the site has a strict content security policy. We can rewrite these to make Tridactyl work, but we do not want to worsen the security of sensitive pages, so it is taking us a little while. See [#112](https://github.com/cmcaine/tridactyl/issues/112).
 
-- How can I know which mode I'm in/have a status line?
+*   How can I know which mode I'm in/have a status line?
 
     Press `j` and see if you scroll down :) There's no status line yet: see [#210](https://github.com/cmcaine/tridactyl/issues/210), but we do have a "mode indicator" in the bottom right. It even goes purple when you're in a private window :).
 
-- Does anyone actually use Tridactyl?
+*   Does anyone actually use Tridactyl?
 
     In addition to the developers, some other people do. Mozilla keeps tabs on them [here](https://addons.mozilla.org/en-US/firefox/addon/tridactyl-vim/statistics/?last=30).
-
 
 ## Contributing
 
@@ -250,13 +232,14 @@ If you want to build a signed copy (e.g. for the non-developer release), you can
 
 #### Building on Windows
 
-  - Install [Git for Windows][win-git]
+*   Install [Git for Windows][win-git]
 
-  - Install [NodeJS for Windows][win-nodejs]
-      - Current 8.11.1 LTS seems to work fine
+*   Install [NodeJS for Windows][win-nodejs]
 
-  - Launch the installation steps described above from MinTTY shell
-      - Also known as "Git Bash"
+    *   Current 8.11.1 LTS seems to work fine
+
+*   Launch the installation steps described above from MinTTY shell
+    *   Also known as "Git Bash"
 
 [win-git]: https://git-scm.com/download/win
 [win-nodejs]: https://nodejs.org/dist/v8.11.1/node-v8.11.1-x64.msi
@@ -268,6 +251,7 @@ npm run build & npm run run
 ```
 
 <!-- This will compile and deploy your files each time you save them. -->
+
 You'll need to run `npm run build` every time you edit the files, and press "r" in the `npm run run` window to make sure that the files are properly reloaded.
 
 ### Committing
@@ -280,24 +264,24 @@ Ask in `#tridactyl` on [matrix.org][matrix-link], freenode, or [gitter][gitter-l
 
 Default keybindings are currently best discovered by reading the [default config](./src/config.ts).
 
-Development notes are in the doc directory, but they're mostly out of date now. Code is quite short and not *too* badly commented, though.
+Development notes are in the doc directory, but they're mostly out of date now. Code is quite short and not _too_ badly commented, though.
 
 ## Principles and objectives
 
 Principles:
 
-* Keyboard > mouse
-* default keybinds should be Vim-like
-* actions should be composable and repeatable
-* ex mode should expose all the browser functionality anyone might want
-* Arguable: most (all?) actions should have an ex mode version (departure from Vim?)
-* users can map and define their own actions and commands
+*   Keyboard > mouse
+*   default keybinds should be Vim-like
+*   actions should be composable and repeatable
+*   ex mode should expose all the browser functionality anyone might want
+*   Arguable: most (all?) actions should have an ex mode version (departure from Vim?)
+*   users can map and define their own actions and commands
 
 Other objectives:
 
-* be fast - the whole point of a keyboard interface is to be more efficient, don't compromise that with slow code
-* don't crash - we're the new UI and we shouldn't crash
-* be maintainable - code should be well documented, reasoned about and tested.
+*   be fast - the whole point of a keyboard interface is to be more efficient, don't compromise that with slow code
+*   don't crash - we're the new UI and we shouldn't crash
+*   be maintainable - code should be well documented, reasoned about and tested.
 
 ## Logo acknowledgement
 

--- a/scripts/common
+++ b/scripts/common
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cachedJS() {
-    git diff --cached --name-only --diff-filter=ACM "*.js" "*.jsx" "*.ts" "*.tsx" | tr '\n' ' '
+    git diff --cached --name-only --diff-filter=ACM "*.js" "*.jsx" "*.ts" "*.tsx" "*.md" | tr '\n' ' '
 }
 
 staged() {

--- a/src/static/clippy/command_mode.md
+++ b/src/static/clippy/command_mode.md
@@ -2,19 +2,19 @@
 
 Command mode, i.e, "the console", is used for accessing less frequently used commands, such as:
 
-- `tabdetach` to detach the current tab into a new window
-- `bind [key] [excommand]` to bind keys
-- `viewsource` to view the current page's source
-- `viewconfig nmaps` to view the current normal mode bindings
-- `help [command]` to access help on a command
-- `composite [command 1]; [command 2]; [command 3]...` lets you execute commands sequentially, useful for binding. If you want the results of each command to be piped to the other, use pipes `|` instead of semi-colons.
+*   `tabdetach` to detach the current tab into a new window
+*   `bind [key] [excommand]` to bind keys
+*   `viewsource` to view the current page's source
+*   `viewconfig nmaps` to view the current normal mode bindings
+*   `help [command]` to access help on a command
+*   `composite [command 1]; [command 2]; [command 3]...` lets you execute commands sequentially, useful for binding. If you want the results of each command to be piped to the other, use pipes `|` instead of semi-colons.
 
 We support a handful of keybinds in the console:
 
-- `Ctrl-C` to exit to normal mode, or copy selected text.
-- `Up`/`Down` to search in command history: e.g. `:tabopen` `Up` will show you the most recent tabopen command.
-- `Tab`/`Shift-Tab` cycle completion, enter to select
-- `Ctrl-F` to complete the command from command history
-- `Space` to insert the URL of the highlighted completion into the command line
+*   `Ctrl-C` to exit to normal mode, or copy selected text.
+*   `Up`/`Down` to search in command history: e.g. `:tabopen` `Up` will show you the most recent tabopen command.
+*   `Tab`/`Shift-Tab` cycle completion, enter to select
+*   `Ctrl-F` to complete the command from command history
+*   `Space` to insert the URL of the highlighted completion into the command line
 
 The [next page](./settings.html) will talk about the various settings available.

--- a/src/static/clippy/help.md
+++ b/src/static/clippy/help.md
@@ -1,10 +1,10 @@
 # Getting help
 
-You can get help about any command by typing `help [command]` in command mode. Additionally, 
+You can get help about any command by typing `help [command]` in command mode. Additionally,
 
-- If you want to know what a key is bound to, you can simply type `bind [key]` and you will be told the ex command.
-- You can view all of your config on `viewconfig` (but Tridactyl can't run on this page: `Alt-LeftArrow` will get you back to your previous page).
-- If you want to know the value of a setting, `get [setting]`, for example `get nmaps`.
+*   If you want to know what a key is bound to, you can simply type `bind [key]` and you will be told the ex command.
+*   You can view all of your config on `viewconfig` (but Tridactyl can't run on this page: `Alt-LeftArrow` will get you back to your previous page).
+*   If you want to know the value of a setting, `get [setting]`, for example `get nmaps`.
 
 Lastly, you can contact the developers via Matrix or GitHub, as mentioned on the new tab page.
 

--- a/src/static/clippy/hint_mode.md
+++ b/src/static/clippy/hint_mode.md
@@ -4,11 +4,11 @@ There are many different hint submodes. They all follow a similar pattern: hinti
 
 Here are some of the most useful hint modes:
 
-- `:hint -b` or `F`: open link in background
-- `:hint -y` or `;y`: copy link location to clipboard
-- `:hint -p` or `;p`: copy element text (such as a paragraph) to clipboard
-- `:hint -#` or `;#`: copy anchor location. Useful for linking someone to a specific part of a page.
-- `:hint -k` or `;k`: kill an element. Very satisfying.
+*   `:hint -b` or `F`: open link in background
+*   `:hint -y` or `;y`: copy link location to clipboard
+*   `:hint -p` or `;p`: copy element text (such as a paragraph) to clipboard
+*   `:hint -#` or `;#`: copy anchor location. Useful for linking someone to a specific part of a page.
+*   `:hint -k` or `;k`: kill an element. Very satisfying.
 
 If there is ever only a single hint remaining (for example, because you have wittled them down, or there is only a single link visible on the page) the hint mode will follow it automatically.
 

--- a/src/static/clippy/normal_mode.md
+++ b/src/static/clippy/normal_mode.md
@@ -12,20 +12,19 @@ Many keypresses in normal mode take you into another mode. `t`, for example, put
 
 ## Useful normal mode keybinds
 
-- `b` brings up a list of your current tabs. Press `Tab`/`Shift-Tab` to cycle through them and enter to select. You can also type to filter down the tabs based on their titles and URLs
-- Opening web pages:
-    - `w` opens URLs in new windows
-    - `o` in the current tab
-    - `t` in a new tab
-    - Using a capital letter in place of any of the previous commands opens the command with the current URL pasted into it, i.e, `W`,`O`,`T`
-    - `s` lets you search easily
-    - in general, you can search many search engines straight from these prompts by simply starting your query with the search engine, such as `bing` `duckduckgo` or `scholar`
-- Navigate history with `H` and `L`
-- `yy` copies the current URL to your clipboard
-- `p` opens the clipboard contents as a web page, or searches for it, in the current tab. `P` opens it in a new tab
-    - Protip: quickly search for the source of a quote by using `;p` to copy a paragraph, and `P` to search the internet for it
-- `zi`,`zo`,`zz` zoom in, out and return to the default zoom
-
+*   `b` brings up a list of your current tabs. Press `Tab`/`Shift-Tab` to cycle through them and enter to select. You can also type to filter down the tabs based on their titles and URLs
+*   Opening web pages:
+    *   `w` opens URLs in new windows
+    *   `o` in the current tab
+    *   `t` in a new tab
+    *   Using a capital letter in place of any of the previous commands opens the command with the current URL pasted into it, i.e, `W`,`O`,`T`
+    *   `s` lets you search easily
+    *   in general, you can search many search engines straight from these prompts by simply starting your query with the search engine, such as `bing` `duckduckgo` or `scholar`
+*   Navigate history with `H` and `L`
+*   `yy` copies the current URL to your clipboard
+*   `p` opens the clipboard contents as a web page, or searches for it, in the current tab. `P` opens it in a new tab
+    *   Protip: quickly search for the source of a quote by using `;p` to copy a paragraph, and `P` to search the internet for it
+*   `zi`,`zo`,`zz` zoom in, out and return to the default zoom
 
 All the keys in normal mode are bound to commands; for example, `j` is bound to `scrolline 10`. If you are ever curious as to what a key sequence does in normal mode, you can simply use `:bind [keys]` and the command line will tell you to which command they are bound.
 

--- a/src/static/clippy/settings.md
+++ b/src/static/clippy/settings.md
@@ -6,16 +6,16 @@ Currently, you can view settings on `help` next to the commands that they affect
 
 Here we will briefly summarise some of the main settings:
 
-- nmaps
-    - these are all of the keybinds in normal mode
-- searchengine
-    - the default search engine to use. You can choose any from the searchurls setting, or add your own.
-- hintfiltermode
-    - the style of hint mode to use. Set it to "vimperator" to filter links by typing in the text they display
-    - You will also want to change the hintchars setting to something that allows you to type in most text, e.g, 5432167890.
-- theme
-    - dark or default
-- excmds
-    - aliases for command mode: the things on the left actually run the commands on the right. The most interesting one of these is `current_url`, which is how the binds for O, W and T (`bind T`) work.
+*   nmaps
+    *   these are all of the keybinds in normal mode
+*   searchengine
+    *   the default search engine to use. You can choose any from the searchurls setting, or add your own.
+*   hintfiltermode
+    *   the style of hint mode to use. Set it to "vimperator" to filter links by typing in the text they display
+    *   You will also want to change the hintchars setting to something that allows you to type in most text, e.g, 5432167890.
+*   theme
+    *   dark or default
+*   excmds
+    *   aliases for command mode: the things on the left actually run the commands on the right. The most interesting one of these is `current_url`, which is how the binds for O, W and T (`bind T`) work.
 
 The <a href='./help.html' rel='next'>final page</a> describes how you can get further help.

--- a/src/static/clippy/tutor.md
+++ b/src/static/clippy/tutor.md
@@ -12,21 +12,21 @@ It will not cover advanced topics. For those, [`:help`](../docs/modules/_excmds_
 
 The idea behind Tridactyl is to allow you to navigate the web more efficiently with just the keyboard. Tridactyl turns Firefox into a modal browser, meaning it has several different modes of operation, like Vim. It can only ever be in one mode at a time, and each of these modes could have a wildly different operation. You can think of it a bit like a Transformer, if you like. There are four main modes you will want to be familiar with:
 
-- Normal mode
-    - This mode is used for navigating around single pages and starting other modes.
-    - You are usually in this mode. You can enter normal mode from the other modes by pressing `Escape`.
-- Hint mode
-    - This mode highlights elements on the web page and performs actions on those elements.
-    - This is most often used for following links, but it has many other submodes.
-    - You can enter this mode with `f` and exit it with `Escape` or `Enter`.
-    - Hint characters are displayed as uppercase letters, but you should type the lowercase letter.
-- Command mode ("ex-mode")
-    - This mode allows you to execute more complicated commands by typing them out manually.
-    - It is commonly used for binding keys and accessing help.
-    - You can enter this mode with `:` and exit it with `Escape` or `Enter`.
-- Ignore mode
-    - This mode passes all keypresses through to the web page. It is useful for websites that have their own keybinds, such as games and Gmail.
-    - You can toggle the mode with `Shift-Insert`.
+*   Normal mode
+    *   This mode is used for navigating around single pages and starting other modes.
+    *   You are usually in this mode. You can enter normal mode from the other modes by pressing `Escape`.
+*   Hint mode
+    *   This mode highlights elements on the web page and performs actions on those elements.
+    *   This is most often used for following links, but it has many other submodes.
+    *   You can enter this mode with `f` and exit it with `Escape` or `Enter`.
+    *   Hint characters are displayed as uppercase letters, but you should type the lowercase letter.
+*   Command mode ("ex-mode")
+    *   This mode allows you to execute more complicated commands by typing them out manually.
+    *   It is commonly used for binding keys and accessing help.
+    *   You can enter this mode with `:` and exit it with `Escape` or `Enter`.
+*   Ignore mode
+    *   This mode passes all keypresses through to the web page. It is useful for websites that have their own keybinds, such as games and Gmail.
+    *   You can toggle the mode with `Shift-Insert`.
 
 Almost all of the modes are controlled by series of keypresses. In this tutorial, a sequence of keys such as `zz` should be entered by pressing the key `z`, letting go, and then pressing the key `z`. There is no need to hold both keys at once, if that were even possible. (`zz` resets the zoom level to the default, so it probably didn't seem to do anything). Sometimes `help` refers to a command that must be entered in command mode; it should hopefully always be clear from context which we mean.
 

--- a/src/static/newtab.md
+++ b/src/static/newtab.md
@@ -4,47 +4,46 @@
 
 Tridactyl has to override your new tab page due to WebExtension limitations. You can learn how to change it at the bottom of the page, otherwise please read on for some tips and tricks.
 
-- You can view the main help page by typing [`:help`][help], and access the tutorial with [`:tutor`][tutor].
+*   You can view the main help page by typing [`:help`][help], and access the tutorial with [`:tutor`][tutor].
 
-- You can view your current configuration with `:viewconfig`.
+*   You can view your current configuration with `:viewconfig`.
 
-- You can contact the developers, other users and contributors for support or whatever on [Matrix][matrix-link], [Gitter][gitter-link], or [IRC][freenode-link].
+*   You can contact the developers, other users and contributors for support or whatever on [Matrix][matrix-link], [Gitter][gitter-link], or [IRC][freenode-link].
 
-- If you're enjoying Tridactyl (or not), please leave a review on [addons.mozilla.org][amo].
+*   If you're enjoying Tridactyl (or not), please leave a review on [addons.mozilla.org][amo].
 
-- **Breaking change to `composite`:** composite now tries to pass the return value from each preceding function to its ancestor. This might break some of your binds to composite, or cause them to act in unexpected ways.
-- **NB:** Tridactyl can now run external programs on Linux and OSX if you decide to install an additional executable. Just run `:installnative` to get going, and then Ctrl-i `<C-i>` in a text box to open your editor.
-
+*   **Breaking change to `composite`:** composite now tries to pass the return value from each preceding function to its ancestor. This might break some of your binds to composite, or cause them to act in unexpected ways.
+*   **NB:** Tridactyl can now run external programs on Linux and OSX if you decide to install an additional executable. Just run `:installnative` to get going, and then Ctrl-i `<C-i>` in a text box to open your editor.
 
 REPLACE_ME_WITH_THE_CHANGE_LOG_USING_SED
 
 ## Highlighted features:
 
-- `f`/`F` — enter the "hint mode" to select a link to follow. `F` to open it in a background tab. (Note: hint characters should be typed in lowercase.)
-- `Shift` + `Insert` — enter "ignore mode" to send all key presses to the web page you are on. Press `Shift` + `Insert` again to return to the highly productive "normal mode".
-- `H`/`L` — go back/forward in the history.
-- `o`/`O` — open a URL in this tab (`O` to pre-load current URL).
-- `t`/`T` — open a URL in a new tab (`T` to pre-load current URL).
-- `gt`/`gT` — go to the next/previous tab.
-- `d` — close the current tab.
-- `/` — open the find search box.
-- `A` — bookmark the current page
-- `b` — bring up a list of open tabs in the current window.
-- `s` — if you want to search for something that looks like a domain name or URL.
-- `gi` — scroll to and focus the last-used input on the page.
-- `gr` — open Firefox reader mode (note: Tridactyl will not work in this mode).
-- Bind your own commands with, e.g., `:bind J tabprev`. Type `:help bind` to see help on custom binds.
-- `yy` — copy the current page URL to your clipboard.
-- `[[`/`]]` — navigate forward/backward though paginated pages.
-- `ZZ` — close all tabs and windows, but it will only "save" them if your about:preferences are set to "show your tabs and windows from last time".
-- [`:help hint`][help-hint] to see all the other useful hint modes (this is the `f` magic. :) ).
+*   `f`/`F` — enter the "hint mode" to select a link to follow. `F` to open it in a background tab. (Note: hint characters should be typed in lowercase.)
+*   `Shift` + `Insert` — enter "ignore mode" to send all key presses to the web page you are on. Press `Shift` + `Insert` again to return to the highly productive "normal mode".
+*   `H`/`L` — go back/forward in the history.
+*   `o`/`O` — open a URL in this tab (`O` to pre-load current URL).
+*   `t`/`T` — open a URL in a new tab (`T` to pre-load current URL).
+*   `gt`/`gT` — go to the next/previous tab.
+*   `d` — close the current tab.
+*   `/` — open the find search box.
+*   `A` — bookmark the current page
+*   `b` — bring up a list of open tabs in the current window.
+*   `s` — if you want to search for something that looks like a domain name or URL.
+*   `gi` — scroll to and focus the last-used input on the page.
+*   `gr` — open Firefox reader mode (note: Tridactyl will not work in this mode).
+*   Bind your own commands with, e.g., `:bind J tabprev`. Type `:help bind` to see help on custom binds.
+*   `yy` — copy the current page URL to your clipboard.
+*   `[[`/`]]` — navigate forward/backward though paginated pages.
+*   `ZZ` — close all tabs and windows, but it will only "save" them if your about:preferences are set to "show your tabs and windows from last time".
+*   [`:help hint`][help-hint] to see all the other useful hint modes (this is the `f` magic. :) ).
 
 ## Important limitations due to WebExtensions
 
-- You can only navigate to most about:*\file:* pages if you have Tridactyl's native executable installed.
-- Firefox will not load Tridactyl on addons.mozilla.org, about:\*, some file:\* URIs, view-source:\*, or data:\*. On these pages Ctrl-L (or F6), Ctrl-Tab and Ctrl-W are your escape hatches.
-- You can change the Firefox GUI with `guiset` (e.g. `guiset gui none` and then `restart`) if you have the native messenger installed, or you can do it yourself by changing your userChrome. There is an example file available on our repository [[2]].
-- Tridactyl cannot capture key presses until web pages are loaded. You can use `:reloadall` to reload all tabs to make life more bearable, or flip `browser.sessionstore.restore_tabs_lazily` to false in `about:config`.
+*   You can only navigate to most about:_\file:_ pages if you have Tridactyl's native executable installed.
+*   Firefox will not load Tridactyl on addons.mozilla.org, about:\*, some file:\* URIs, view-source:\*, or data:\*. On these pages Ctrl-L (or F6), Ctrl-Tab and Ctrl-W are your escape hatches.
+*   You can change the Firefox GUI with `guiset` (e.g. `guiset gui none` and then `restart`) if you have the native messenger installed, or you can do it yourself by changing your userChrome. There is an example file available on our repository [[2]].
+*   Tridactyl cannot capture key presses until web pages are loaded. You can use `:reloadall` to reload all tabs to make life more bearable, or flip `browser.sessionstore.restore_tabs_lazily` to false in `about:config`.
 
 ## Why do I see this here?
 
@@ -52,8 +51,8 @@ Tridactyl overrides your newtab page because it cannot insert its content script
 
 ### How can I get rid of it?
 
-- `:set newtab [URL]`
-    - e.g, `:set newtab about:blank`
+*   `:set newtab [URL]`
+    *   e.g, `:set newtab about:blank`
 
 ## FAQ
 


### PR DESCRIPTION
I ran `prettier` on all of the `.md` files in the repository. Pretter appears to have made the following changes:

- Remove all hard-wraps
- Change list formatting
- Fix spacing around headers/paragraphs

This should make all of the docs consistently formatted.

Is there anywhere that I should mention that people should run `prettier` on their documentation before committing?