### PR TITLE
Prettier compliance for CSS

### DIFF
--- a/scripts/common
+++ b/scripts/common
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cachedJS() {
-    git diff --cached --name-only --diff-filter=ACM "*.js" "*.jsx" "*.ts" "*.tsx" "*.md" | tr '\n' ' '
+    git diff --cached --name-only --diff-filter=ACM "*.js" "*.jsx" "*.ts" "*.tsx" "*.md" "*.css" | tr '\n' ' '
 }
 
 staged() {

--- a/src/static/css/authors.css
+++ b/src/static/css/authors.css
@@ -1,61 +1,63 @@
 /* From https://css-tricks.com/snippets/css/star-wars-crawl-text/ */
 body {
-  width: 100%;
-  height: 100%;
-  background: #000;
-  overflow: hidden;
+    width: 100%;
+    height: 100%;
+    background: #000;
+    overflow: hidden;
 }
 
-* { text-align: left !important }
+* {
+    text-align: left !important;
+}
 
 .fade {
-  position: relative;
-  width: 100%;
-  min-height: 60vh;
-  top: -25px;
-  background-image: linear-gradient(0deg, transparent, black 75%);
-  z-index: 1;
+    position: relative;
+    width: 100%;
+    min-height: 60vh;
+    top: -25px;
+    background-image: linear-gradient(0deg, transparent, black 75%);
+    z-index: 1;
 }
 
 .star-wars {
-  display: flex;
-  justify-content: center;
-  position: relative;
-  height: 800px;
-  color: #feda4a;
-  font-family: 'Pathway Gothic One', sans-serif;
-  font-size: 500%;
-  font-weight: 600;
-  letter-spacing: 6px;
-  line-height: 150%;
-  perspective: 400px;
-  text-align: justify;
+    display: flex;
+    justify-content: center;
+    position: relative;
+    height: 800px;
+    color: #feda4a;
+    font-family: "Pathway Gothic One", sans-serif;
+    font-size: 500%;
+    font-weight: 600;
+    letter-spacing: 6px;
+    line-height: 150%;
+    perspective: 400px;
+    text-align: justify;
 }
 
 .crawl {
-  position: relative;
-  top: 9999px;
-  transform-origin: 50% 100%;
-  animation: crawl 90s linear;
+    position: relative;
+    top: 9999px;
+    transform-origin: 50% 100%;
+    animation: crawl 90s linear;
 }
 
 .crawl > .title {
-  font-size: 90%;
-  text-align: center;
+    font-size: 90%;
+    text-align: center;
 }
 
 .crawl > .title h1 {
-  margin: 0 0 100px;
-  text-transform: uppercase;
+    margin: 0 0 100px;
+    text-transform: uppercase;
 }
 
 @keyframes crawl {
-  0% {
-    top: 0;
-    transform: rotateX(20deg)  translateZ(0);
-  }
-  100% { 
-    top: -25000px;
-    transform: rotateX(25deg) translateZ(-10000px);
-  }
+    0% {
+        top: 0;
+        transform: rotateX(20deg) translateZ(0);
+    }
+    100% {
+        top: -25000px;
+        transform: rotateX(25deg) translateZ(-10000px);
+    }
 }

--- a/src/static/css/commandline.css
+++ b/src/static/css/commandline.css
@@ -32,8 +32,8 @@ input {
     /* border-top: solid 1px lightgray; */
 }
 
-#tridactyl-colon::before{
-    content: ":"
+#tridactyl-colon::before {
+    content: ":";
 }
 
 /* COMPLETIONS */
@@ -89,10 +89,17 @@ input {
     table-layout: fixed;
 }
 
-#completions table tr td:nth-of-type(1) { width: 1.5em; padding-left: 0.5em}
-#completions table tr td:nth-of-type(2) { width: 1.5em; }
+#completions table tr td:nth-of-type(1) {
+    width: 1.5em;
+    padding-left: 0.5em;
+}
+#completions table tr td:nth-of-type(2) {
+    width: 1.5em;
+}
 /* #completions table tr td:nth-of-type(3) { width: 5em; } */
-#completions table tr td:nth-of-type(4) { width: 50%; }
+#completions table tr td:nth-of-type(4) {
+    width: 50%;
+}
 
 #completions table tr {
     white-space: nowrap;
@@ -111,16 +118,18 @@ input {
 }
 
 #completions .sectionHeader {
-    background: linear-gradient( 
-    var(--tridactyl-header-first-bg), 
-    var(--tridactyl-header-second-bg), 
-    var(--tridactyl-header-third-bg));
+    background: linear-gradient(
+        var(--tridactyl-header-first-bg),
+        var(--tridactyl-header-second-bg),
+        var(--tridactyl-header-third-bg)
+    );
     font-weight: var(--tridactyl-header-font-weight);
     border-bottom: var(--tridactyl-header-border-bottom);
     padding-left: 0.5ex;
 }
 
-#completions .sectionHeader, #completions .option {
+#completions .sectionHeader,
+#completions .option {
     height: var(--option-height);
     line-height: var(--option-height);
 }
@@ -157,7 +166,8 @@ a.url:hover {
 }
 
 /* Pick the .url out especially because otherwise its link styles dominate. */
-.focused, .focused .url {
+.focused,
+.focused .url {
     color: var(--tridactyl-of-fg);
     background: var(--tridactyl-of-bg);
 }

--- a/src/static/css/content.css
+++ b/src/static/css/content.css
@@ -37,7 +37,6 @@
     background: #f9f5ff !important;
 }
 
-
 @media print {
     .TridactylStatusIndicator {
         display: none !important;

--- a/src/static/css/hint.css
+++ b/src/static/css/hint.css
@@ -8,14 +8,15 @@ span.TridactylHint {
     background-color: var(--tridactyl-hintspan-bg) !important;
     border-color: var(--tridactyl-hintspan-border-color) !important;
     border-width: var(--tridactyl-hintspan-border-width) !important;
-    min-width: .75em !important;
+    min-width: 0.75em !important;
     border-style: var(--tridactyl-hintspan-border-style) !important;
     padding: 0 1pt !important;
     text-align: center !important;
     z-index: 2147483647 !important;
 }
 
-.TridactylHintElem, .TridactylHintActive {
+.TridactylHintElem,
+.TridactylHintActive {
     color: var(--tridactyl-hint-active-fg) !important !important;
     animation: none !important;
     transition: unset !important;

--- a/src/static/css/newtab.css
+++ b/src/static/css/newtab.css
@@ -8,46 +8,45 @@ body {
     margin: auto;
 }
 
-input[id^="spoiler"]{
- display: none;
+input[id^="spoiler"] {
+    display: none;
 }
 
 /* Borrowed from https://codepen.io/oloman/pen/odnqy */
 input[id^="spoiler"] + label {
-  display: block;
-  width: 8em;
-  margin: 0 auto;
-  padding: 0.25em, 0.25em;
-  background: #1f9947;
-  color: #fff;
-  text-align: center;
-  font-size: 12pt;
-  border-radius: 2px;
-  cursor: pointer;
-  transition: all .6s;
+    display: block;
+    width: 8em;
+    margin: 0 auto;
+    padding: 0.25em, 0.25em;
+    background: #1f9947;
+    color: #fff;
+    text-align: center;
+    font-size: 12pt;
+    border-radius: 2px;
+    cursor: pointer;
+    transition: all 0.6s;
 }
 input[id^="spoiler"]:checked + label {
-  color: #333;
-  background: #ccc;
+    color: #333;
+    background: #ccc;
 }
 input[id^="spoiler"] ~ .spoiler {
-  height: 0;
-  overflow: hidden;
-  opacity: 0;
-  margin: 10px auto 0;
-  padding: 10px;
-  background: var(--tridactyl-highlight-box-bg);
-  color: var(--tridactyl-highlight-box-fg);
-  border: 1px solid #ccc;
-  border-radius: 2px;
-  transition: all .6s;
+    height: 0;
+    overflow: hidden;
+    opacity: 0;
+    margin: 10px auto 0;
+    padding: 10px;
+    background: var(--tridactyl-highlight-box-bg);
+    color: var(--tridactyl-highlight-box-fg);
+    border: 1px solid #ccc;
+    border-radius: 2px;
+    transition: all 0.6s;
 }
-input[id^="spoiler"]:checked + label + .spoiler{
-  height: auto;
-  opacity: 1;
-  padding: 10px;
+input[id^="spoiler"]:checked + label + .spoiler {
+    height: auto;
+    opacity: 1;
+    padding: 10px;
 }
-
 
 h1 {
     padding-top: 1em;
@@ -64,7 +63,8 @@ ul {
     padding-right: 20px;
 }
 
-p,li {
+p,
+li {
     hyphens: auto;
     text-align: justify;
 }
@@ -75,17 +75,17 @@ div.align-left * {
 }
 
 code {
-  background-color: rgba(27,31,35,0.05);
-  padding: 0.2em;
-  /* font-size: 85%; */
-  font-size: 10pt;
-  border-radius: 3px;
+    background-color: rgba(27, 31, 35, 0.05);
+    padding: 0.2em;
+    /* font-size: 85%; */
+    font-size: 10pt;
+    border-radius: 3px;
 }
 
 img {
-  max-width: 100%;
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-  padding-top: .5em;
+    max-width: 100%;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    padding-top: 0.5em;
 }

--- a/src/static/css/userChrome-minimal.css
+++ b/src/static/css/userChrome-minimal.css
@@ -21,7 +21,6 @@
  *
  */
 
-
 /* auto-hide the tab and navigation bar in a similar way to fullscreen mode */
 
 /* User config */
@@ -34,24 +33,30 @@
 }
 
 /* Hide grey container box */
-:root:not([customizing]) #navigator-toolbox:not(:hover):not(:focus-within) { 
+:root:not([customizing]) #navigator-toolbox:not(:hover):not(:focus-within) {
     max-height: 0;
-    min-height: calc(0px); /* I have no idea why just using 0 or 0px does not work... */
+    min-height: calc(
+        0px
+    ); /* I have no idea why just using 0 or 0px does not work... */
 }
 
 /* Auto hide tab bar */
-:root:not([customizing]) #navigator-toolbox:not(:hover):not(:focus-within) #TabsToolbar { 
+:root:not([customizing])
+    #navigator-toolbox:not(:hover):not(:focus-within)
+    #TabsToolbar {
     visibility: collapse;
 }
 
 /* Auto hide nav bar */
-:root:not([customizing]) #navigator-toolbox:not(:hover):not(:focus-within) #nav-bar {
+:root:not([customizing])
+    #navigator-toolbox:not(:hover):not(:focus-within)
+    #nav-bar {
     max-height: 0;
-    min-height: 0!important;
+    min-height: 0 !important;
     /* Use margin-bottom to allow trigger zones that are larger than the nav-bar */
     margin-bottom: calc(-1 * var(--tridactyl-auto-show-zone));
     opacity: 0;
-} 
+}
 
 /* Avoid transparent background for menubar if nav-toolbox not focussed */
 #navigator-toolbox:not(:hover):not(:focus-within) #toolbar-menubar > * {
@@ -59,30 +64,39 @@
     background-color: rgb(232, 232, 231);
 }
 
-
 /* Make top bar more compact */
 
 /* Make nav-bar thinner */
-#nav-bar{
+#nav-bar {
     padding-top: 1px !important;
     padding-bottom: 0 !important;
 }
 
 /* We need more padding when maximised (maybe just on Windows?) */
-#main-window[sizemode="maximized"] #nav-bar{
+#main-window[sizemode="maximized"] #nav-bar {
     padding-top: 7px !important;
 }
 
 /* Hide URL notifications that aren't particularly useful and cover up the command line
  * TODO: move it above the command line / bring functionality into status line like Vimperator */
-statuspanel[type="overLink"]{display: none !important;}
+statuspanel[type="overLink"] {
+    display: none !important;
+}
 
 /* Partial removal of black bottom 1px line shown in fullscreen mode */
-#navigator-toolbox::after { display: none !important; }
+#navigator-toolbox::after {
+    display: none !important;
+}
 
 /* Kill tab bar */
-#TabsToolbar { visibility: collapse; }
+#TabsToolbar {
+    visibility: collapse;
+}
 
 /* Remove window decorations (Close, Minimize, Fullscreen) */
-#titlebar { display: none !important; }
-#TabsToolbar .titlebar-placeholder { display: none !important; }
+#titlebar {
+    display: none !important;
+}
+#TabsToolbar .titlebar-placeholder {
+    display: none !important;
+}

--- a/src/static/css/viewsource.css
+++ b/src/static/css/viewsource.css
@@ -1,17 +1,17 @@
 #TridactylViewsourceElement {
-  position: absolute !important;
-  /* This is the z-index of hint.css and content.css -1 */
-  z-index: 2147483646 !important;
-  top: 0px !important;
-  font-family: monospace !important;
-  background: white !important;
-  white-space: pre !important;
-  min-width: 100% !important;
-  min-height: 100% !important;
-  margin: 0px !important;
+    position: absolute !important;
+    /* This is the z-index of hint.css and content.css -1 */
+    z-index: 2147483646 !important;
+    top: 0px !important;
+    font-family: monospace !important;
+    background: white !important;
+    white-space: pre !important;
+    min-width: 100% !important;
+    min-height: 100% !important;
+    margin: 0px !important;
 }
 
 #TridactylViewsourceElement.dark {
-  background: #111 !important;
-  color: #fff !important;
+    background: #111 !important;
+    color: #fff !important;
 }

--- a/src/static/themes/dark.css
+++ b/src/static/themes/dark.css
@@ -1,5 +1,4 @@
 :root.TridactylThemeDark {
-
     /* {{{ photon-colours */
 
     /* From https://github.com/overdodactyl/ShadowFox/blob/7dbe9343da87bde804e8fb88dd3b5eaaeb4817b2/css/common-files/color_variables.css */
@@ -53,14 +52,14 @@
     --tridactyl-photon-colours-grey-70: #38383d;
     --tridactyl-photon-colours-grey-80: #2a2a2e;
     --tridactyl-photon-colours-grey-90: #0c0c0d;
-    --tridactyl-photon-colours-code-green: #86de74!important;
-    --tridactyl-photon-colours-warning-color: #FCE19F;
-    --tridactyl-photon-colours-warning-background-color: #44391F;
-    --tridactyl-photon-colours-theme-highlight-green: #86DE74;
-    --tridactyl-photon-colours-theme-highlight-blue: #75BFFF;
-    --tridactyl-photon-colours-theme-highlight-purple: #B98EFF;
-    --tridactyl-photon-colours-theme-highlight-red: #FF7DE9;
-    --tridactyl-photon-colours-theme-highlight-yellow: #FFF89E;
+    --tridactyl-photon-colours-code-green: #86de74 !important;
+    --tridactyl-photon-colours-warning-color: #fce19f;
+    --tridactyl-photon-colours-warning-background-color: #44391f;
+    --tridactyl-photon-colours-theme-highlight-green: #86de74;
+    --tridactyl-photon-colours-theme-highlight-blue: #75bfff;
+    --tridactyl-photon-colours-theme-highlight-purple: #b98eff;
+    --tridactyl-photon-colours-theme-highlight-red: #ff7de9;
+    --tridactyl-photon-colours-theme-highlight-yellow: #fff89e;
     --tridactyl-photon-colours-theme-highlight-bluegrey: #5e88b0;
     --tridactyl-photon-colours-theme-highlight-lightorange: #d99b28;
     --tridactyl-photon-colours-theme-highlight-orange: #d96629;
@@ -74,58 +73,156 @@
     --tridactyl-photon-colours-tone-7: var(--tridactyl-photon-colours-grey-70);
     --tridactyl-photon-colours-tone-8: var(--tridactyl-photon-colours-grey-80);
     --tridactyl-photon-colours-tone-9: var(--tridactyl-photon-colours-grey-90);
-    --tridactyl-photon-colours-accent-1: var(--tridactyl-photon-colours-blue-40);
-    --tridactyl-photon-colours-accent-2: var(--tridactyl-photon-colours-blue-50);
-    --tridactyl-photon-colours-accent-3: var(--tridactyl-photon-colours-blue-60);
-    --tridactyl-photon-colours-in-content-page-color: var(--tridactyl-photon-colours-tone-4)!important;
-    --tridactyl-photon-colours-in-content-page-background: var(--tridactyl-photon-colours-tone-7)!important;
-    --tridactyl-photon-colours-in-content-text-color: var(--tridactyl-photon-colours-tone-3)!important;
-    --tridactyl-photon-colours-in-content-selected-text: var(--tridactyl-photon-colours-tone-1)!important;
-    --tridactyl-photon-colours-in-content-box-background: var(--tridactyl-photon-colours-tone-6)!important;
+    --tridactyl-photon-colours-accent-1: var(
+        --tridactyl-photon-colours-blue-40
+    );
+    --tridactyl-photon-colours-accent-2: var(
+        --tridactyl-photon-colours-blue-50
+    );
+    --tridactyl-photon-colours-accent-3: var(
+        --tridactyl-photon-colours-blue-60
+    );
+    --tridactyl-photon-colours-in-content-page-color: var(
+        --tridactyl-photon-colours-tone-4
+    ) !important;
+    --tridactyl-photon-colours-in-content-page-background: var(
+        --tridactyl-photon-colours-tone-7
+    ) !important;
+    --tridactyl-photon-colours-in-content-text-color: var(
+        --tridactyl-photon-colours-tone-3
+    ) !important;
+    --tridactyl-photon-colours-in-content-selected-text: var(
+        --tridactyl-photon-colours-tone-1
+    ) !important;
+    --tridactyl-photon-colours-in-content-box-background: var(
+        --tridactyl-photon-colours-tone-6
+    ) !important;
     --tridactyl-photon-colours-in-content-box-background-odd: #f3f6fa;
-    --tridactyl-photon-colours-in-content-box-background-hover: var(--tridactyl-photon-colours-tone-6)!important;
-    --tridactyl-photon-colours-in-content-box-background-active: var(--tridactyl-photon-colours-tone-6)!important;
-    --tridactyl-photon-colours-in-content-box-border-color: var(--tridactyl-photon-colours-tone-5)!important;
-    --tridactyl-photon-colours-in-content-item-hover: rgba(0,149,221,0.25);
-    --tridactyl-photon-colours-in-content-item-selected: var(--tridactyl-photon-colours-tone-8)!important;
-    --tridactyl-photon-colours-in-content-border-highlight: var(--tridactyl-photon-colours-accent-1)!important;
-    --tridactyl-photon-colours-in-content-border-focus: var(--tridactyl-photon-colours-accent-1)!important;
-    --tridactyl-photon-colours-in-content-border-color: var(--tridactyl-photon-colours-tone-6)!important;
-    --tridactyl-photon-colours-in-content-category-outline-focus: 1px dotted #0a84ff;
-    --tridactyl-photon-colours-in-content-category-text: var(--tridactyl-photon-colours-tone-4)!important;
+    --tridactyl-photon-colours-in-content-box-background-hover: var(
+        --tridactyl-photon-colours-tone-6
+    ) !important;
+    --tridactyl-photon-colours-in-content-box-background-active: var(
+        --tridactyl-photon-colours-tone-6
+    ) !important;
+    --tridactyl-photon-colours-in-content-box-border-color: var(
+        --tridactyl-photon-colours-tone-5
+    ) !important;
+    --tridactyl-photon-colours-in-content-item-hover: rgba(0, 149, 221, 0.25);
+    --tridactyl-photon-colours-in-content-item-selected: var(
+        --tridactyl-photon-colours-tone-8
+    ) !important;
+    --tridactyl-photon-colours-in-content-border-highlight: var(
+        --tridactyl-photon-colours-accent-1
+    ) !important;
+    --tridactyl-photon-colours-in-content-border-focus: var(
+        --tridactyl-photon-colours-accent-1
+    ) !important;
+    --tridactyl-photon-colours-in-content-border-color: var(
+        --tridactyl-photon-colours-tone-6
+    ) !important;
+    --tridactyl-photon-colours-in-content-category-outline-focus: 1px dotted
+        #0a84ff;
+    --tridactyl-photon-colours-in-content-category-text: var(
+        --tridactyl-photon-colours-tone-4
+    ) !important;
     --tridactyl-photon-colours-in-content-category-text-active: #0c0c0d;
-    --tridactyl-photon-colours-in-content-category-text-selected: var(--tridactyl-photon-colours-accent-1)!important;
+    --tridactyl-photon-colours-in-content-category-text-selected: var(
+        --tridactyl-photon-colours-accent-1
+    ) !important;
     --tridactyl-photon-colours-in-content-category-text-selected-active: #0060df;
-    --tridactyl-photon-colours-in-content-category-background-hover: rgba(12,12,13,0.1);
-    --tridactyl-photon-colours-in-content-category-background-active: rgba(12,12,13,0.15);
-    --tridactyl-photon-colours-in-content-category-background-selected-hover: rgba(12,12,13,0.15);
-    --tridactyl-photon-colours-in-content-category-background-selected-active: rgba(12,12,13,0.2);
+    --tridactyl-photon-colours-in-content-category-background-hover: rgba(
+        12,
+        12,
+        13,
+        0.1
+    );
+    --tridactyl-photon-colours-in-content-category-background-active: rgba(
+        12,
+        12,
+        13,
+        0.15
+    );
+    --tridactyl-photon-colours-in-content-category-background-selected-hover: rgba(
+        12,
+        12,
+        13,
+        0.15
+    );
+    --tridactyl-photon-colours-in-content-category-background-selected-active: rgba(
+        12,
+        12,
+        13,
+        0.2
+    );
     --tridactyl-photon-colours-in-content-tab-color: #424f5a;
-    --tridactyl-photon-colours-in-content-link-color: var(--tridactyl-photon-colours-accent-1)!important;
-    --tridactyl-photon-colours-in-content-link-color-hover: var(--tridactyl-photon-colours-accent-2)!important;
+    --tridactyl-photon-colours-in-content-link-color: var(
+        --tridactyl-photon-colours-accent-1
+    ) !important;
+    --tridactyl-photon-colours-in-content-link-color-hover: var(
+        --tridactyl-photon-colours-accent-2
+    ) !important;
     --tridactyl-photon-colours-in-content-link-color-active: #003eaa;
     --tridactyl-photon-colours-in-content-link-color-visited: #0a8dff;
-    --tridactyl-photon-colours-in-content-primary-button-background: var(--tridactyl-photon-colours-accent-2)!important;
-    --tridactyl-photon-colours-in-content-primary-button-background-hover: var(--tridactyl-photon-colours-accent-3)!important;
-    --tridactyl-photon-colours-in-content-primary-button-background-active: var(--tridactyl-photon-colours-accent-3)!important;
-    --tridactyl-photon-colours-in-content-table-border-dark-color: var(--tridactyl-photon-colours-tone-7)!important;
-    --tridactyl-photon-colours-in-content-table-header-background: var(--tridactyl-photon-colours-accent-2)!important;
-    --tridactyl-photon-colours-theme-selection-background: var(--tridactyl-photon-colours-accent-2)!important;
-    --tridactyl-photon-colours-theme-selection-background-hover: var(--tridactyl-photon-colours-accent-1)!important;
-    --tridactyl-photon-colours-in-content-category-header-background: var(--tridactyl-photon-colours-tone-8)!important;
-    --tridactyl-photon-colours-selected-icon-fill-color: var(--tridactyl-photon-colours-tone-2)!important;
-    --tridactyl-photon-colours-in-content-dark-header-background: var(--tridactyl-photon-colours-tone-9)!important;
-    --tridactyl-photon-colours-secure-connection-color: var(--tridactyl-photon-colours-accent-1);
-    --tridactyl-photon-colours-theme-sidebar-background: #1B1B1D!important;
-    --tridactyl-photon-colours-cm-background: var(--tridactyl-photon-colours-tone-8)!important;
-    --tridactyl-photon-colours-cm-selection: #353b48!important;
-    --tridactyl-photon-colours-cm-marker: #555!important;
-    --tridactyl-photon-colours-cm-linenumber: #58575c!important;
-    --tridactyl-photon-colours-cm-cursor: #fff!important;
-    --tridactyl-photon-colours-cm-active-line-background: rgba(185,215,253,.15)!important;
-    --tridactyl-photon-colours-cm-matching-bracket: rgba(255,255,255,.25)!important;
-    --tridactyl-photon-colours-cm-search-background: rgba(24,29,32,1)!important;
-    --tridactyl-photon-colours-cm-red: #de7474!important;
+    --tridactyl-photon-colours-in-content-primary-button-background: var(
+        --tridactyl-photon-colours-accent-2
+    ) !important;
+    --tridactyl-photon-colours-in-content-primary-button-background-hover: var(
+        --tridactyl-photon-colours-accent-3
+    ) !important;
+    --tridactyl-photon-colours-in-content-primary-button-background-active: var(
+        --tridactyl-photon-colours-accent-3
+    ) !important;
+    --tridactyl-photon-colours-in-content-table-border-dark-color: var(
+        --tridactyl-photon-colours-tone-7
+    ) !important;
+    --tridactyl-photon-colours-in-content-table-header-background: var(
+        --tridactyl-photon-colours-accent-2
+    ) !important;
+    --tridactyl-photon-colours-theme-selection-background: var(
+        --tridactyl-photon-colours-accent-2
+    ) !important;
+    --tridactyl-photon-colours-theme-selection-background-hover: var(
+        --tridactyl-photon-colours-accent-1
+    ) !important;
+    --tridactyl-photon-colours-in-content-category-header-background: var(
+        --tridactyl-photon-colours-tone-8
+    ) !important;
+    --tridactyl-photon-colours-selected-icon-fill-color: var(
+        --tridactyl-photon-colours-tone-2
+    ) !important;
+    --tridactyl-photon-colours-in-content-dark-header-background: var(
+        --tridactyl-photon-colours-tone-9
+    ) !important;
+    --tridactyl-photon-colours-secure-connection-color: var(
+        --tridactyl-photon-colours-accent-1
+    );
+    --tridactyl-photon-colours-theme-sidebar-background: #1b1b1d !important;
+    --tridactyl-photon-colours-cm-background: var(
+        --tridactyl-photon-colours-tone-8
+    ) !important;
+    --tridactyl-photon-colours-cm-selection: #353b48 !important;
+    --tridactyl-photon-colours-cm-marker: #555 !important;
+    --tridactyl-photon-colours-cm-linenumber: #58575c !important;
+    --tridactyl-photon-colours-cm-cursor: #fff !important;
+    --tridactyl-photon-colours-cm-active-line-background: rgba(
+        185,
+        215,
+        253,
+        0.15
+    ) !important;
+    --tridactyl-photon-colours-cm-matching-bracket: rgba(
+        255,
+        255,
+        255,
+        0.25
+    ) !important;
+    --tridactyl-photon-colours-cm-search-background: rgba(
+        24,
+        29,
+        32,
+        1
+    ) !important;
+    --tridactyl-photon-colours-cm-red: #de7474 !important;
     --tridactyl-photon-colours-start-indicator-for-updater-scripts: black;
     --tridactyl-photon-colours-end-indicator-for-updater-scripts: black;
     --tridactyl-photon-colours-dummy-variable-for-updater-scripys: black;
@@ -136,7 +233,9 @@
     --tridactyl-bg: var(--tridactyl-photon-colours-in-content-page-background);
 
     --tridactyl-cmdl-fg: var(--tridactyl-photon-colours-in-content-text-color);
-    --tridactyl-cmdl-bg: var(--tridactyl-photon-colours-in-content-category-header-background);
+    --tridactyl-cmdl-bg: var(
+        --tridactyl-photon-colours-in-content-category-header-background
+    );
 
     /* --tridactyl-header-first-bg: var(--tridactyl-photon-colours-in-content-category-header-background); */
     /* --tridactyl-header-second-bg: var(--tridactyl-photon-colours-in-content-category-header-background); */
@@ -146,7 +245,8 @@
     --tridactyl-header-second-bg: #222;
     --tridactyl-header-third-bg: #111;
 
-    --tridactyl-cmplt-border-top: 1px solid var(--tridactyl-photon-colours-in-content-category-header-background);
+    --tridactyl-cmplt-border-top: 1px solid
+        var(--tridactyl-photon-colours-in-content-category-header-background);
 
     --tridactyl-url-fg: var(--tridactyl-photon-colours-code-green);
     --tridactyl-url-bg: var(--tridactyl-bg);
@@ -157,34 +257,36 @@
     /* Hints are not photon coloured. Feel free to experiment with that */
 
     --tridactyl-hintspan-fg: white;
-    --tridactyl-hintspan-bg: #204E8A;
+    --tridactyl-hintspan-bg: #204e8a;
 
     --tridactyl-hint-active-fg: #333;
-    --tridactyl-hint-active-bg: #88FF00;
-    --tridactyl-hint-active-outline:1px solid #000;
+    --tridactyl-hint-active-bg: #88ff00;
+    --tridactyl-hint-active-outline: 1px solid #000;
 
-    --tridactyl-hint-bg: rgba(13, 31, 54, 0.25); 
+    --tridactyl-hint-bg: rgba(13, 31, 54, 0.25);
     --tridactyl-hint-outline: 1px solid var(--tridactyl-hintspan-bg);
 
-    --tridactyl-highlight-box-bg: var(--tridactyl-photon-colours-in-content-box-background);
-    --tridactyl-highlight-box-fg: var(--tridactyl-photon-colours-in-content-text-color);
+    --tridactyl-highlight-box-bg: var(
+        --tridactyl-photon-colours-in-content-box-background
+    );
+    --tridactyl-highlight-box-fg: var(
+        --tridactyl-photon-colours-in-content-text-color
+    );
 }
 
-:root.TridactylThemeDark.TridactylOwnNamespace 
-input[id^="spoiler"] ~ .spoiler {
+:root.TridactylThemeDark.TridactylOwnNamespace input[id^="spoiler"] ~ .spoiler {
     border-color: var(--tridactyl-photon-colours-in-content-box-border-color);
 }
-
 
 /* These rules have greater specificity than the rules applying the variables
  * above, which causes *issues*. */
 
-/* :root.TridactylThemeDark.TridactylOwnNamespace */ 
+/* :root.TridactylThemeDark.TridactylOwnNamespace */
 /* a:link { */
 /*     color: var(--tridactyl-photon-colours-in-content-link-color); */
 /* } */
 
-/* :root.TridactylThemeDark.TridactylOwnNamespace */ 
+/* :root.TridactylThemeDark.TridactylOwnNamespace */
 /* a:link:visited { */
 /*     --tridactyl-photon-colours-in-content-link-color-visited: #0a8dff; */
 /* } */

--- a/src/static/themes/default.css
+++ b/src/static/themes/default.css
@@ -1,5 +1,4 @@
 :root {
-
     /* Generic */
     --tridactyl-font-family: monospace;
     --tridactyl-font-family-sans: sans-serif;
@@ -18,30 +17,30 @@
 
     /* Hinting */
 
-        /* Hint character tags */
-        --tridactyl-hintspan-font-family: var(--tridactyl-font-family-sans);
-        --tridactyl-hintspan-font-size: var(--tridactyl-small-font-size);
-        --tridactyl-hintspan-font-weight: bold;
-        --tridactyl-hintspan-fg: white;
-        --tridactyl-hintspan-bg: red;
-        --tridactyl-hintspan-border-color: ButtonShadow;
-        --tridactyl-hintspan-border-width: 0px;
-        --tridactyl-hintspan-border-style: solid;
+    /* Hint character tags */
+    --tridactyl-hintspan-font-family: var(--tridactyl-font-family-sans);
+    --tridactyl-hintspan-font-size: var(--tridactyl-small-font-size);
+    --tridactyl-hintspan-font-weight: bold;
+    --tridactyl-hintspan-fg: white;
+    --tridactyl-hintspan-bg: red;
+    --tridactyl-hintspan-border-color: ButtonShadow;
+    --tridactyl-hintspan-border-width: 0px;
+    --tridactyl-hintspan-border-style: solid;
 
-        /* Element highlights */
-        --tridactyl-hint-active-fg: var(--tridactyl-fg);
-        --tridactyl-hint-active-bg: #88FF00;
-        --tridactyl-hint-active-outline: 1px solid #CC0000;
+    /* Element highlights */
+    --tridactyl-hint-active-fg: var(--tridactyl-fg);
+    --tridactyl-hint-active-bg: #88ff00;
+    --tridactyl-hint-active-outline: 1px solid #cc0000;
 
-        --tridactyl-hint-bg: rgba(255, 255, 0, 0.25);
-        --tridactyl-hint-outline: 1px solid #8F5902;
+    --tridactyl-hint-bg: rgba(255, 255, 0, 0.25);
+    --tridactyl-hint-outline: 1px solid #8f5902;
 
     /* :viewsource */
     --tridactyl-vs-bg: var(--tridactyl-bg);
     --tridactyl-vs-fg: var(--tridactyl-fg);
     --tridactyl-vs-font-family: var(--tridactyl-font-family);
 
-/*commandline*/
+    /*commandline*/
 
     --tridactyl-cmdl-bg: var(--tridactyl-bg);
     --tridactyl-cmdl-fg: var(--tridactyl-fg);
@@ -49,7 +48,7 @@
     --tridactyl-cmdl-font-family: monospace;
     --tridactyl-cmdl-font-size: 9pt;
 
-/*completions*/
+    /*completions*/
 
     --tridactyl-cmplt-option-height: 1.4em;
     --tridactyl-cmplt-fg: var(--tridactyl-fg);
@@ -66,7 +65,7 @@
 
     */
 
-/*sectionHeader*/
+    /*sectionHeader*/
 
     --tridactyl-header-first-bg: LightGray;
     --tridactyl-header-second-bg: #ddd;
@@ -81,21 +80,20 @@
     --tridactyl-header-font-weight: bold;
     /* i don't think 0.5px is redered */
     --tridactyl-header-border-bottom: 1px solid bottom;
-    
 
-/*url style*/
+    /*url style*/
 
     --tridactyl-url-text-decoration: none;
     --tridactyl-url-fg: #1f9947;
     --tridactyl-url-bg: var(--tridactyl-bg);
     --tridactyl-url-cursor: pointer;
 
-/*option focused*/
+    /*option focused*/
 
     --tridactyl-of-fg: var(--tridactyl-fg);
-    --tridactyl-of-bg: #FFEC8B;
+    --tridactyl-of-bg: #ffec8b;
 
-/*new tab spoiler box*/
+    /*new tab spoiler box*/
     --tridactyl-highlight-box-bg: #eee;
     --tridactyl-highlight-box-fg: var(--tridactyl-fg);
 }

--- a/src/static/themes/greenmat/aldrich-ff.css
+++ b/src/static/themes/greenmat/aldrich-ff.css
@@ -1,6 +1,7 @@
 @font-face {
-  font-family: 'Aldrich';
-  font-style: normal;
-  font-weight: 400;
-  src: local('Aldrich Regular'), local('Aldrich-Regular'), url('aldrich.ttf') format('truetype');
+    font-family: "Aldrich";
+    font-style: normal;
+    font-weight: 400;
+    src: local("Aldrich Regular"), local("Aldrich-Regular"),
+        url("aldrich.ttf") format("truetype");
 }

--- a/src/static/themes/greenmat/greenmat.css
+++ b/src/static/themes/greenmat/greenmat.css
@@ -1,91 +1,90 @@
 :root.TridactylThemeGreenmat {
+    --tridactyl-fg: #00eb00;
+    --tridactyl-bg: #001500;
+    --tridactyl-cmdl-fg: #00eb00;
+    --tridactyl-cmdl-bg: #001500;
+    --tridactyl-font-family: "Aldrich";
 
-  --tridactyl-fg: #00eb00;
-  --tridactyl-bg: #001500;
-  --tridactyl-cmdl-fg: #00eb00;
-  --tridactyl-cmdl-bg: #001500;
-  --tridactyl-font-family: 'Aldrich';
+    --tridactyl-header-first-bg: black;
+    --tridactyl-header-second-bg: #003500;
+    --tridactyl-header-third-bg: black;
 
-  --tridactyl-header-first-bg: black;
-  --tridactyl-header-second-bg: #003500;
-  --tridactyl-header-third-bg: black;
+    --tridactyl-cmplt-font-family: "Aldrich";
+    --tridactyl-cmplt-fg: var(--tridactyl-cmdl-fg);
+    --tridactyl-cmplt-bg: rgba(0, 0, 0, 0.9);
+    --tridactyl-cmplt-border-top: 1px solid var(--tridactyl-cmdl-bg);
 
-  --tridactyl-cmplt-font-family: 'Aldrich';
-  --tridactyl-cmplt-fg: var(--tridactyl-cmdl-fg);
-  --tridactyl-cmplt-bg: rgba(0,0,0,0.90);
-  --tridactyl-cmplt-border-top: 1px solid var(--tridactyl-cmdl-bg);
+    --tridactyl-url-fg: var(--tridactyl-cmdl-fg);
+    --tridactyl-url-bg: none;
 
-  --tridactyl-url-fg: var(--tridactyl-cmdl-fg);
-  --tridactyl-url-bg: none;
+    --tridactyl-of-fg: #00ff00;
+    --tridactyl-of-bg: black;
 
-  --tridactyl-of-fg: #00FF00;
-  --tridactyl-of-bg: black;
+    --tridactyl-highlight-box-bg: black;
+    --tridactyl-highlight-box-fg: var(--tridactyl-fg);
 
-  --tridactyl-highlight-box-bg: black;
-  --tridactyl-highlight-box-fg: var(--tridactyl-fg);
+    /*custom theme variables*/
+    --focused-prefix-color: black;
+    --focused-border-color: green;
 
-  /*custom theme variables*/
-  --focused-prefix-color: black;
-  --focused-border-color: green;
+    --tridactyl-hintspan-fg: #88ff00;
+    --tridactyl-hintspan-bg: black;
+    --tridactyl-hintspan-font-family: "Aldrich";
 
-  --tridactyl-hintspan-fg: #88FF00;
-  --tridactyl-hintspan-bg: black;
-  --tridactyl-hintspan-font-family: "Aldrich";
+    --tridactyl-hint-active-fg: #333;
+    --tridactyl-hint-active-bg: #88ff00;
+    --tridactyl-hint-active-outline: 1px solid #000;
 
-  --tridactyl-hint-active-fg: #333;
-  --tridactyl-hint-active-bg: #88FF00;
-  --tridactyl-hint-active-outline:1px solid #000;
-
-  --tridactyl-hint-bg: rgba(0, 0, 0, 0.25);
-  --tridactyl-hint-outline: 2px solid var(--tridactyl-hintspan-bg);
-
+    --tridactyl-hint-bg: rgba(0, 0, 0, 0.25);
+    --tridactyl-hint-outline: 2px solid var(--tridactyl-hintspan-bg);
 }
 
-:root.TridactylThemeGreenmat #completions .focused{
-  border-bottom: 1px solid green;
+:root.TridactylThemeGreenmat #completions .focused {
+    border-bottom: 1px solid green;
 }
 
-:root.TridactylThemeGreenmat #completions .focused .prefix{
-   color:var(--focused-prefix-color);
-   background: linear-gradient(
-   var(--focused-prefix-color),
-   var(--focused-border-color),
-   var(--focused-prefix-color));
+:root.TridactylThemeGreenmat #completions .focused .prefix {
+    color: var(--focused-prefix-color);
+    background: linear-gradient(
+        var(--focused-prefix-color),
+        var(--focused-border-color),
+        var(--focused-prefix-color)
+    );
 }
 
 :root.TridactylThemeGreenmat.TridactylOwnNamespace table {
-   border-collapse: collapse;
+    border-collapse: collapse;
 }
 
 :root.TridactylThemeGreenmat.TridactylOwnNamespace #completions table tr td {
-  color: var(--tridactyl-cmplt-fg);
+    color: var(--tridactyl-cmplt-fg);
 }
 
 /* ### newtab ### */
 
 :root.TridactylThemeGreenmat.TridactylOwnNamespace code {
-  background-color: rgba(255,255,255,0.10);
-  border-top: 1px solid var(--tridactyl-fg);
+    background-color: rgba(255, 255, 255, 0.1);
+    border-top: 1px solid var(--tridactyl-fg);
 }
 
 :root.TridactylThemeGreenmat.TridactylOwnNamespace ul {
-   background-color: rgba(0,0,0,0.55);
-   border-radius: 10px;
-   border-top: 1px solid var(--tridactyl-fg);
-   padding-top: 10px;
-   padding-bottom: 5px;
+    background-color: rgba(0, 0, 0, 0.55);
+    border-radius: 10px;
+    border-top: 1px solid var(--tridactyl-fg);
+    padding-top: 10px;
+    padding-bottom: 5px;
 }
 
-:root.TridactylThemeGreenmat.TridactylOwnNamespace .spoiler > h2 + ul{
-   background-color: rgba(255,255,255,0.05);
-   border-radius: 10px;
-   border-left: 1px solid var(--tridactyl-fg);
-   border-right: 1px solid var(--tridactyl-fg);
-   border-top: unset;
-   border-bottom: unset;
+:root.TridactylThemeGreenmat.TridactylOwnNamespace .spoiler > h2 + ul {
+    background-color: rgba(255, 255, 255, 0.05);
+    border-radius: 10px;
+    border-left: 1px solid var(--tridactyl-fg);
+    border-right: 1px solid var(--tridactyl-fg);
+    border-top: unset;
+    border-bottom: unset;
 }
 
 :root.TridactylThemeGreenmat.TridactylOwnNamespace a {
-   color: var(--tridactyl-fg);
-   font-weight: bold;
+    color: var(--tridactyl-fg);
+    font-weight: bold;
 }

--- a/src/static/themes/quake.css
+++ b/src/static/themes/quake.css
@@ -2,16 +2,17 @@
     --tridactyl-bg: black;
     --tridactyl-fg: lightgreen;
 }
- 
+
 :root.TridactylThemeQuake #completions .sectionHeader {
-    display: none
+    display: none;
 }
 
 :root.TridactylThemeQuake #tridactyl-colon::before {
-    content: "] "
+    content: "] ";
 }
 
-:root.TridactylThemeQuake #completions .focused, :root.TridactylThemeQuake #completions .focused .url{
+:root.TridactylThemeQuake #completions .focused,
+:root.TridactylThemeQuake #completions .focused .url {
     background: var(--tridactyl-bg);
     text-decoration: underline;
 }
@@ -21,6 +22,6 @@
     bottom: unset;
     top: 0% !important;
     left: 0% !important;
-	box-shadow: rgba(0,0,0,0.5) 0px 0px 15px !important;
-    opacity: 0.9
+    box-shadow: rgba(0, 0, 0, 0.5) 0px 0px 15px !important;
+    opacity: 0.9;
 }

--- a/src/static/themes/shydactyl.css
+++ b/src/static/themes/shydactyl.css
@@ -3,20 +3,20 @@
     --tridactyl-small-font-size: "1.5rem";
 }
 
-:root.TridactylThemeShydactyl #command-line-holder{
-	order: 1;
+:root.TridactylThemeShydactyl #command-line-holder {
+    order: 1;
     border: 2px solid #000;
     color: var(--tridactyl-bg);
 }
 
-:root.TridactylThemeShydactyl #tridactyl-input{
+:root.TridactylThemeShydactyl #tridactyl-input {
     padding: 1rem;
     color: var(--tridactyl-fg);
     width: 90%;
     font-size: 1.5rem;
     line-height: 1.5;
     color: black;
-    background:  white;
+    background: white;
     padding-left: unset;
     padding: 1rem;
 }
@@ -37,60 +37,61 @@
 
 /* COMPLETIONS */
 
-
 :root.TridactylThemeShydactyl #completions {
-  --option-height: 1.4em;
-  color: black;
-  background: white;
-  display: inline-block;
-  font-size: unset;
-  font-weight: 200;
-  overflow: hidden;
-  width: 100%;
-  border-top: unset;
-  order: 2;
+    --option-height: 1.4em;
+    color: black;
+    background: white;
+    display: inline-block;
+    font-size: unset;
+    font-weight: 200;
+    overflow: hidden;
+    width: 100%;
+    border-top: unset;
+    order: 2;
 }
-
 
 /* Olie doesn't know how CSS inheritance works */
 :root.TridactylThemeShydactyl #completions .HistoryCompletionSource {
-  max-height: unset;
-  min-height: unset;
+    max-height: unset;
+    min-height: unset;
 }
 
 :root.TridactylThemeShydactyl #completions .HistoryCompletionSource table {
-  width: 100%;
-  font-size: 9pt;
-  border-spacing: 0;
-  table-layout: fixed;
+    width: 100%;
+    font-size: 9pt;
+    border-spacing: 0;
+    table-layout: fixed;
 }
 
 /* redundancy 2: redundancy 2: more redundancy */
 :root.TridactylThemeShydactyl #completions .BmarkCompletionSource {
-  max-height: unset;
-  min-height: unset;
-}
- 
- 
-:root.TridactylThemeShydactyl #completions table tr td:nth-of-type(1) { display: none; }
-:root.TridactylThemeShydactyl #completions table tr td:nth-of-type(2) { display: none; }
-:root.TridactylThemeShydactyl #completions .BufferCompletionSource table {
-  width: unset;
-  font-size: unset;
-  border-spacing: unset;
-  table-layout: unset;
+    max-height: unset;
+    min-height: unset;
 }
 
-:root.TridactylThemeShydactyl #completions table tr td:nth-of-type(4) { width: 50%; }
- 
- 
+:root.TridactylThemeShydactyl #completions table tr td:nth-of-type(1) {
+    display: none;
+}
+:root.TridactylThemeShydactyl #completions table tr td:nth-of-type(2) {
+    display: none;
+}
+:root.TridactylThemeShydactyl #completions .BufferCompletionSource table {
+    width: unset;
+    font-size: unset;
+    border-spacing: unset;
+    table-layout: unset;
+}
+
+:root.TridactylThemeShydactyl #completions table tr td:nth-of-type(4) {
+    width: 50%;
+}
+
 :root.TridactylThemeShydactyl #completions table tr {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
 }
- 
- 
+
 :root.TridactylThemeShydactyl #completions .sectionHeader {
     background: unset;
     font-weight: 200;
@@ -107,7 +108,7 @@
     left: 10% !important;
     z-index: 2147483647 !important;
     width: 80% !important;
-	box-shadow: rgba(0,0,0,0.5) 0px 0px 15px !important;
+    box-shadow: rgba(0, 0, 0, 0.5) 0px 0px 15px !important;
 }
 
 :root.TridactylThemeShydactyl .TridactylStatusIndicator {
@@ -121,13 +122,11 @@
     font-weight: 200 !important;
     padding: 0.8ex !important;
 }
- 
- 
+
 /* #Shydactyl-normal { */
- /*  border-color: green !important; */
+/*  border-color: green !important; */
 /* } */
 
 /* #Shydactyl-insert { */
- /*  border-color: yellow !important; */
+/*  border-color: yellow !important; */
 /* } */
-

--- a/src/static/typedoc/assets/css/main.css
+++ b/src/static/typedoc/assets/css/main.css
@@ -10,863 +10,2910 @@
 /*! normalize.css v1.1.3 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 6/7/8/9 and Firefox 3. */
-article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary { display: block; }
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+nav,
+section,
+summary {
+    display: block;
+}
 
 /** Correct `inline-block` display not defined in IE 6/7/8/9 and Firefox 3. */
-audio, canvas, video { display: inline-block; *display: inline; *zoom: 1; }
+audio,
+canvas,
+video {
+    display: inline-block;
+    *display: inline;
+    *zoom: 1;
+}
 
 /** Prevent modern browsers from displaying `audio` without controls. Remove excess height in iOS 5 devices. */
-audio:not([controls]) { display: none; height: 0; }
+audio:not([controls]) {
+    display: none;
+    height: 0;
+}
 
 /** Address styling not present in IE 7/8/9, Firefox 3, and Safari 4. Known issue: no IE 6 support. */
-[hidden] { display: none; }
+[hidden] {
+    display: none;
+}
 
 /* ========================================================================== Base ========================================================================== */
 /** 1. Correct text resizing oddly in IE 6/7 when body `font-size` is set using `em` units. 2. Prevent iOS text size adjust after orientation change, without disabling user zoom. */
-html { font-size: 100%; /* 1 */ -ms-text-size-adjust: 100%; /* 2 */ -webkit-text-size-adjust: 100%; /* 2 */ font-family: sans-serif; }
+html {
+    font-size: 100%; /* 1 */
+    -ms-text-size-adjust: 100%; /* 2 */
+    -webkit-text-size-adjust: 100%; /* 2 */
+    font-family: sans-serif;
+}
 
 /** Address `font-family` inconsistency between `textarea` and other form elements. */
-button, input, select, textarea { font-family: sans-serif; }
+button,
+input,
+select,
+textarea {
+    font-family: sans-serif;
+}
 
 /** Address margins handled incorrectly in IE 6/7. */
-body { margin: 0; }
+body {
+    margin: 0;
+}
 
 /* ========================================================================== Links ========================================================================== */
 /** Address `outline` inconsistency between Chrome and other browsers. */
-a:focus { outline: thin dotted; }
-a:active, a:hover { outline: 0; }
+a:focus {
+    outline: thin dotted;
+}
+a:active,
+a:hover {
+    outline: 0;
+}
 
 /** Improve readability when focused and also mouse hovered in all browsers. */
 /* ========================================================================== Typography ========================================================================== */
 /** Address font sizes and margins set differently in IE 6/7. Address font sizes within `section` and `article` in Firefox 4+, Safari 5, and Chrome. */
-h1 { font-size: 2em; margin: 0.67em 0; }
+h1 {
+    font-size: 2em;
+    margin: 0.67em 0;
+}
 
-h2 { font-size: 1.5em; margin: 0.83em 0; }
+h2 {
+    font-size: 1.5em;
+    margin: 0.83em 0;
+}
 
-h3 { font-size: 1.17em; margin: 1em 0; }
+h3 {
+    font-size: 1.17em;
+    margin: 1em 0;
+}
 
-h4, .tsd-index-panel h3 { font-size: 1em; margin: 1.33em 0; }
+h4,
+.tsd-index-panel h3 {
+    font-size: 1em;
+    margin: 1.33em 0;
+}
 
-h5 { font-size: 0.83em; margin: 1.67em 0; }
+h5 {
+    font-size: 0.83em;
+    margin: 1.67em 0;
+}
 
-h6 { font-size: 0.67em; margin: 2.33em 0; }
+h6 {
+    font-size: 0.67em;
+    margin: 2.33em 0;
+}
 
 /** Address styling not present in IE 7/8/9, Safari 5, and Chrome. */
-abbr[title] { border-bottom: 1px dotted; }
+abbr[title] {
+    border-bottom: 1px dotted;
+}
 
 /** Address style set to `bolder` in Firefox 3+, Safari 4/5, and Chrome. */
-b, strong { font-weight: bold; }
+b,
+strong {
+    font-weight: bold;
+}
 
-blockquote { margin: 1em 40px; }
+blockquote {
+    margin: 1em 40px;
+}
 
 /** Address styling not present in Safari 5 and Chrome. */
-dfn { font-style: italic; }
+dfn {
+    font-style: italic;
+}
 
 /** Address differences between Firefox and other browsers. Known issue: no IE 6/7 normalization. */
-hr { box-sizing: content-box; height: 0; }
+hr {
+    box-sizing: content-box;
+    height: 0;
+}
 
 /** Address styling not present in IE 6/7/8/9. */
-mark { background: #ff0; color: #000; }
+mark {
+    background: #ff0;
+    color: #000;
+}
 
 /** Address margins set differently in IE 6/7. */
-p, pre { margin: 1em 0; }
+p,
+pre {
+    margin: 1em 0;
+}
 
 /** Correct font family set oddly in IE 6, Safari 4/5, and Chrome. */
-code, kbd, pre, samp { font-family: monospace, serif; _font-family: "courier new", monospace; font-size: 1em; }
+code,
+kbd,
+pre,
+samp {
+    font-family: monospace, serif;
+    _font-family: "courier new", monospace;
+    font-size: 1em;
+}
 
 /** Improve readability of pre-formatted text in all browsers. */
-pre { white-space: pre; white-space: pre-wrap; word-wrap: break-word; }
+pre {
+    white-space: pre;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
 
 /** Address CSS quotes not supported in IE 6/7. */
-q { quotes: none; }
-q:before, q:after { content: ""; content: none; }
+q {
+    quotes: none;
+}
+q:before,
+q:after {
+    content: "";
+    content: none;
+}
 
 /** Address `quotes` property not supported in Safari 4. */
 /** Address inconsistent and variable font size in all browsers. */
-small { font-size: 80%; }
+small {
+    font-size: 80%;
+}
 
 /** Prevent `sub` and `sup` affecting `line-height` in all browsers. */
-sub { font-size: 75%; line-height: 0; position: relative; vertical-align: baseline; }
+sub {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+}
 
-sup { font-size: 75%; line-height: 0; position: relative; vertical-align: baseline; top: -0.5em; }
+sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+    top: -0.5em;
+}
 
-sub { bottom: -0.25em; }
+sub {
+    bottom: -0.25em;
+}
 
 /* ========================================================================== Lists ========================================================================== */
 /** Address margins set differently in IE 6/7. */
-dl, menu, ol, ul { margin: 1em 0; }
+dl,
+menu,
+ol,
+ul {
+    margin: 1em 0;
+}
 
-dd { margin: 0 0 0 40px; }
+dd {
+    margin: 0 0 0 40px;
+}
 
 /** Address paddings set differently in IE 6/7. */
-menu, ol, ul { padding: 0 0 0 40px; }
+menu,
+ol,
+ul {
+    padding: 0 0 0 40px;
+}
 
 /** Correct list images handled incorrectly in IE 7. */
-nav ul, nav ol { list-style: none; list-style-image: none; }
+nav ul,
+nav ol {
+    list-style: none;
+    list-style-image: none;
+}
 
 /* ========================================================================== Embedded content ========================================================================== */
 /** 1. Remove border when inside `a` element in IE 6/7/8/9 and Firefox 3. 2. Improve image quality when scaled in IE 7. */
-img { border: 0; /* 1 */ -ms-interpolation-mode: bicubic; }
+img {
+    border: 0; /* 1 */
+    -ms-interpolation-mode: bicubic;
+}
 
 /* 2 */
 /** Correct overflow displayed oddly in IE 9. */
-svg:not(:root) { overflow: hidden; }
+svg:not(:root) {
+    overflow: hidden;
+}
 
 /* ========================================================================== Figures ========================================================================== */
 /** Address margin not present in IE 6/7/8/9, Safari 5, and Opera 11. */
-figure, form { margin: 0; }
+figure,
+form {
+    margin: 0;
+}
 
 /* ========================================================================== Forms ========================================================================== */
 /** Correct margin displayed oddly in IE 6/7. */
 /** Define consistent border, margin, and padding. */
-fieldset { border: 1px solid #c0c0c0; margin: 0 2px; padding: 0.35em 0.625em 0.75em; }
+fieldset {
+    border: 1px solid #c0c0c0;
+    margin: 0 2px;
+    padding: 0.35em 0.625em 0.75em;
+}
 
 /** 1. Correct color not being inherited in IE 6/7/8/9. 2. Correct text not wrapping in Firefox 3. 3. Correct alignment displayed oddly in IE 6/7. */
-legend { border: 0; /* 1 */ padding: 0; white-space: normal; /* 2 */ *margin-left: -7px; }
+legend {
+    border: 0; /* 1 */
+    padding: 0;
+    white-space: normal; /* 2 */
+    *margin-left: -7px;
+}
 
 /* 3 */
 /** 1. Correct font size not being inherited in all browsers. 2. Address margins set differently in IE 6/7, Firefox 3+, Safari 5, and Chrome. 3. Improve appearance and consistency in all browsers. */
-button, input, select, textarea { font-size: 100%; /* 1 */ margin: 0; /* 2 */ vertical-align: baseline; /* 3 */ *vertical-align: middle; }
+button,
+input,
+select,
+textarea {
+    font-size: 100%; /* 1 */
+    margin: 0; /* 2 */
+    vertical-align: baseline; /* 3 */
+    *vertical-align: middle;
+}
 
 /* 3 */
 /** Address Firefox 3+ setting `line-height` on `input` using `!important` in the UA stylesheet. */
-button, input { line-height: normal; }
+button,
+input {
+    line-height: normal;
+}
 
 /** Address inconsistent `text-transform` inheritance for `button` and `select`. All other form control elements do not inherit `text-transform` values. Correct `button` style inheritance in Chrome, Safari 5+, and IE 6+. Correct `select` style inheritance in Firefox 4+ and Opera. */
-button, select { text-transform: none; }
+button,
+select {
+    text-transform: none;
+}
 
 /** 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio` and `video` controls. 2. Correct inability to style clickable `input` types in iOS. 3. Improve usability and consistency of cursor style between image-type `input` and others. 4. Remove inner spacing in IE 7 without affecting normal text inputs. Known issue: inner spacing remains in IE 6. */
-button, html input[type="button"] { -webkit-appearance: button; /* 2 */ cursor: pointer; /* 3 */ *overflow: visible; }
+button,
+html input[type="button"] {
+    -webkit-appearance: button; /* 2 */
+    cursor: pointer; /* 3 */
+    *overflow: visible;
+}
 
 /* 4 */
-input[type="reset"], input[type="submit"] { -webkit-appearance: button; /* 2 */ cursor: pointer; /* 3 */ *overflow: visible; }
+input[type="reset"],
+input[type="submit"] {
+    -webkit-appearance: button; /* 2 */
+    cursor: pointer; /* 3 */
+    *overflow: visible;
+}
 
 /* 4 */
 /** Re-set default cursor for disabled elements. */
-button[disabled], html input[disabled] { cursor: default; }
+button[disabled],
+html input[disabled] {
+    cursor: default;
+}
 
 /** 1. Address box sizing set to content-box in IE 8/9. 2. Remove excess padding in IE 8/9. 3. Remove excess padding in IE 7. Known issue: excess padding remains in IE 6. */
-input { /* 3 */ }
-input[type="checkbox"], input[type="radio"] { box-sizing: border-box; /* 1 */ padding: 0; /* 2 */ *height: 13px; /* 3 */ *width: 13px; }
-input[type="search"] { -webkit-appearance: textfield; /* 1 */ /* 2 */ box-sizing: content-box; }
-input[type="search"]::-webkit-search-cancel-button, input[type="search"]::-webkit-search-decoration { -webkit-appearance: none; }
+input {
+    /* 3 */
+}
+input[type="checkbox"],
+input[type="radio"] {
+    box-sizing: border-box; /* 1 */
+    padding: 0; /* 2 */
+    *height: 13px; /* 3 */
+    *width: 13px;
+}
+input[type="search"] {
+    -webkit-appearance: textfield; /* 1 */ /* 2 */
+    box-sizing: content-box;
+}
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+    -webkit-appearance: none;
+}
 
 /** 1. Address `appearance` set to `searchfield` in Safari 5 and Chrome. 2. Address `box-sizing` set to `border-box` in Safari 5 and Chrome (include `-moz` to future-proof). */
 /** Remove inner padding and search cancel button in Safari 5 and Chrome on OS X. */
 /** Remove inner padding and border in Firefox 3+. */
-button::-moz-focus-inner, input::-moz-focus-inner { border: 0; padding: 0; }
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+    border: 0;
+    padding: 0;
+}
 
 /** 1. Remove default vertical scrollbar in IE 6/7/8/9. 2. Improve readability and alignment in all browsers. */
-textarea { overflow: auto; /* 1 */ vertical-align: top; }
+textarea {
+    overflow: auto; /* 1 */
+    vertical-align: top;
+}
 
 /* 2 */
 /* ========================================================================== Tables ========================================================================== */
 /** Remove most spacing between table cells. */
-table { border-collapse: collapse; border-spacing: 0; }
+table {
+    border-collapse: collapse;
+    border-spacing: 0;
+}
 
 /* Visual Studio-like style based on original C# coloring by Jason Diamond <jason@diamond.name> */
-.hljs { display: inline-block; padding: 0.5em; background: white; color: black; }
-
-.hljs-comment, .hljs-annotation, .hljs-template_comment, .diff .hljs-header, .hljs-chunk, .apache .hljs-cbracket { color: #008000; }
-
-.hljs-keyword, .hljs-id, .hljs-built_in, .css .smalltalk .hljs-class, .hljs-winutils, .bash .hljs-variable, .tex .hljs-command, .hljs-request, .hljs-status, .nginx .hljs-title { color: #00f; }
-
-.xml .hljs-tag { color: #00f; }
-.xml .hljs-tag .hljs-value { color: #00f; }
-
-.hljs-string, .hljs-title, .hljs-parent, .hljs-tag .hljs-value, .hljs-rules .hljs-value { color: #a31515; }
-
-.ruby .hljs-symbol { color: #a31515; }
-.ruby .hljs-symbol .hljs-string { color: #a31515; }
-
-.hljs-template_tag, .django .hljs-variable, .hljs-addition, .hljs-flow, .hljs-stream, .apache .hljs-tag, .hljs-date, .tex .hljs-formula, .coffeescript .hljs-attribute { color: #a31515; }
-
-.ruby .hljs-string, .hljs-decorator, .hljs-filter .hljs-argument, .hljs-localvars, .hljs-array, .hljs-attr_selector, .hljs-pseudo, .hljs-pi, .hljs-doctype, .hljs-deletion, .hljs-envvar, .hljs-shebang, .hljs-preprocessor, .hljs-pragma, .userType, .apache .hljs-sqbracket, .nginx .hljs-built_in, .tex .hljs-special, .hljs-prompt { color: #2b91af; }
-
-.hljs-phpdoc, .hljs-javadoc, .hljs-xmlDocTag { color: #808080; }
-
-.vhdl .hljs-typename { font-weight: bold; }
-.vhdl .hljs-string { color: #666666; }
-.vhdl .hljs-literal { color: #a31515; }
-.vhdl .hljs-attribute { color: #00b0e8; }
-
-.xml .hljs-attribute { color: #f00; }
-
-.col > :first-child, .col-1 > :first-child, .col-2 > :first-child, .col-3 > :first-child, .col-4 > :first-child, .col-5 > :first-child, .col-6 > :first-child, .col-7 > :first-child, .col-8 > :first-child, .col-9 > :first-child, .col-10 > :first-child, .col-11 > :first-child, .tsd-panel > :first-child, ul.tsd-descriptions > li > :first-child, .col > :first-child > :first-child, .col-1 > :first-child > :first-child, .col-2 > :first-child > :first-child, .col-3 > :first-child > :first-child, .col-4 > :first-child > :first-child, .col-5 > :first-child > :first-child, .col-6 > :first-child > :first-child, .col-7 > :first-child > :first-child, .col-8 > :first-child > :first-child, .col-9 > :first-child > :first-child, .col-10 > :first-child > :first-child, .col-11 > :first-child > :first-child, .tsd-panel > :first-child > :first-child, ul.tsd-descriptions > li > :first-child > :first-child, .col > :first-child > :first-child > :first-child, .col-1 > :first-child > :first-child > :first-child, .col-2 > :first-child > :first-child > :first-child, .col-3 > :first-child > :first-child > :first-child, .col-4 > :first-child > :first-child > :first-child, .col-5 > :first-child > :first-child > :first-child, .col-6 > :first-child > :first-child > :first-child, .col-7 > :first-child > :first-child > :first-child, .col-8 > :first-child > :first-child > :first-child, .col-9 > :first-child > :first-child > :first-child, .col-10 > :first-child > :first-child > :first-child, .col-11 > :first-child > :first-child > :first-child, .tsd-panel > :first-child > :first-child > :first-child, ul.tsd-descriptions > li > :first-child > :first-child > :first-child { margin-top: 0; }
-.col > :last-child, .col-1 > :last-child, .col-2 > :last-child, .col-3 > :last-child, .col-4 > :last-child, .col-5 > :last-child, .col-6 > :last-child, .col-7 > :last-child, .col-8 > :last-child, .col-9 > :last-child, .col-10 > :last-child, .col-11 > :last-child, .tsd-panel > :last-child, ul.tsd-descriptions > li > :last-child, .col > :last-child > :last-child, .col-1 > :last-child > :last-child, .col-2 > :last-child > :last-child, .col-3 > :last-child > :last-child, .col-4 > :last-child > :last-child, .col-5 > :last-child > :last-child, .col-6 > :last-child > :last-child, .col-7 > :last-child > :last-child, .col-8 > :last-child > :last-child, .col-9 > :last-child > :last-child, .col-10 > :last-child > :last-child, .col-11 > :last-child > :last-child, .tsd-panel > :last-child > :last-child, ul.tsd-descriptions > li > :last-child > :last-child, .col > :last-child > :last-child > :last-child, .col-1 > :last-child > :last-child > :last-child, .col-2 > :last-child > :last-child > :last-child, .col-3 > :last-child > :last-child > :last-child, .col-4 > :last-child > :last-child > :last-child, .col-5 > :last-child > :last-child > :last-child, .col-6 > :last-child > :last-child > :last-child, .col-7 > :last-child > :last-child > :last-child, .col-8 > :last-child > :last-child > :last-child, .col-9 > :last-child > :last-child > :last-child, .col-10 > :last-child > :last-child > :last-child, .col-11 > :last-child > :last-child > :last-child, .tsd-panel > :last-child > :last-child > :last-child, ul.tsd-descriptions > li > :last-child > :last-child > :last-child { margin-bottom: 0; }
-
-.container { max-width: 1200px; margin: 0 auto; padding: 0 40px; }
-@media (max-width: 640px) { .container { padding: 0 20px; } }
-
-.container-main { padding-bottom: 200px; }
-
-.row { position: relative; margin: 0 -10px; }
-.row:after { visibility: hidden; display: block; content: ""; clear: both; height: 0; }
-
-.col, .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11 { box-sizing: border-box; float: left; padding: 0 10px; }
-
-.col-1 { width: 8.33333%; }
-
-.offset-1 { margin-left: 8.33333%; }
-
-.col-2 { width: 16.66667%; }
-
-.offset-2 { margin-left: 16.66667%; }
-
-.col-3 { width: 25%; }
-
-.offset-3 { margin-left: 25%; }
-
-.col-4 { width: 33.33333%; }
-
-.offset-4 { margin-left: 33.33333%; }
-
-.col-5 { width: 41.66667%; }
-
-.offset-5 { margin-left: 41.66667%; }
-
-.col-6 { width: 50%; }
-
-.offset-6 { margin-left: 50%; }
-
-.col-7 { width: 58.33333%; }
-
-.offset-7 { margin-left: 58.33333%; }
-
-.col-8 { width: 66.66667%; }
-
-.offset-8 { margin-left: 66.66667%; }
-
-.col-9 { width: 75%; }
-
-.offset-9 { margin-left: 75%; }
-
-.col-10 { width: 83.33333%; }
-
-.offset-10 { margin-left: 83.33333%; }
-
-.col-11 { width: 91.66667%; }
-
-.offset-11 { margin-left: 91.66667%; }
-
-.tsd-kind-icon { display: block; position: relative; padding-left: 20px; text-indent: -20px; }
-
-.tsd-signature.tsd-kind-icon:before { background-position: 0 -153px; }
-
-.tsd-kind-object-literal > .tsd-kind-icon:before { background-position: 0px -17px; }
-.tsd-kind-object-literal.tsd-is-protected > .tsd-kind-icon:before { background-position: -17px -17px; }
-.tsd-kind-object-literal.tsd-is-private > .tsd-kind-icon:before { background-position: -34px -17px; }
-
-.tsd-kind-class > .tsd-kind-icon:before { background-position: 0px -34px; }
-.tsd-kind-class.tsd-is-protected > .tsd-kind-icon:before { background-position: -17px -34px; }
-.tsd-kind-class.tsd-is-private > .tsd-kind-icon:before { background-position: -34px -34px; }
-
-.tsd-kind-class.tsd-has-type-parameter > .tsd-kind-icon:before { background-position: 0px -51px; }
-.tsd-kind-class.tsd-has-type-parameter.tsd-is-protected > .tsd-kind-icon:before { background-position: -17px -51px; }
-.tsd-kind-class.tsd-has-type-parameter.tsd-is-private > .tsd-kind-icon:before { background-position: -34px -51px; }
-
-.tsd-kind-interface > .tsd-kind-icon:before { background-position: 0px -68px; }
-.tsd-kind-interface.tsd-is-protected > .tsd-kind-icon:before { background-position: -17px -68px; }
-.tsd-kind-interface.tsd-is-private > .tsd-kind-icon:before { background-position: -34px -68px; }
-
-.tsd-kind-interface.tsd-has-type-parameter > .tsd-kind-icon:before { background-position: 0px -85px; }
-.tsd-kind-interface.tsd-has-type-parameter.tsd-is-protected > .tsd-kind-icon:before { background-position: -17px -85px; }
-.tsd-kind-interface.tsd-has-type-parameter.tsd-is-private > .tsd-kind-icon:before { background-position: -34px -85px; }
-
-.tsd-kind-module > .tsd-kind-icon:before { background-position: 0px -102px; }
-.tsd-kind-module.tsd-is-protected > .tsd-kind-icon:before { background-position: -17px -102px; }
-.tsd-kind-module.tsd-is-private > .tsd-kind-icon:before { background-position: -34px -102px; }
-
-.tsd-kind-external-module > .tsd-kind-icon:before { background-position: 0px -102px; }
-.tsd-kind-external-module.tsd-is-protected > .tsd-kind-icon:before { background-position: -17px -102px; }
-.tsd-kind-external-module.tsd-is-private > .tsd-kind-icon:before { background-position: -34px -102px; }
-
-.tsd-kind-enum > .tsd-kind-icon:before { background-position: 0px -119px; }
-.tsd-kind-enum.tsd-is-protected > .tsd-kind-icon:before { background-position: -17px -119px; }
-.tsd-kind-enum.tsd-is-private > .tsd-kind-icon:before { background-position: -34px -119px; }
-
-.tsd-kind-enum-member > .tsd-kind-icon:before { background-position: 0px -136px; }
-.tsd-kind-enum-member.tsd-is-protected > .tsd-kind-icon:before { background-position: -17px -136px; }
-.tsd-kind-enum-member.tsd-is-private > .tsd-kind-icon:before { background-position: -34px -136px; }
-
-.tsd-kind-signature > .tsd-kind-icon:before { background-position: 0px -153px; }
-.tsd-kind-signature.tsd-is-protected > .tsd-kind-icon:before { background-position: -17px -153px; }
-.tsd-kind-signature.tsd-is-private > .tsd-kind-icon:before { background-position: -34px -153px; }
-
-.tsd-kind-type-alias > .tsd-kind-icon:before { background-position: 0px -170px; }
-.tsd-kind-type-alias.tsd-is-protected > .tsd-kind-icon:before { background-position: -17px -170px; }
-.tsd-kind-type-alias.tsd-is-private > .tsd-kind-icon:before { background-position: -34px -170px; }
-
-.tsd-kind-variable > .tsd-kind-icon:before { background-position: -136px -0px; }
-.tsd-kind-variable.tsd-is-protected > .tsd-kind-icon:before { background-position: -153px -0px; }
-.tsd-kind-variable.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -0px; }
-.tsd-kind-variable.tsd-parent-kind-class > .tsd-kind-icon:before { background-position: -51px -0px; }
-.tsd-kind-variable.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before { background-position: -68px -0px; }
-.tsd-kind-variable.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before { background-position: -85px -0px; }
-.tsd-kind-variable.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited > .tsd-kind-icon:before { background-position: -102px -0px; }
-.tsd-kind-variable.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -0px; }
-.tsd-kind-variable.tsd-parent-kind-enum > .tsd-kind-icon:before { background-position: -170px -0px; }
-.tsd-kind-variable.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before { background-position: -187px -0px; }
-.tsd-kind-variable.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -0px; }
-.tsd-kind-variable.tsd-parent-kind-interface > .tsd-kind-icon:before { background-position: -204px -0px; }
-.tsd-kind-variable.tsd-parent-kind-interface.tsd-is-inherited > .tsd-kind-icon:before { background-position: -221px -0px; }
-
-.tsd-kind-property > .tsd-kind-icon:before { background-position: -136px -0px; }
-.tsd-kind-property.tsd-is-protected > .tsd-kind-icon:before { background-position: -153px -0px; }
-.tsd-kind-property.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -0px; }
-.tsd-kind-property.tsd-parent-kind-class > .tsd-kind-icon:before { background-position: -51px -0px; }
-.tsd-kind-property.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before { background-position: -68px -0px; }
-.tsd-kind-property.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before { background-position: -85px -0px; }
-.tsd-kind-property.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited > .tsd-kind-icon:before { background-position: -102px -0px; }
-.tsd-kind-property.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -0px; }
-.tsd-kind-property.tsd-parent-kind-enum > .tsd-kind-icon:before { background-position: -170px -0px; }
-.tsd-kind-property.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before { background-position: -187px -0px; }
-.tsd-kind-property.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -0px; }
-.tsd-kind-property.tsd-parent-kind-interface > .tsd-kind-icon:before { background-position: -204px -0px; }
-.tsd-kind-property.tsd-parent-kind-interface.tsd-is-inherited > .tsd-kind-icon:before { background-position: -221px -0px; }
-
-.tsd-kind-get-signature > .tsd-kind-icon:before { background-position: -136px -17px; }
-.tsd-kind-get-signature.tsd-is-protected > .tsd-kind-icon:before { background-position: -153px -17px; }
-.tsd-kind-get-signature.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -17px; }
-.tsd-kind-get-signature.tsd-parent-kind-class > .tsd-kind-icon:before { background-position: -51px -17px; }
-.tsd-kind-get-signature.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before { background-position: -68px -17px; }
-.tsd-kind-get-signature.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before { background-position: -85px -17px; }
-.tsd-kind-get-signature.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited > .tsd-kind-icon:before { background-position: -102px -17px; }
-.tsd-kind-get-signature.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -17px; }
-.tsd-kind-get-signature.tsd-parent-kind-enum > .tsd-kind-icon:before { background-position: -170px -17px; }
-.tsd-kind-get-signature.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before { background-position: -187px -17px; }
-.tsd-kind-get-signature.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -17px; }
-.tsd-kind-get-signature.tsd-parent-kind-interface > .tsd-kind-icon:before { background-position: -204px -17px; }
-.tsd-kind-get-signature.tsd-parent-kind-interface.tsd-is-inherited > .tsd-kind-icon:before { background-position: -221px -17px; }
-
-.tsd-kind-set-signature > .tsd-kind-icon:before { background-position: -136px -34px; }
-.tsd-kind-set-signature.tsd-is-protected > .tsd-kind-icon:before { background-position: -153px -34px; }
-.tsd-kind-set-signature.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -34px; }
-.tsd-kind-set-signature.tsd-parent-kind-class > .tsd-kind-icon:before { background-position: -51px -34px; }
-.tsd-kind-set-signature.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before { background-position: -68px -34px; }
-.tsd-kind-set-signature.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before { background-position: -85px -34px; }
-.tsd-kind-set-signature.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited > .tsd-kind-icon:before { background-position: -102px -34px; }
-.tsd-kind-set-signature.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -34px; }
-.tsd-kind-set-signature.tsd-parent-kind-enum > .tsd-kind-icon:before { background-position: -170px -34px; }
-.tsd-kind-set-signature.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before { background-position: -187px -34px; }
-.tsd-kind-set-signature.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -34px; }
-.tsd-kind-set-signature.tsd-parent-kind-interface > .tsd-kind-icon:before { background-position: -204px -34px; }
-.tsd-kind-set-signature.tsd-parent-kind-interface.tsd-is-inherited > .tsd-kind-icon:before { background-position: -221px -34px; }
-
-.tsd-kind-accessor > .tsd-kind-icon:before { background-position: -136px -51px; }
-.tsd-kind-accessor.tsd-is-protected > .tsd-kind-icon:before { background-position: -153px -51px; }
-.tsd-kind-accessor.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -51px; }
-.tsd-kind-accessor.tsd-parent-kind-class > .tsd-kind-icon:before { background-position: -51px -51px; }
-.tsd-kind-accessor.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before { background-position: -68px -51px; }
-.tsd-kind-accessor.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before { background-position: -85px -51px; }
-.tsd-kind-accessor.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited > .tsd-kind-icon:before { background-position: -102px -51px; }
-.tsd-kind-accessor.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -51px; }
-.tsd-kind-accessor.tsd-parent-kind-enum > .tsd-kind-icon:before { background-position: -170px -51px; }
-.tsd-kind-accessor.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before { background-position: -187px -51px; }
-.tsd-kind-accessor.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -51px; }
-.tsd-kind-accessor.tsd-parent-kind-interface > .tsd-kind-icon:before { background-position: -204px -51px; }
-.tsd-kind-accessor.tsd-parent-kind-interface.tsd-is-inherited > .tsd-kind-icon:before { background-position: -221px -51px; }
-
-.tsd-kind-function > .tsd-kind-icon:before { background-position: -136px -68px; }
-.tsd-kind-function.tsd-is-protected > .tsd-kind-icon:before { background-position: -153px -68px; }
-.tsd-kind-function.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -68px; }
-.tsd-kind-function.tsd-parent-kind-class > .tsd-kind-icon:before { background-position: -51px -68px; }
-.tsd-kind-function.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before { background-position: -68px -68px; }
-.tsd-kind-function.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before { background-position: -85px -68px; }
-.tsd-kind-function.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited > .tsd-kind-icon:before { background-position: -102px -68px; }
-.tsd-kind-function.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -68px; }
-.tsd-kind-function.tsd-parent-kind-enum > .tsd-kind-icon:before { background-position: -170px -68px; }
-.tsd-kind-function.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before { background-position: -187px -68px; }
-.tsd-kind-function.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -68px; }
-.tsd-kind-function.tsd-parent-kind-interface > .tsd-kind-icon:before { background-position: -204px -68px; }
-.tsd-kind-function.tsd-parent-kind-interface.tsd-is-inherited > .tsd-kind-icon:before { background-position: -221px -68px; }
-
-.tsd-kind-method > .tsd-kind-icon:before { background-position: -136px -68px; }
-.tsd-kind-method.tsd-is-protected > .tsd-kind-icon:before { background-position: -153px -68px; }
-.tsd-kind-method.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -68px; }
-.tsd-kind-method.tsd-parent-kind-class > .tsd-kind-icon:before { background-position: -51px -68px; }
-.tsd-kind-method.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before { background-position: -68px -68px; }
-.tsd-kind-method.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before { background-position: -85px -68px; }
-.tsd-kind-method.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited > .tsd-kind-icon:before { background-position: -102px -68px; }
-.tsd-kind-method.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -68px; }
-.tsd-kind-method.tsd-parent-kind-enum > .tsd-kind-icon:before { background-position: -170px -68px; }
-.tsd-kind-method.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before { background-position: -187px -68px; }
-.tsd-kind-method.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -68px; }
-.tsd-kind-method.tsd-parent-kind-interface > .tsd-kind-icon:before { background-position: -204px -68px; }
-.tsd-kind-method.tsd-parent-kind-interface.tsd-is-inherited > .tsd-kind-icon:before { background-position: -221px -68px; }
-
-.tsd-kind-call-signature > .tsd-kind-icon:before { background-position: -136px -68px; }
-.tsd-kind-call-signature.tsd-is-protected > .tsd-kind-icon:before { background-position: -153px -68px; }
-.tsd-kind-call-signature.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -68px; }
-.tsd-kind-call-signature.tsd-parent-kind-class > .tsd-kind-icon:before { background-position: -51px -68px; }
-.tsd-kind-call-signature.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before { background-position: -68px -68px; }
-.tsd-kind-call-signature.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before { background-position: -85px -68px; }
-.tsd-kind-call-signature.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited > .tsd-kind-icon:before { background-position: -102px -68px; }
-.tsd-kind-call-signature.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -68px; }
-.tsd-kind-call-signature.tsd-parent-kind-enum > .tsd-kind-icon:before { background-position: -170px -68px; }
-.tsd-kind-call-signature.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before { background-position: -187px -68px; }
-.tsd-kind-call-signature.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -68px; }
-.tsd-kind-call-signature.tsd-parent-kind-interface > .tsd-kind-icon:before { background-position: -204px -68px; }
-.tsd-kind-call-signature.tsd-parent-kind-interface.tsd-is-inherited > .tsd-kind-icon:before { background-position: -221px -68px; }
-
-.tsd-kind-function.tsd-has-type-parameter > .tsd-kind-icon:before { background-position: -136px -85px; }
-.tsd-kind-function.tsd-has-type-parameter.tsd-is-protected > .tsd-kind-icon:before { background-position: -153px -85px; }
-.tsd-kind-function.tsd-has-type-parameter.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -85px; }
-.tsd-kind-function.tsd-has-type-parameter.tsd-parent-kind-class > .tsd-kind-icon:before { background-position: -51px -85px; }
-.tsd-kind-function.tsd-has-type-parameter.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before { background-position: -68px -85px; }
-.tsd-kind-function.tsd-has-type-parameter.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before { background-position: -85px -85px; }
-.tsd-kind-function.tsd-has-type-parameter.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited > .tsd-kind-icon:before { background-position: -102px -85px; }
-.tsd-kind-function.tsd-has-type-parameter.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -85px; }
-.tsd-kind-function.tsd-has-type-parameter.tsd-parent-kind-enum > .tsd-kind-icon:before { background-position: -170px -85px; }
-.tsd-kind-function.tsd-has-type-parameter.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before { background-position: -187px -85px; }
-.tsd-kind-function.tsd-has-type-parameter.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -85px; }
-.tsd-kind-function.tsd-has-type-parameter.tsd-parent-kind-interface > .tsd-kind-icon:before { background-position: -204px -85px; }
-.tsd-kind-function.tsd-has-type-parameter.tsd-parent-kind-interface.tsd-is-inherited > .tsd-kind-icon:before { background-position: -221px -85px; }
-
-.tsd-kind-method.tsd-has-type-parameter > .tsd-kind-icon:before { background-position: -136px -85px; }
-.tsd-kind-method.tsd-has-type-parameter.tsd-is-protected > .tsd-kind-icon:before { background-position: -153px -85px; }
-.tsd-kind-method.tsd-has-type-parameter.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -85px; }
-.tsd-kind-method.tsd-has-type-parameter.tsd-parent-kind-class > .tsd-kind-icon:before { background-position: -51px -85px; }
-.tsd-kind-method.tsd-has-type-parameter.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before { background-position: -68px -85px; }
-.tsd-kind-method.tsd-has-type-parameter.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before { background-position: -85px -85px; }
-.tsd-kind-method.tsd-has-type-parameter.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited > .tsd-kind-icon:before { background-position: -102px -85px; }
-.tsd-kind-method.tsd-has-type-parameter.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -85px; }
-.tsd-kind-method.tsd-has-type-parameter.tsd-parent-kind-enum > .tsd-kind-icon:before { background-position: -170px -85px; }
-.tsd-kind-method.tsd-has-type-parameter.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before { background-position: -187px -85px; }
-.tsd-kind-method.tsd-has-type-parameter.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -85px; }
-.tsd-kind-method.tsd-has-type-parameter.tsd-parent-kind-interface > .tsd-kind-icon:before { background-position: -204px -85px; }
-.tsd-kind-method.tsd-has-type-parameter.tsd-parent-kind-interface.tsd-is-inherited > .tsd-kind-icon:before { background-position: -221px -85px; }
-
-.tsd-kind-constructor > .tsd-kind-icon:before { background-position: -136px -102px; }
-.tsd-kind-constructor.tsd-is-protected > .tsd-kind-icon:before { background-position: -153px -102px; }
-.tsd-kind-constructor.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -102px; }
-.tsd-kind-constructor.tsd-parent-kind-class > .tsd-kind-icon:before { background-position: -51px -102px; }
-.tsd-kind-constructor.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before { background-position: -68px -102px; }
-.tsd-kind-constructor.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before { background-position: -85px -102px; }
-.tsd-kind-constructor.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited > .tsd-kind-icon:before { background-position: -102px -102px; }
-.tsd-kind-constructor.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -102px; }
-.tsd-kind-constructor.tsd-parent-kind-enum > .tsd-kind-icon:before { background-position: -170px -102px; }
-.tsd-kind-constructor.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before { background-position: -187px -102px; }
-.tsd-kind-constructor.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -102px; }
-.tsd-kind-constructor.tsd-parent-kind-interface > .tsd-kind-icon:before { background-position: -204px -102px; }
-.tsd-kind-constructor.tsd-parent-kind-interface.tsd-is-inherited > .tsd-kind-icon:before { background-position: -221px -102px; }
-
-.tsd-kind-constructor-signature > .tsd-kind-icon:before { background-position: -136px -102px; }
-.tsd-kind-constructor-signature.tsd-is-protected > .tsd-kind-icon:before { background-position: -153px -102px; }
-.tsd-kind-constructor-signature.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -102px; }
-.tsd-kind-constructor-signature.tsd-parent-kind-class > .tsd-kind-icon:before { background-position: -51px -102px; }
-.tsd-kind-constructor-signature.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before { background-position: -68px -102px; }
-.tsd-kind-constructor-signature.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before { background-position: -85px -102px; }
-.tsd-kind-constructor-signature.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited > .tsd-kind-icon:before { background-position: -102px -102px; }
-.tsd-kind-constructor-signature.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -102px; }
-.tsd-kind-constructor-signature.tsd-parent-kind-enum > .tsd-kind-icon:before { background-position: -170px -102px; }
-.tsd-kind-constructor-signature.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before { background-position: -187px -102px; }
-.tsd-kind-constructor-signature.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -102px; }
-.tsd-kind-constructor-signature.tsd-parent-kind-interface > .tsd-kind-icon:before { background-position: -204px -102px; }
-.tsd-kind-constructor-signature.tsd-parent-kind-interface.tsd-is-inherited > .tsd-kind-icon:before { background-position: -221px -102px; }
-
-.tsd-kind-index-signature > .tsd-kind-icon:before { background-position: -136px -119px; }
-.tsd-kind-index-signature.tsd-is-protected > .tsd-kind-icon:before { background-position: -153px -119px; }
-.tsd-kind-index-signature.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -119px; }
-.tsd-kind-index-signature.tsd-parent-kind-class > .tsd-kind-icon:before { background-position: -51px -119px; }
-.tsd-kind-index-signature.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before { background-position: -68px -119px; }
-.tsd-kind-index-signature.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before { background-position: -85px -119px; }
-.tsd-kind-index-signature.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited > .tsd-kind-icon:before { background-position: -102px -119px; }
-.tsd-kind-index-signature.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -119px; }
-.tsd-kind-index-signature.tsd-parent-kind-enum > .tsd-kind-icon:before { background-position: -170px -119px; }
-.tsd-kind-index-signature.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before { background-position: -187px -119px; }
-.tsd-kind-index-signature.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -119px; }
-.tsd-kind-index-signature.tsd-parent-kind-interface > .tsd-kind-icon:before { background-position: -204px -119px; }
-.tsd-kind-index-signature.tsd-parent-kind-interface.tsd-is-inherited > .tsd-kind-icon:before { background-position: -221px -119px; }
-
-.tsd-kind-event > .tsd-kind-icon:before { background-position: -136px -136px; }
-.tsd-kind-event.tsd-is-protected > .tsd-kind-icon:before { background-position: -153px -136px; }
-.tsd-kind-event.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -136px; }
-.tsd-kind-event.tsd-parent-kind-class > .tsd-kind-icon:before { background-position: -51px -136px; }
-.tsd-kind-event.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before { background-position: -68px -136px; }
-.tsd-kind-event.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before { background-position: -85px -136px; }
-.tsd-kind-event.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited > .tsd-kind-icon:before { background-position: -102px -136px; }
-.tsd-kind-event.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -136px; }
-.tsd-kind-event.tsd-parent-kind-enum > .tsd-kind-icon:before { background-position: -170px -136px; }
-.tsd-kind-event.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before { background-position: -187px -136px; }
-.tsd-kind-event.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -136px; }
-.tsd-kind-event.tsd-parent-kind-interface > .tsd-kind-icon:before { background-position: -204px -136px; }
-.tsd-kind-event.tsd-parent-kind-interface.tsd-is-inherited > .tsd-kind-icon:before { background-position: -221px -136px; }
-
-.tsd-is-static > .tsd-kind-icon:before { background-position: -136px -153px; }
-.tsd-is-static.tsd-is-protected > .tsd-kind-icon:before { background-position: -153px -153px; }
-.tsd-is-static.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -153px; }
-.tsd-is-static.tsd-parent-kind-class > .tsd-kind-icon:before { background-position: -51px -153px; }
-.tsd-is-static.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before { background-position: -68px -153px; }
-.tsd-is-static.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before { background-position: -85px -153px; }
-.tsd-is-static.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited > .tsd-kind-icon:before { background-position: -102px -153px; }
-.tsd-is-static.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -153px; }
-.tsd-is-static.tsd-parent-kind-enum > .tsd-kind-icon:before { background-position: -170px -153px; }
-.tsd-is-static.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before { background-position: -187px -153px; }
-.tsd-is-static.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -153px; }
-.tsd-is-static.tsd-parent-kind-interface > .tsd-kind-icon:before { background-position: -204px -153px; }
-.tsd-is-static.tsd-parent-kind-interface.tsd-is-inherited > .tsd-kind-icon:before { background-position: -221px -153px; }
-
-.tsd-is-static.tsd-kind-function > .tsd-kind-icon:before { background-position: -136px -170px; }
-.tsd-is-static.tsd-kind-function.tsd-is-protected > .tsd-kind-icon:before { background-position: -153px -170px; }
-.tsd-is-static.tsd-kind-function.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -170px; }
-.tsd-is-static.tsd-kind-function.tsd-parent-kind-class > .tsd-kind-icon:before { background-position: -51px -170px; }
-.tsd-is-static.tsd-kind-function.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before { background-position: -68px -170px; }
-.tsd-is-static.tsd-kind-function.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before { background-position: -85px -170px; }
-.tsd-is-static.tsd-kind-function.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited > .tsd-kind-icon:before { background-position: -102px -170px; }
-.tsd-is-static.tsd-kind-function.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -170px; }
-.tsd-is-static.tsd-kind-function.tsd-parent-kind-enum > .tsd-kind-icon:before { background-position: -170px -170px; }
-.tsd-is-static.tsd-kind-function.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before { background-position: -187px -170px; }
-.tsd-is-static.tsd-kind-function.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -170px; }
-.tsd-is-static.tsd-kind-function.tsd-parent-kind-interface > .tsd-kind-icon:before { background-position: -204px -170px; }
-.tsd-is-static.tsd-kind-function.tsd-parent-kind-interface.tsd-is-inherited > .tsd-kind-icon:before { background-position: -221px -170px; }
-
-.tsd-is-static.tsd-kind-method > .tsd-kind-icon:before { background-position: -136px -170px; }
-.tsd-is-static.tsd-kind-method.tsd-is-protected > .tsd-kind-icon:before { background-position: -153px -170px; }
-.tsd-is-static.tsd-kind-method.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -170px; }
-.tsd-is-static.tsd-kind-method.tsd-parent-kind-class > .tsd-kind-icon:before { background-position: -51px -170px; }
-.tsd-is-static.tsd-kind-method.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before { background-position: -68px -170px; }
-.tsd-is-static.tsd-kind-method.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before { background-position: -85px -170px; }
-.tsd-is-static.tsd-kind-method.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited > .tsd-kind-icon:before { background-position: -102px -170px; }
-.tsd-is-static.tsd-kind-method.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -170px; }
-.tsd-is-static.tsd-kind-method.tsd-parent-kind-enum > .tsd-kind-icon:before { background-position: -170px -170px; }
-.tsd-is-static.tsd-kind-method.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before { background-position: -187px -170px; }
-.tsd-is-static.tsd-kind-method.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -170px; }
-.tsd-is-static.tsd-kind-method.tsd-parent-kind-interface > .tsd-kind-icon:before { background-position: -204px -170px; }
-.tsd-is-static.tsd-kind-method.tsd-parent-kind-interface.tsd-is-inherited > .tsd-kind-icon:before { background-position: -221px -170px; }
-
-.tsd-is-static.tsd-kind-call-signature > .tsd-kind-icon:before { background-position: -136px -170px; }
-.tsd-is-static.tsd-kind-call-signature.tsd-is-protected > .tsd-kind-icon:before { background-position: -153px -170px; }
-.tsd-is-static.tsd-kind-call-signature.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -170px; }
-.tsd-is-static.tsd-kind-call-signature.tsd-parent-kind-class > .tsd-kind-icon:before { background-position: -51px -170px; }
-.tsd-is-static.tsd-kind-call-signature.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before { background-position: -68px -170px; }
-.tsd-is-static.tsd-kind-call-signature.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before { background-position: -85px -170px; }
-.tsd-is-static.tsd-kind-call-signature.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited > .tsd-kind-icon:before { background-position: -102px -170px; }
-.tsd-is-static.tsd-kind-call-signature.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -170px; }
-.tsd-is-static.tsd-kind-call-signature.tsd-parent-kind-enum > .tsd-kind-icon:before { background-position: -170px -170px; }
-.tsd-is-static.tsd-kind-call-signature.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before { background-position: -187px -170px; }
-.tsd-is-static.tsd-kind-call-signature.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -170px; }
-.tsd-is-static.tsd-kind-call-signature.tsd-parent-kind-interface > .tsd-kind-icon:before { background-position: -204px -170px; }
-.tsd-is-static.tsd-kind-call-signature.tsd-parent-kind-interface.tsd-is-inherited > .tsd-kind-icon:before { background-position: -221px -170px; }
-
-.tsd-is-static.tsd-kind-event > .tsd-kind-icon:before { background-position: -136px -187px; }
-.tsd-is-static.tsd-kind-event.tsd-is-protected > .tsd-kind-icon:before { background-position: -153px -187px; }
-.tsd-is-static.tsd-kind-event.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -187px; }
-.tsd-is-static.tsd-kind-event.tsd-parent-kind-class > .tsd-kind-icon:before { background-position: -51px -187px; }
-.tsd-is-static.tsd-kind-event.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before { background-position: -68px -187px; }
-.tsd-is-static.tsd-kind-event.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before { background-position: -85px -187px; }
-.tsd-is-static.tsd-kind-event.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited > .tsd-kind-icon:before { background-position: -102px -187px; }
-.tsd-is-static.tsd-kind-event.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -187px; }
-.tsd-is-static.tsd-kind-event.tsd-parent-kind-enum > .tsd-kind-icon:before { background-position: -170px -187px; }
-.tsd-is-static.tsd-kind-event.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before { background-position: -187px -187px; }
-.tsd-is-static.tsd-kind-event.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before { background-position: -119px -187px; }
-.tsd-is-static.tsd-kind-event.tsd-parent-kind-interface > .tsd-kind-icon:before { background-position: -204px -187px; }
-.tsd-is-static.tsd-kind-event.tsd-parent-kind-interface.tsd-is-inherited > .tsd-kind-icon:before { background-position: -221px -187px; }
-
-.no-transition { transition: none !important; }
-
-@-webkit-keyframes fade-in { from { opacity: 0; }
-  to { opacity: 1; } }
-
-@keyframes fade-in { from { opacity: 0; }
-  to { opacity: 1; } }
-@-webkit-keyframes fade-out { from { opacity: 1; visibility: visible; }
-  to { opacity: 0; } }
-@keyframes fade-out { from { opacity: 1; visibility: visible; }
-  to { opacity: 0; } }
-@-webkit-keyframes fade-in-delayed { 0% { opacity: 0; }
-  33% { opacity: 0; }
-  100% { opacity: 1; } }
-@keyframes fade-in-delayed { 0% { opacity: 0; }
-  33% { opacity: 0; }
-  100% { opacity: 1; } }
-@-webkit-keyframes fade-out-delayed { 0% { opacity: 1; visibility: visible; }
-  66% { opacity: 0; }
-  100% { opacity: 0; } }
-@keyframes fade-out-delayed { 0% { opacity: 1; visibility: visible; }
-  66% { opacity: 0; }
-  100% { opacity: 0; } }
-@-webkit-keyframes shift-to-left { from { -webkit-transform: translate(0, 0); transform: translate(0, 0); }
-  to { -webkit-transform: translate(-25%, 0); transform: translate(-25%, 0); } }
-@keyframes shift-to-left { from { -webkit-transform: translate(0, 0); transform: translate(0, 0); }
-  to { -webkit-transform: translate(-25%, 0); transform: translate(-25%, 0); } }
-@-webkit-keyframes unshift-to-left { from { -webkit-transform: translate(-25%, 0); transform: translate(-25%, 0); }
-  to { -webkit-transform: translate(0, 0); transform: translate(0, 0); } }
-@keyframes unshift-to-left { from { -webkit-transform: translate(-25%, 0); transform: translate(-25%, 0); }
-  to { -webkit-transform: translate(0, 0); transform: translate(0, 0); } }
-@-webkit-keyframes pop-in-from-right { from { -webkit-transform: translate(100%, 0); transform: translate(100%, 0); }
-  to { -webkit-transform: translate(0, 0); transform: translate(0, 0); } }
-@keyframes pop-in-from-right { from { -webkit-transform: translate(100%, 0); transform: translate(100%, 0); }
-  to { -webkit-transform: translate(0, 0); transform: translate(0, 0); } }
-@-webkit-keyframes pop-out-to-right { from { -webkit-transform: translate(0, 0); transform: translate(0, 0); visibility: visible; }
-  to { -webkit-transform: translate(100%, 0); transform: translate(100%, 0); } }
-@keyframes pop-out-to-right { from { -webkit-transform: translate(0, 0); transform: translate(0, 0); visibility: visible; }
-  to { -webkit-transform: translate(100%, 0); transform: translate(100%, 0); } }
-body { background: #fdfdfd; font-family: "Segoe UI", sans-serif; font-size: 16px; color: #222; }
-
-a { color: #4da6ff; text-decoration: none; }
-a:hover { text-decoration: underline; }
-
-code, pre { font-family: Menlo, Monaco, Consolas, "Courier New", monospace; padding: 0.2em; margin: 0; font-size: 14px; background-color: rgba(0, 0, 0, 0.04); }
-
-pre { padding: 10px; }
-pre code { padding: 0; font-size: 100%; background-color: transparent; }
-
-.tsd-typography { line-height: 1.333em; }
-.tsd-typography ul { list-style: square; padding: 0 0 0 20px; margin: 0; }
-.tsd-typography h4, .tsd-typography .tsd-index-panel h3, .tsd-index-panel .tsd-typography h3, .tsd-typography h5, .tsd-typography h6 { font-size: 1em; margin: 0; }
-.tsd-typography h5, .tsd-typography h6 { font-weight: normal; }
-.tsd-typography p, .tsd-typography ul, .tsd-typography ol { margin: 1em 0; }
-
-@media (min-width: 901px) and (max-width: 1024px) { html.default .col-content { width: 72%; }
-  html.default .col-menu { width: 28%; }
-  html.default .tsd-navigation { padding-left: 10px; } }
-@media (max-width: 900px) { html.default .col-content { float: none; width: 100%; }
-  html.default .col-menu { position: fixed !important; overflow: auto; -webkit-overflow-scrolling: touch; overflow-scrolling: touch; z-index: 1024; top: 0 !important; bottom: 0 !important; left: auto !important; right: 0 !important; width: 100%; padding: 20px 20px 0 0; max-width: 450px; visibility: hidden; background-color: #fff; -webkit-transform: translate(100%, 0); transform: translate(100%, 0); }
-  html.default .col-menu > *:last-child { padding-bottom: 20px; }
-  html.default .overlay { content: ""; display: block; position: fixed; z-index: 1023; top: 0; left: 0; right: 0; bottom: 0; background-color: rgba(0, 0, 0, 0.75); visibility: hidden; }
-  html.default.to-has-menu .overlay { -webkit-animation: fade-in 0.4s; animation: fade-in 0.4s; }
-  html.default.to-has-menu header, html.default.to-has-menu footer, html.default.to-has-menu .col-content { -webkit-animation: shift-to-left 0.4s; animation: shift-to-left 0.4s; }
-  html.default.to-has-menu .col-menu { -webkit-animation: pop-in-from-right 0.4s; animation: pop-in-from-right 0.4s; }
-  html.default.from-has-menu .overlay { -webkit-animation: fade-out 0.4s; animation: fade-out 0.4s; }
-  html.default.from-has-menu header, html.default.from-has-menu footer, html.default.from-has-menu .col-content { -webkit-animation: unshift-to-left 0.4s; animation: unshift-to-left 0.4s; }
-  html.default.from-has-menu .col-menu { -webkit-animation: pop-out-to-right 0.4s; animation: pop-out-to-right 0.4s; }
-  html.default.has-menu body { overflow: hidden; }
-  html.default.has-menu .overlay { visibility: visible; }
-  html.default.has-menu header, html.default.has-menu footer, html.default.has-menu .col-content { -webkit-transform: translate(-25%, 0); transform: translate(-25%, 0); }
-  html.default.has-menu .col-menu { visibility: visible; -webkit-transform: translate(0, 0); transform: translate(0, 0); } }
-
-.tsd-page-title { padding: 70px 0 20px 0; margin: 0 0 40px 0; background: #fff; box-shadow: 0 0 5px rgba(0, 0, 0, 0.35); }
-.tsd-page-title h1 { margin: 0; }
-
-.tsd-breadcrumb { margin: 0; padding: 0; color: #808080; }
-.tsd-breadcrumb a { color: #808080; text-decoration: none; }
-.tsd-breadcrumb a:hover { text-decoration: underline; }
-.tsd-breadcrumb li { display: inline; }
-.tsd-breadcrumb li:after { content: " / "; }
-
-html.minimal .container { margin: 0; }
-html.minimal .container-main { padding-top: 50px; padding-bottom: 0; }
-html.minimal .content-wrap { padding-left: 300px; }
-html.minimal .tsd-navigation { position: fixed !important; overflow: auto; -webkit-overflow-scrolling: touch; overflow-scrolling: touch; box-sizing: border-box; z-index: 1; left: 0; top: 40px; bottom: 0; width: 300px; padding: 20px; margin: 0; }
-html.minimal .tsd-member .tsd-member { margin-left: 0; }
-html.minimal .tsd-page-toolbar { position: fixed; z-index: 2; }
-html.minimal #tsd-filter .tsd-filter-group { right: 0; -webkit-transform: none; transform: none; }
-html.minimal footer { background-color: transparent; }
-html.minimal footer .container { padding: 0; }
-html.minimal .tsd-generator { padding: 0; }
-@media (max-width: 900px) { html.minimal .tsd-navigation { display: none; }
-  html.minimal .content-wrap { padding-left: 0; } }
-
-dl.tsd-comment-tags { overflow: hidden; }
-dl.tsd-comment-tags dt { clear: both; float: left; padding: 1px 5px; margin: 0 10px 0 0; border-radius: 4px; border: 1px solid #808080; color: #808080; font-size: 0.8em; font-weight: normal; }
-dl.tsd-comment-tags dd { margin: 0 0 10px 0; }
-dl.tsd-comment-tags p { margin: 0; }
-
-.tsd-panel.tsd-comment .lead { font-size: 1.1em; line-height: 1.333em; margin-bottom: 2em; }
-.tsd-panel.tsd-comment .lead:last-child { margin-bottom: 0; }
-
-.toggle-protected .tsd-is-private { display: none; }
-
-.toggle-public .tsd-is-private, .toggle-public .tsd-is-protected, .toggle-public .tsd-is-private-protected { display: none; }
-
-.toggle-inherited .tsd-is-inherited { display: none; }
-
-.toggle-only-exported .tsd-is-not-exported { display: none; }
-
-.toggle-externals .tsd-is-external { display: none; }
-
-#tsd-filter { position: relative; display: inline-block; height: 40px; vertical-align: bottom; }
-.no-filter #tsd-filter { display: none; }
-#tsd-filter .tsd-filter-group { display: inline-block; height: 40px; vertical-align: bottom; white-space: nowrap; }
-#tsd-filter input { display: none; }
-@media (max-width: 900px) { #tsd-filter .tsd-filter-group { display: block; position: absolute; top: 40px; right: 20px; height: auto; background-color: #fff; visibility: hidden; -webkit-transform: translate(50%, 0); transform: translate(50%, 0); box-shadow: 0 0 4px rgba(0, 0, 0, 0.25); }
-  .has-options #tsd-filter .tsd-filter-group { visibility: visible; }
-  .to-has-options #tsd-filter .tsd-filter-group { -webkit-animation: fade-in 0.2s; animation: fade-in 0.2s; }
-  .from-has-options #tsd-filter .tsd-filter-group { -webkit-animation: fade-out 0.2s; animation: fade-out 0.2s; }
-  #tsd-filter label, #tsd-filter .tsd-select { display: block; padding-right: 20px; } }
-
-footer { border-top: 1px solid #eee; background-color: #fff; }
-footer.with-border-bottom { border-bottom: 1px solid #eee; }
-footer .tsd-legend-group { font-size: 0; }
-footer .tsd-legend { display: inline-block; width: 25%; padding: 0; font-size: 16px; list-style: none; line-height: 1.333em; vertical-align: top; }
-@media (max-width: 900px) { footer .tsd-legend { width: 50%; } }
-
-.tsd-hierarchy { list-style: square; padding: 0 0 0 20px; margin: 0; }
-.tsd-hierarchy .target { font-weight: bold; }
-
-.tsd-index-panel .tsd-index-content { margin-bottom: -30px !important; }
-.tsd-index-panel .tsd-index-section { margin-bottom: 30px !important; }
-.tsd-index-panel h3 { margin: 0 -20px 10px -20px; padding: 0 20px 10px 20px; border-bottom: 1px solid #eee; }
-.tsd-index-panel ul.tsd-index-list { -webkit-column-count: 3; -moz-column-count: 3; -ms-column-count: 3; -o-column-count: 3; column-count: 3; -webkit-column-gap: 20px; -moz-column-gap: 20px; -ms-column-gap: 20px; -o-column-gap: 20px; column-gap: 20px; padding: 0; list-style: none; line-height: 1.333em; }
-@media (max-width: 900px) { .tsd-index-panel ul.tsd-index-list { -webkit-column-count: 1; -moz-column-count: 1; -ms-column-count: 1; -o-column-count: 1; column-count: 1; } }
-@media (min-width: 901px) and (max-width: 1024px) { .tsd-index-panel ul.tsd-index-list { -webkit-column-count: 2; -moz-column-count: 2; -ms-column-count: 2; -o-column-count: 2; column-count: 2; } }
-.tsd-index-panel ul.tsd-index-list li { -webkit-column-break-inside: avoid; -moz-column-break-inside: avoid; -ms-column-break-inside: avoid; -o-column-break-inside: avoid; column-break-inside: avoid; -webkit-page-break-inside: avoid; -moz-page-break-inside: avoid; -ms-page-break-inside: avoid; -o-page-break-inside: avoid; page-break-inside: avoid; }
-
-.tsd-flag { display: inline-block; padding: 1px 5px; border-radius: 4px; color: #fff; background-color: #808080; text-indent: 0; font-size: 14px; font-weight: normal; }
-
-.tsd-anchor { position: absolute; top: -100px; }
-
-.tsd-member { position: relative; }
-.tsd-member .tsd-anchor + h3 { margin-top: 0; margin-bottom: 0; border-bottom: none; }
-
-.tsd-navigation { padding: 0 0 0 40px; }
-.tsd-navigation a { display: block; padding-top: 2px; padding-bottom: 2px; border-left: 2px solid transparent; color: #222; text-decoration: none; transition: border-left-color 0.1s; }
-.tsd-navigation a:hover { text-decoration: underline; }
-.tsd-navigation ul { margin: 0; padding: 0; list-style: none; }
-.tsd-navigation li { padding: 0; }
-
-.tsd-navigation.primary { padding-bottom: 40px; }
-.tsd-navigation.primary a { display: block; padding-top: 6px; padding-bottom: 6px; }
-.tsd-navigation.primary ul li a { padding-left: 5px; }
-.tsd-navigation.primary ul li li a { padding-left: 25px; }
-.tsd-navigation.primary ul li li li a { padding-left: 45px; }
-.tsd-navigation.primary ul li li li li a { padding-left: 65px; }
-.tsd-navigation.primary ul li li li li li a { padding-left: 85px; }
-.tsd-navigation.primary ul li li li li li li a { padding-left: 105px; }
-.tsd-navigation.primary > ul { border-bottom: 1px solid #eee; }
-.tsd-navigation.primary li { border-top: 1px solid #eee; }
-.tsd-navigation.primary li.current > a { font-weight: bold; }
-.tsd-navigation.primary li.label span { display: block; padding: 20px 0 6px 5px; color: #808080; }
-.tsd-navigation.primary li.globals + li > span, .tsd-navigation.primary li.globals + li > a { padding-top: 20px; }
-
-.tsd-navigation.secondary ul { transition: opacity 0.2s; }
-.tsd-navigation.secondary ul li a { padding-left: 25px; }
-.tsd-navigation.secondary ul li li a { padding-left: 45px; }
-.tsd-navigation.secondary ul li li li a { padding-left: 65px; }
-.tsd-navigation.secondary ul li li li li a { padding-left: 85px; }
-.tsd-navigation.secondary ul li li li li li a { padding-left: 105px; }
-.tsd-navigation.secondary ul li li li li li li a { padding-left: 125px; }
-.tsd-navigation.secondary ul.current a { border-left-color: #eee; }
-.tsd-navigation.secondary li.focus > a, .tsd-navigation.secondary ul.current li.focus > a { border-left-color: #000; }
-.tsd-navigation.secondary li.current { margin-top: 20px; margin-bottom: 20px; border-left-color: #eee; }
-.tsd-navigation.secondary li.current > a { font-weight: bold; }
-
-@media (min-width: 901px) { .menu-sticky-wrap { position: static; }
-  .no-csspositionsticky .menu-sticky-wrap.sticky { position: fixed; }
-  .no-csspositionsticky .menu-sticky-wrap.sticky-current { position: fixed; }
-  .no-csspositionsticky .menu-sticky-wrap.sticky-current ul.before-current, .no-csspositionsticky .menu-sticky-wrap.sticky-current ul.after-current { opacity: 0; }
-  .no-csspositionsticky .menu-sticky-wrap.sticky-bottom { position: absolute; top: auto !important; left: auto !important; bottom: 0; right: 0; }
-  .csspositionsticky .menu-sticky-wrap.sticky { position: -webkit-sticky; position: sticky; }
-  .csspositionsticky .menu-sticky-wrap.sticky-current { position: -webkit-sticky; position: sticky; } }
-
-.tsd-panel { margin: 20px 0; padding: 20px; background-color: #fff; box-shadow: 0 0 4px rgba(0, 0, 0, 0.25); }
-.tsd-panel:empty { display: none; }
-.tsd-panel > h1, .tsd-panel > h2, .tsd-panel > h3 { margin: 1.5em -20px 10px -20px; padding: 0 20px 10px 20px; border-bottom: 1px solid #eee; }
-.tsd-panel > h1.tsd-before-signature, .tsd-panel > h2.tsd-before-signature, .tsd-panel > h3.tsd-before-signature { margin-bottom: 0; border-bottom: 0; }
-.tsd-panel table { display: block; width: 100%; overflow: auto; margin-top: 10px; word-break: normal; word-break: keep-all; }
-.tsd-panel table th { font-weight: bold; }
-.tsd-panel table th, .tsd-panel table td { padding: 6px 13px; border: 1px solid #ddd; }
-.tsd-panel table tr { background-color: #fff; border-top: 1px solid #ccc; }
-.tsd-panel table tr:nth-child(2n) { background-color: #f8f8f8; }
-
-.tsd-panel-group { margin: 60px 0; }
-.tsd-panel-group > h1, .tsd-panel-group > h2, .tsd-panel-group > h3 { padding-left: 20px; padding-right: 20px; }
-
-#tsd-search { transition: background-color 0.2s; }
-#tsd-search .title { position: relative; z-index: 2; }
-#tsd-search .field { position: absolute; left: 0; top: 0; right: 40px; height: 40px; }
-#tsd-search .field input { box-sizing: border-box; position: relative; top: -50px; z-index: 1; width: 100%; padding: 0 10px; opacity: 0; outline: 0; border: 0; background: transparent; color: #222; }
-#tsd-search .field label { position: absolute; overflow: hidden; right: -40px; }
-#tsd-search .field input, #tsd-search .title { transition: opacity 0.2s; }
-#tsd-search .results { position: absolute; visibility: hidden; top: 40px; width: 100%; margin: 0; padding: 0; list-style: none; box-shadow: 0 0 4px rgba(0, 0, 0, 0.25); }
-#tsd-search .results li { padding: 0 10px; background-color: #fdfdfd; }
-#tsd-search .results li:nth-child(even) { background-color: #fff; }
-#tsd-search .results li.state { display: none; }
-#tsd-search .results li.current, #tsd-search .results li:hover { background-color: #eee; }
-#tsd-search .results a { display: block; }
-#tsd-search .results a:before { top: 10px; }
-#tsd-search .results span.parent { color: #808080; font-weight: normal; }
-#tsd-search.has-focus { background-color: #eee; }
-#tsd-search.has-focus .field input { top: 0; opacity: 1; }
-#tsd-search.has-focus .title { z-index: 0; opacity: 0; }
-#tsd-search.has-focus .results { visibility: visible; }
-#tsd-search.loading .results li.state.loading { display: block; }
-#tsd-search.failure .results li.state.failure { display: block; }
-
-.tsd-signature { margin: 0 0 1em 0; padding: 10px; border: 1px solid #eee; font-family: Menlo, Monaco, Consolas, "Courier New", monospace; font-size: 14px; }
-.tsd-signature.tsd-kind-icon { padding-left: 30px; }
-.tsd-signature.tsd-kind-icon:before { top: 10px; left: 10px; }
-.tsd-panel > .tsd-signature { margin-left: -20px; margin-right: -20px; border-width: 1px 0; }
-.tsd-panel > .tsd-signature.tsd-kind-icon { padding-left: 40px; }
-.tsd-panel > .tsd-signature.tsd-kind-icon:before { left: 20px; }
-
-.tsd-signature-symbol { color: #808080; font-weight: normal; }
-
-.tsd-signature-type { font-style: italic; font-weight: normal; }
-
-.tsd-signatures { padding: 0; margin: 0 0 1em 0; border: 1px solid #eee; }
-.tsd-signatures .tsd-signature { margin: 0; border-width: 1px 0 0 0; transition: background-color 0.1s; }
-.tsd-signatures .tsd-signature:first-child { border-top-width: 0; }
-.tsd-signatures .tsd-signature.current { background-color: #eee; }
-.tsd-signatures.active > .tsd-signature { cursor: pointer; }
-.tsd-panel > .tsd-signatures { margin-left: -20px; margin-right: -20px; border-width: 1px 0; }
-.tsd-panel > .tsd-signatures .tsd-signature.tsd-kind-icon { padding-left: 40px; }
-.tsd-panel > .tsd-signatures .tsd-signature.tsd-kind-icon:before { left: 20px; }
-.tsd-panel > a.anchor + .tsd-signatures { border-top-width: 0; margin-top: -20px; }
-
-ul.tsd-descriptions { position: relative; overflow: hidden; transition: height 0.3s; padding: 0; list-style: none; }
-ul.tsd-descriptions.active > .tsd-description { display: none; }
-ul.tsd-descriptions.active > .tsd-description.current { display: block; }
-ul.tsd-descriptions.active > .tsd-description.fade-in { -webkit-animation: fade-in-delayed 0.3s; animation: fade-in-delayed 0.3s; }
-ul.tsd-descriptions.active > .tsd-description.fade-out { -webkit-animation: fade-out-delayed 0.3s; animation: fade-out-delayed 0.3s; position: absolute; display: block; top: 0; left: 0; right: 0; opacity: 0; visibility: hidden; }
-ul.tsd-descriptions h4, ul.tsd-descriptions .tsd-index-panel h3, .tsd-index-panel ul.tsd-descriptions h3 { font-size: 16px; margin: 1em 0 0.5em 0; }
-
-ul.tsd-parameters, ul.tsd-type-parameters { list-style: square; margin: 0; padding-left: 20px; }
-ul.tsd-parameters > li.tsd-parameter-siganture, ul.tsd-type-parameters > li.tsd-parameter-siganture { list-style: none; margin-left: -20px; }
-ul.tsd-parameters h5, ul.tsd-type-parameters h5 { font-size: 16px; margin: 1em 0 0.5em 0; }
-ul.tsd-parameters .tsd-comment, ul.tsd-type-parameters .tsd-comment { margin-top: -0.5em; }
-
-.tsd-sources { font-size: 14px; color: #808080; margin: 0 0 1em 0; }
-.tsd-sources a { color: #808080; text-decoration: underline; }
-.tsd-sources ul, .tsd-sources p { margin: 0 !important; }
-.tsd-sources ul { list-style: none; padding: 0; }
-
-.tsd-page-toolbar { position: absolute; z-index: 1; top: 0; left: 0; width: 100%; height: 40px; color: #333; background: #fff; border-bottom: 1px solid #eee; }
-.tsd-page-toolbar a { color: #333; text-decoration: none; }
-.tsd-page-toolbar a.title { font-weight: bold; }
-.tsd-page-toolbar a.title:hover { text-decoration: underline; }
-.tsd-page-toolbar .table-wrap { display: table; width: 100%; height: 40px; }
-.tsd-page-toolbar .table-cell { display: table-cell; position: relative; white-space: nowrap; line-height: 40px; }
-.tsd-page-toolbar .table-cell:first-child { width: 100%; }
-
-.tsd-widget { display: inline-block; overflow: hidden; opacity: 0.6; height: 40px; transition: opacity 0.1s, background-color 0.2s; vertical-align: bottom; cursor: pointer; }
-.tsd-widget:hover { opacity: 0.8; }
-.tsd-widget.active { opacity: 1; background-color: #eee; }
-.tsd-widget.no-caption { width: 40px; }
-.tsd-widget.no-caption:before { margin: 0; }
-.tsd-widget.search:before { background-position: 0 0; }
-.tsd-widget.menu:before { background-position: -40px 0; }
-.tsd-widget.options:before { background-position: -80px 0; }
-.tsd-widget.options, .tsd-widget.menu { display: none; }
-@media (max-width: 900px) { .tsd-widget.options, .tsd-widget.menu { display: inline-block; } }
-input[type=checkbox] + .tsd-widget:before { background-position: -120px 0; }
-input[type=checkbox]:checked + .tsd-widget:before { background-position: -160px 0; }
-
-.tsd-select { position: relative; display: inline-block; height: 40px; transition: opacity 0.1s, background-color 0.2s; vertical-align: bottom; cursor: pointer; }
-.tsd-select .tsd-select-label { opacity: 0.6; transition: opacity 0.2s; }
-.tsd-select .tsd-select-label:before { background-position: -240px 0; }
-.tsd-select.active .tsd-select-label { opacity: 0.8; }
-.tsd-select.active .tsd-select-list { visibility: visible; opacity: 1; transition-delay: 0s; }
-.tsd-select .tsd-select-list { position: absolute; visibility: hidden; top: 40px; left: 0; margin: 0; padding: 0; opacity: 0; list-style: none; box-shadow: 0 0 4px rgba(0, 0, 0, 0.25); transition: visibility 0s 0.2s, opacity 0.2s; }
-.tsd-select .tsd-select-list li { padding: 0 20px 0 0; background-color: #fdfdfd; }
-.tsd-select .tsd-select-list li:before { background-position: 40px 0; }
-.tsd-select .tsd-select-list li:nth-child(even) { background-color: #fff; }
-.tsd-select .tsd-select-list li:hover { background-color: #eee; }
-.tsd-select .tsd-select-list li.selected:before { background-position: -200px 0; }
-@media (max-width: 900px) { .tsd-select .tsd-select-list { top: 0; left: auto; right: 100%; margin-right: -5px; }
-  .tsd-select .tsd-select-label:before { background-position: -280px 0; } }
-
-img { max-width: 100%; }
+.hljs {
+    display: inline-block;
+    padding: 0.5em;
+    background: white;
+    color: black;
+}
+
+.hljs-comment,
+.hljs-annotation,
+.hljs-template_comment,
+.diff .hljs-header,
+.hljs-chunk,
+.apache .hljs-cbracket {
+    color: #008000;
+}
+
+.hljs-keyword,
+.hljs-id,
+.hljs-built_in,
+.css .smalltalk .hljs-class,
+.hljs-winutils,
+.bash .hljs-variable,
+.tex .hljs-command,
+.hljs-request,
+.hljs-status,
+.nginx .hljs-title {
+    color: #00f;
+}
+
+.xml .hljs-tag {
+    color: #00f;
+}
+.xml .hljs-tag .hljs-value {
+    color: #00f;
+}
+
+.hljs-string,
+.hljs-title,
+.hljs-parent,
+.hljs-tag .hljs-value,
+.hljs-rules .hljs-value {
+    color: #a31515;
+}
+
+.ruby .hljs-symbol {
+    color: #a31515;
+}
+.ruby .hljs-symbol .hljs-string {
+    color: #a31515;
+}
+
+.hljs-template_tag,
+.django .hljs-variable,
+.hljs-addition,
+.hljs-flow,
+.hljs-stream,
+.apache .hljs-tag,
+.hljs-date,
+.tex .hljs-formula,
+.coffeescript .hljs-attribute {
+    color: #a31515;
+}
+
+.ruby .hljs-string,
+.hljs-decorator,
+.hljs-filter .hljs-argument,
+.hljs-localvars,
+.hljs-array,
+.hljs-attr_selector,
+.hljs-pseudo,
+.hljs-pi,
+.hljs-doctype,
+.hljs-deletion,
+.hljs-envvar,
+.hljs-shebang,
+.hljs-preprocessor,
+.hljs-pragma,
+.userType,
+.apache .hljs-sqbracket,
+.nginx .hljs-built_in,
+.tex .hljs-special,
+.hljs-prompt {
+    color: #2b91af;
+}
+
+.hljs-phpdoc,
+.hljs-javadoc,
+.hljs-xmlDocTag {
+    color: #808080;
+}
+
+.vhdl .hljs-typename {
+    font-weight: bold;
+}
+.vhdl .hljs-string {
+    color: #666666;
+}
+.vhdl .hljs-literal {
+    color: #a31515;
+}
+.vhdl .hljs-attribute {
+    color: #00b0e8;
+}
+
+.xml .hljs-attribute {
+    color: #f00;
+}
+
+.col > :first-child,
+.col-1 > :first-child,
+.col-2 > :first-child,
+.col-3 > :first-child,
+.col-4 > :first-child,
+.col-5 > :first-child,
+.col-6 > :first-child,
+.col-7 > :first-child,
+.col-8 > :first-child,
+.col-9 > :first-child,
+.col-10 > :first-child,
+.col-11 > :first-child,
+.tsd-panel > :first-child,
+ul.tsd-descriptions > li > :first-child,
+.col > :first-child > :first-child,
+.col-1 > :first-child > :first-child,
+.col-2 > :first-child > :first-child,
+.col-3 > :first-child > :first-child,
+.col-4 > :first-child > :first-child,
+.col-5 > :first-child > :first-child,
+.col-6 > :first-child > :first-child,
+.col-7 > :first-child > :first-child,
+.col-8 > :first-child > :first-child,
+.col-9 > :first-child > :first-child,
+.col-10 > :first-child > :first-child,
+.col-11 > :first-child > :first-child,
+.tsd-panel > :first-child > :first-child,
+ul.tsd-descriptions > li > :first-child > :first-child,
+.col > :first-child > :first-child > :first-child,
+.col-1 > :first-child > :first-child > :first-child,
+.col-2 > :first-child > :first-child > :first-child,
+.col-3 > :first-child > :first-child > :first-child,
+.col-4 > :first-child > :first-child > :first-child,
+.col-5 > :first-child > :first-child > :first-child,
+.col-6 > :first-child > :first-child > :first-child,
+.col-7 > :first-child > :first-child > :first-child,
+.col-8 > :first-child > :first-child > :first-child,
+.col-9 > :first-child > :first-child > :first-child,
+.col-10 > :first-child > :first-child > :first-child,
+.col-11 > :first-child > :first-child > :first-child,
+.tsd-panel > :first-child > :first-child > :first-child,
+ul.tsd-descriptions > li > :first-child > :first-child > :first-child {
+    margin-top: 0;
+}
+.col > :last-child,
+.col-1 > :last-child,
+.col-2 > :last-child,
+.col-3 > :last-child,
+.col-4 > :last-child,
+.col-5 > :last-child,
+.col-6 > :last-child,
+.col-7 > :last-child,
+.col-8 > :last-child,
+.col-9 > :last-child,
+.col-10 > :last-child,
+.col-11 > :last-child,
+.tsd-panel > :last-child,
+ul.tsd-descriptions > li > :last-child,
+.col > :last-child > :last-child,
+.col-1 > :last-child > :last-child,
+.col-2 > :last-child > :last-child,
+.col-3 > :last-child > :last-child,
+.col-4 > :last-child > :last-child,
+.col-5 > :last-child > :last-child,
+.col-6 > :last-child > :last-child,
+.col-7 > :last-child > :last-child,
+.col-8 > :last-child > :last-child,
+.col-9 > :last-child > :last-child,
+.col-10 > :last-child > :last-child,
+.col-11 > :last-child > :last-child,
+.tsd-panel > :last-child > :last-child,
+ul.tsd-descriptions > li > :last-child > :last-child,
+.col > :last-child > :last-child > :last-child,
+.col-1 > :last-child > :last-child > :last-child,
+.col-2 > :last-child > :last-child > :last-child,
+.col-3 > :last-child > :last-child > :last-child,
+.col-4 > :last-child > :last-child > :last-child,
+.col-5 > :last-child > :last-child > :last-child,
+.col-6 > :last-child > :last-child > :last-child,
+.col-7 > :last-child > :last-child > :last-child,
+.col-8 > :last-child > :last-child > :last-child,
+.col-9 > :last-child > :last-child > :last-child,
+.col-10 > :last-child > :last-child > :last-child,
+.col-11 > :last-child > :last-child > :last-child,
+.tsd-panel > :last-child > :last-child > :last-child,
+ul.tsd-descriptions > li > :last-child > :last-child > :last-child {
+    margin-bottom: 0;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 40px;
+}
+@media (max-width: 640px) {
+    .container {
+        padding: 0 20px;
+    }
+}
+
+.container-main {
+    padding-bottom: 200px;
+}
+
+.row {
+    position: relative;
+    margin: 0 -10px;
+}
+.row:after {
+    visibility: hidden;
+    display: block;
+    content: "";
+    clear: both;
+    height: 0;
+}
+
+.col,
+.col-1,
+.col-2,
+.col-3,
+.col-4,
+.col-5,
+.col-6,
+.col-7,
+.col-8,
+.col-9,
+.col-10,
+.col-11 {
+    box-sizing: border-box;
+    float: left;
+    padding: 0 10px;
+}
+
+.col-1 {
+    width: 8.33333%;
+}
+
+.offset-1 {
+    margin-left: 8.33333%;
+}
+
+.col-2 {
+    width: 16.66667%;
+}
+
+.offset-2 {
+    margin-left: 16.66667%;
+}
+
+.col-3 {
+    width: 25%;
+}
+
+.offset-3 {
+    margin-left: 25%;
+}
+
+.col-4 {
+    width: 33.33333%;
+}
+
+.offset-4 {
+    margin-left: 33.33333%;
+}
+
+.col-5 {
+    width: 41.66667%;
+}
+
+.offset-5 {
+    margin-left: 41.66667%;
+}
+
+.col-6 {
+    width: 50%;
+}
+
+.offset-6 {
+    margin-left: 50%;
+}
+
+.col-7 {
+    width: 58.33333%;
+}
+
+.offset-7 {
+    margin-left: 58.33333%;
+}
+
+.col-8 {
+    width: 66.66667%;
+}
+
+.offset-8 {
+    margin-left: 66.66667%;
+}
+
+.col-9 {
+    width: 75%;
+}
+
+.offset-9 {
+    margin-left: 75%;
+}
+
+.col-10 {
+    width: 83.33333%;
+}
+
+.offset-10 {
+    margin-left: 83.33333%;
+}
+
+.col-11 {
+    width: 91.66667%;
+}
+
+.offset-11 {
+    margin-left: 91.66667%;
+}
+
+.tsd-kind-icon {
+    display: block;
+    position: relative;
+    padding-left: 20px;
+    text-indent: -20px;
+}
+
+.tsd-signature.tsd-kind-icon:before {
+    background-position: 0 -153px;
+}
+
+.tsd-kind-object-literal > .tsd-kind-icon:before {
+    background-position: 0px -17px;
+}
+.tsd-kind-object-literal.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -17px -17px;
+}
+.tsd-kind-object-literal.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -34px -17px;
+}
+
+.tsd-kind-class > .tsd-kind-icon:before {
+    background-position: 0px -34px;
+}
+.tsd-kind-class.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -17px -34px;
+}
+.tsd-kind-class.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -34px -34px;
+}
+
+.tsd-kind-class.tsd-has-type-parameter > .tsd-kind-icon:before {
+    background-position: 0px -51px;
+}
+.tsd-kind-class.tsd-has-type-parameter.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -17px -51px;
+}
+.tsd-kind-class.tsd-has-type-parameter.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -34px -51px;
+}
+
+.tsd-kind-interface > .tsd-kind-icon:before {
+    background-position: 0px -68px;
+}
+.tsd-kind-interface.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -17px -68px;
+}
+.tsd-kind-interface.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -34px -68px;
+}
+
+.tsd-kind-interface.tsd-has-type-parameter > .tsd-kind-icon:before {
+    background-position: 0px -85px;
+}
+.tsd-kind-interface.tsd-has-type-parameter.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -17px -85px;
+}
+.tsd-kind-interface.tsd-has-type-parameter.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -34px -85px;
+}
+
+.tsd-kind-module > .tsd-kind-icon:before {
+    background-position: 0px -102px;
+}
+.tsd-kind-module.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -17px -102px;
+}
+.tsd-kind-module.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -34px -102px;
+}
+
+.tsd-kind-external-module > .tsd-kind-icon:before {
+    background-position: 0px -102px;
+}
+.tsd-kind-external-module.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -17px -102px;
+}
+.tsd-kind-external-module.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -34px -102px;
+}
+
+.tsd-kind-enum > .tsd-kind-icon:before {
+    background-position: 0px -119px;
+}
+.tsd-kind-enum.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -17px -119px;
+}
+.tsd-kind-enum.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -34px -119px;
+}
+
+.tsd-kind-enum-member > .tsd-kind-icon:before {
+    background-position: 0px -136px;
+}
+.tsd-kind-enum-member.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -17px -136px;
+}
+.tsd-kind-enum-member.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -34px -136px;
+}
+
+.tsd-kind-signature > .tsd-kind-icon:before {
+    background-position: 0px -153px;
+}
+.tsd-kind-signature.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -17px -153px;
+}
+.tsd-kind-signature.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -34px -153px;
+}
+
+.tsd-kind-type-alias > .tsd-kind-icon:before {
+    background-position: 0px -170px;
+}
+.tsd-kind-type-alias.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -17px -170px;
+}
+.tsd-kind-type-alias.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -34px -170px;
+}
+
+.tsd-kind-variable > .tsd-kind-icon:before {
+    background-position: -136px -0px;
+}
+.tsd-kind-variable.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -153px -0px;
+}
+.tsd-kind-variable.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -0px;
+}
+.tsd-kind-variable.tsd-parent-kind-class > .tsd-kind-icon:before {
+    background-position: -51px -0px;
+}
+.tsd-kind-variable.tsd-parent-kind-class.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -68px -0px;
+}
+.tsd-kind-variable.tsd-parent-kind-class.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -85px -0px;
+}
+.tsd-kind-variable.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -102px -0px;
+}
+.tsd-kind-variable.tsd-parent-kind-class.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -0px;
+}
+.tsd-kind-variable.tsd-parent-kind-enum > .tsd-kind-icon:before {
+    background-position: -170px -0px;
+}
+.tsd-kind-variable.tsd-parent-kind-enum.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -187px -0px;
+}
+.tsd-kind-variable.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -0px;
+}
+.tsd-kind-variable.tsd-parent-kind-interface > .tsd-kind-icon:before {
+    background-position: -204px -0px;
+}
+.tsd-kind-variable.tsd-parent-kind-interface.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -221px -0px;
+}
+
+.tsd-kind-property > .tsd-kind-icon:before {
+    background-position: -136px -0px;
+}
+.tsd-kind-property.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -153px -0px;
+}
+.tsd-kind-property.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -0px;
+}
+.tsd-kind-property.tsd-parent-kind-class > .tsd-kind-icon:before {
+    background-position: -51px -0px;
+}
+.tsd-kind-property.tsd-parent-kind-class.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -68px -0px;
+}
+.tsd-kind-property.tsd-parent-kind-class.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -85px -0px;
+}
+.tsd-kind-property.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -102px -0px;
+}
+.tsd-kind-property.tsd-parent-kind-class.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -0px;
+}
+.tsd-kind-property.tsd-parent-kind-enum > .tsd-kind-icon:before {
+    background-position: -170px -0px;
+}
+.tsd-kind-property.tsd-parent-kind-enum.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -187px -0px;
+}
+.tsd-kind-property.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -0px;
+}
+.tsd-kind-property.tsd-parent-kind-interface > .tsd-kind-icon:before {
+    background-position: -204px -0px;
+}
+.tsd-kind-property.tsd-parent-kind-interface.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -221px -0px;
+}
+
+.tsd-kind-get-signature > .tsd-kind-icon:before {
+    background-position: -136px -17px;
+}
+.tsd-kind-get-signature.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -153px -17px;
+}
+.tsd-kind-get-signature.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -17px;
+}
+.tsd-kind-get-signature.tsd-parent-kind-class > .tsd-kind-icon:before {
+    background-position: -51px -17px;
+}
+.tsd-kind-get-signature.tsd-parent-kind-class.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -68px -17px;
+}
+.tsd-kind-get-signature.tsd-parent-kind-class.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -85px -17px;
+}
+.tsd-kind-get-signature.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -102px -17px;
+}
+.tsd-kind-get-signature.tsd-parent-kind-class.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -17px;
+}
+.tsd-kind-get-signature.tsd-parent-kind-enum > .tsd-kind-icon:before {
+    background-position: -170px -17px;
+}
+.tsd-kind-get-signature.tsd-parent-kind-enum.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -187px -17px;
+}
+.tsd-kind-get-signature.tsd-parent-kind-enum.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -17px;
+}
+.tsd-kind-get-signature.tsd-parent-kind-interface > .tsd-kind-icon:before {
+    background-position: -204px -17px;
+}
+.tsd-kind-get-signature.tsd-parent-kind-interface.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -221px -17px;
+}
+
+.tsd-kind-set-signature > .tsd-kind-icon:before {
+    background-position: -136px -34px;
+}
+.tsd-kind-set-signature.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -153px -34px;
+}
+.tsd-kind-set-signature.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -34px;
+}
+.tsd-kind-set-signature.tsd-parent-kind-class > .tsd-kind-icon:before {
+    background-position: -51px -34px;
+}
+.tsd-kind-set-signature.tsd-parent-kind-class.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -68px -34px;
+}
+.tsd-kind-set-signature.tsd-parent-kind-class.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -85px -34px;
+}
+.tsd-kind-set-signature.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -102px -34px;
+}
+.tsd-kind-set-signature.tsd-parent-kind-class.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -34px;
+}
+.tsd-kind-set-signature.tsd-parent-kind-enum > .tsd-kind-icon:before {
+    background-position: -170px -34px;
+}
+.tsd-kind-set-signature.tsd-parent-kind-enum.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -187px -34px;
+}
+.tsd-kind-set-signature.tsd-parent-kind-enum.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -34px;
+}
+.tsd-kind-set-signature.tsd-parent-kind-interface > .tsd-kind-icon:before {
+    background-position: -204px -34px;
+}
+.tsd-kind-set-signature.tsd-parent-kind-interface.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -221px -34px;
+}
+
+.tsd-kind-accessor > .tsd-kind-icon:before {
+    background-position: -136px -51px;
+}
+.tsd-kind-accessor.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -153px -51px;
+}
+.tsd-kind-accessor.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -51px;
+}
+.tsd-kind-accessor.tsd-parent-kind-class > .tsd-kind-icon:before {
+    background-position: -51px -51px;
+}
+.tsd-kind-accessor.tsd-parent-kind-class.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -68px -51px;
+}
+.tsd-kind-accessor.tsd-parent-kind-class.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -85px -51px;
+}
+.tsd-kind-accessor.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -102px -51px;
+}
+.tsd-kind-accessor.tsd-parent-kind-class.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -51px;
+}
+.tsd-kind-accessor.tsd-parent-kind-enum > .tsd-kind-icon:before {
+    background-position: -170px -51px;
+}
+.tsd-kind-accessor.tsd-parent-kind-enum.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -187px -51px;
+}
+.tsd-kind-accessor.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -51px;
+}
+.tsd-kind-accessor.tsd-parent-kind-interface > .tsd-kind-icon:before {
+    background-position: -204px -51px;
+}
+.tsd-kind-accessor.tsd-parent-kind-interface.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -221px -51px;
+}
+
+.tsd-kind-function > .tsd-kind-icon:before {
+    background-position: -136px -68px;
+}
+.tsd-kind-function.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -153px -68px;
+}
+.tsd-kind-function.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -68px;
+}
+.tsd-kind-function.tsd-parent-kind-class > .tsd-kind-icon:before {
+    background-position: -51px -68px;
+}
+.tsd-kind-function.tsd-parent-kind-class.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -68px -68px;
+}
+.tsd-kind-function.tsd-parent-kind-class.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -85px -68px;
+}
+.tsd-kind-function.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -102px -68px;
+}
+.tsd-kind-function.tsd-parent-kind-class.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -68px;
+}
+.tsd-kind-function.tsd-parent-kind-enum > .tsd-kind-icon:before {
+    background-position: -170px -68px;
+}
+.tsd-kind-function.tsd-parent-kind-enum.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -187px -68px;
+}
+.tsd-kind-function.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -68px;
+}
+.tsd-kind-function.tsd-parent-kind-interface > .tsd-kind-icon:before {
+    background-position: -204px -68px;
+}
+.tsd-kind-function.tsd-parent-kind-interface.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -221px -68px;
+}
+
+.tsd-kind-method > .tsd-kind-icon:before {
+    background-position: -136px -68px;
+}
+.tsd-kind-method.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -153px -68px;
+}
+.tsd-kind-method.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -68px;
+}
+.tsd-kind-method.tsd-parent-kind-class > .tsd-kind-icon:before {
+    background-position: -51px -68px;
+}
+.tsd-kind-method.tsd-parent-kind-class.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -68px -68px;
+}
+.tsd-kind-method.tsd-parent-kind-class.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -85px -68px;
+}
+.tsd-kind-method.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -102px -68px;
+}
+.tsd-kind-method.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -68px;
+}
+.tsd-kind-method.tsd-parent-kind-enum > .tsd-kind-icon:before {
+    background-position: -170px -68px;
+}
+.tsd-kind-method.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -187px -68px;
+}
+.tsd-kind-method.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -68px;
+}
+.tsd-kind-method.tsd-parent-kind-interface > .tsd-kind-icon:before {
+    background-position: -204px -68px;
+}
+.tsd-kind-method.tsd-parent-kind-interface.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -221px -68px;
+}
+
+.tsd-kind-call-signature > .tsd-kind-icon:before {
+    background-position: -136px -68px;
+}
+.tsd-kind-call-signature.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -153px -68px;
+}
+.tsd-kind-call-signature.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -68px;
+}
+.tsd-kind-call-signature.tsd-parent-kind-class > .tsd-kind-icon:before {
+    background-position: -51px -68px;
+}
+.tsd-kind-call-signature.tsd-parent-kind-class.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -68px -68px;
+}
+.tsd-kind-call-signature.tsd-parent-kind-class.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -85px -68px;
+}
+.tsd-kind-call-signature.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -102px -68px;
+}
+.tsd-kind-call-signature.tsd-parent-kind-class.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -68px;
+}
+.tsd-kind-call-signature.tsd-parent-kind-enum > .tsd-kind-icon:before {
+    background-position: -170px -68px;
+}
+.tsd-kind-call-signature.tsd-parent-kind-enum.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -187px -68px;
+}
+.tsd-kind-call-signature.tsd-parent-kind-enum.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -68px;
+}
+.tsd-kind-call-signature.tsd-parent-kind-interface > .tsd-kind-icon:before {
+    background-position: -204px -68px;
+}
+.tsd-kind-call-signature.tsd-parent-kind-interface.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -221px -68px;
+}
+
+.tsd-kind-function.tsd-has-type-parameter > .tsd-kind-icon:before {
+    background-position: -136px -85px;
+}
+.tsd-kind-function.tsd-has-type-parameter.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -153px -85px;
+}
+.tsd-kind-function.tsd-has-type-parameter.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -85px;
+}
+.tsd-kind-function.tsd-has-type-parameter.tsd-parent-kind-class
+    > .tsd-kind-icon:before {
+    background-position: -51px -85px;
+}
+.tsd-kind-function.tsd-has-type-parameter.tsd-parent-kind-class.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -68px -85px;
+}
+.tsd-kind-function.tsd-has-type-parameter.tsd-parent-kind-class.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -85px -85px;
+}
+.tsd-kind-function.tsd-has-type-parameter.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -102px -85px;
+}
+.tsd-kind-function.tsd-has-type-parameter.tsd-parent-kind-class.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -85px;
+}
+.tsd-kind-function.tsd-has-type-parameter.tsd-parent-kind-enum
+    > .tsd-kind-icon:before {
+    background-position: -170px -85px;
+}
+.tsd-kind-function.tsd-has-type-parameter.tsd-parent-kind-enum.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -187px -85px;
+}
+.tsd-kind-function.tsd-has-type-parameter.tsd-parent-kind-enum.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -85px;
+}
+.tsd-kind-function.tsd-has-type-parameter.tsd-parent-kind-interface
+    > .tsd-kind-icon:before {
+    background-position: -204px -85px;
+}
+.tsd-kind-function.tsd-has-type-parameter.tsd-parent-kind-interface.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -221px -85px;
+}
+
+.tsd-kind-method.tsd-has-type-parameter > .tsd-kind-icon:before {
+    background-position: -136px -85px;
+}
+.tsd-kind-method.tsd-has-type-parameter.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -153px -85px;
+}
+.tsd-kind-method.tsd-has-type-parameter.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -85px;
+}
+.tsd-kind-method.tsd-has-type-parameter.tsd-parent-kind-class
+    > .tsd-kind-icon:before {
+    background-position: -51px -85px;
+}
+.tsd-kind-method.tsd-has-type-parameter.tsd-parent-kind-class.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -68px -85px;
+}
+.tsd-kind-method.tsd-has-type-parameter.tsd-parent-kind-class.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -85px -85px;
+}
+.tsd-kind-method.tsd-has-type-parameter.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -102px -85px;
+}
+.tsd-kind-method.tsd-has-type-parameter.tsd-parent-kind-class.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -85px;
+}
+.tsd-kind-method.tsd-has-type-parameter.tsd-parent-kind-enum
+    > .tsd-kind-icon:before {
+    background-position: -170px -85px;
+}
+.tsd-kind-method.tsd-has-type-parameter.tsd-parent-kind-enum.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -187px -85px;
+}
+.tsd-kind-method.tsd-has-type-parameter.tsd-parent-kind-enum.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -85px;
+}
+.tsd-kind-method.tsd-has-type-parameter.tsd-parent-kind-interface
+    > .tsd-kind-icon:before {
+    background-position: -204px -85px;
+}
+.tsd-kind-method.tsd-has-type-parameter.tsd-parent-kind-interface.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -221px -85px;
+}
+
+.tsd-kind-constructor > .tsd-kind-icon:before {
+    background-position: -136px -102px;
+}
+.tsd-kind-constructor.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -153px -102px;
+}
+.tsd-kind-constructor.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -102px;
+}
+.tsd-kind-constructor.tsd-parent-kind-class > .tsd-kind-icon:before {
+    background-position: -51px -102px;
+}
+.tsd-kind-constructor.tsd-parent-kind-class.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -68px -102px;
+}
+.tsd-kind-constructor.tsd-parent-kind-class.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -85px -102px;
+}
+.tsd-kind-constructor.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -102px -102px;
+}
+.tsd-kind-constructor.tsd-parent-kind-class.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -102px;
+}
+.tsd-kind-constructor.tsd-parent-kind-enum > .tsd-kind-icon:before {
+    background-position: -170px -102px;
+}
+.tsd-kind-constructor.tsd-parent-kind-enum.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -187px -102px;
+}
+.tsd-kind-constructor.tsd-parent-kind-enum.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -102px;
+}
+.tsd-kind-constructor.tsd-parent-kind-interface > .tsd-kind-icon:before {
+    background-position: -204px -102px;
+}
+.tsd-kind-constructor.tsd-parent-kind-interface.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -221px -102px;
+}
+
+.tsd-kind-constructor-signature > .tsd-kind-icon:before {
+    background-position: -136px -102px;
+}
+.tsd-kind-constructor-signature.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -153px -102px;
+}
+.tsd-kind-constructor-signature.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -102px;
+}
+.tsd-kind-constructor-signature.tsd-parent-kind-class > .tsd-kind-icon:before {
+    background-position: -51px -102px;
+}
+.tsd-kind-constructor-signature.tsd-parent-kind-class.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -68px -102px;
+}
+.tsd-kind-constructor-signature.tsd-parent-kind-class.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -85px -102px;
+}
+.tsd-kind-constructor-signature.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -102px -102px;
+}
+.tsd-kind-constructor-signature.tsd-parent-kind-class.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -102px;
+}
+.tsd-kind-constructor-signature.tsd-parent-kind-enum > .tsd-kind-icon:before {
+    background-position: -170px -102px;
+}
+.tsd-kind-constructor-signature.tsd-parent-kind-enum.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -187px -102px;
+}
+.tsd-kind-constructor-signature.tsd-parent-kind-enum.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -102px;
+}
+.tsd-kind-constructor-signature.tsd-parent-kind-interface
+    > .tsd-kind-icon:before {
+    background-position: -204px -102px;
+}
+.tsd-kind-constructor-signature.tsd-parent-kind-interface.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -221px -102px;
+}
+
+.tsd-kind-index-signature > .tsd-kind-icon:before {
+    background-position: -136px -119px;
+}
+.tsd-kind-index-signature.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -153px -119px;
+}
+.tsd-kind-index-signature.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -119px;
+}
+.tsd-kind-index-signature.tsd-parent-kind-class > .tsd-kind-icon:before {
+    background-position: -51px -119px;
+}
+.tsd-kind-index-signature.tsd-parent-kind-class.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -68px -119px;
+}
+.tsd-kind-index-signature.tsd-parent-kind-class.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -85px -119px;
+}
+.tsd-kind-index-signature.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -102px -119px;
+}
+.tsd-kind-index-signature.tsd-parent-kind-class.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -119px;
+}
+.tsd-kind-index-signature.tsd-parent-kind-enum > .tsd-kind-icon:before {
+    background-position: -170px -119px;
+}
+.tsd-kind-index-signature.tsd-parent-kind-enum.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -187px -119px;
+}
+.tsd-kind-index-signature.tsd-parent-kind-enum.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -119px;
+}
+.tsd-kind-index-signature.tsd-parent-kind-interface > .tsd-kind-icon:before {
+    background-position: -204px -119px;
+}
+.tsd-kind-index-signature.tsd-parent-kind-interface.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -221px -119px;
+}
+
+.tsd-kind-event > .tsd-kind-icon:before {
+    background-position: -136px -136px;
+}
+.tsd-kind-event.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -153px -136px;
+}
+.tsd-kind-event.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -136px;
+}
+.tsd-kind-event.tsd-parent-kind-class > .tsd-kind-icon:before {
+    background-position: -51px -136px;
+}
+.tsd-kind-event.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before {
+    background-position: -68px -136px;
+}
+.tsd-kind-event.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -85px -136px;
+}
+.tsd-kind-event.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -102px -136px;
+}
+.tsd-kind-event.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -136px;
+}
+.tsd-kind-event.tsd-parent-kind-enum > .tsd-kind-icon:before {
+    background-position: -170px -136px;
+}
+.tsd-kind-event.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -187px -136px;
+}
+.tsd-kind-event.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -136px;
+}
+.tsd-kind-event.tsd-parent-kind-interface > .tsd-kind-icon:before {
+    background-position: -204px -136px;
+}
+.tsd-kind-event.tsd-parent-kind-interface.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -221px -136px;
+}
+
+.tsd-is-static > .tsd-kind-icon:before {
+    background-position: -136px -153px;
+}
+.tsd-is-static.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -153px -153px;
+}
+.tsd-is-static.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -153px;
+}
+.tsd-is-static.tsd-parent-kind-class > .tsd-kind-icon:before {
+    background-position: -51px -153px;
+}
+.tsd-is-static.tsd-parent-kind-class.tsd-is-inherited > .tsd-kind-icon:before {
+    background-position: -68px -153px;
+}
+.tsd-is-static.tsd-parent-kind-class.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -85px -153px;
+}
+.tsd-is-static.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -102px -153px;
+}
+.tsd-is-static.tsd-parent-kind-class.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -153px;
+}
+.tsd-is-static.tsd-parent-kind-enum > .tsd-kind-icon:before {
+    background-position: -170px -153px;
+}
+.tsd-is-static.tsd-parent-kind-enum.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -187px -153px;
+}
+.tsd-is-static.tsd-parent-kind-enum.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -153px;
+}
+.tsd-is-static.tsd-parent-kind-interface > .tsd-kind-icon:before {
+    background-position: -204px -153px;
+}
+.tsd-is-static.tsd-parent-kind-interface.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -221px -153px;
+}
+
+.tsd-is-static.tsd-kind-function > .tsd-kind-icon:before {
+    background-position: -136px -170px;
+}
+.tsd-is-static.tsd-kind-function.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -153px -170px;
+}
+.tsd-is-static.tsd-kind-function.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -170px;
+}
+.tsd-is-static.tsd-kind-function.tsd-parent-kind-class > .tsd-kind-icon:before {
+    background-position: -51px -170px;
+}
+.tsd-is-static.tsd-kind-function.tsd-parent-kind-class.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -68px -170px;
+}
+.tsd-is-static.tsd-kind-function.tsd-parent-kind-class.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -85px -170px;
+}
+.tsd-is-static.tsd-kind-function.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -102px -170px;
+}
+.tsd-is-static.tsd-kind-function.tsd-parent-kind-class.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -170px;
+}
+.tsd-is-static.tsd-kind-function.tsd-parent-kind-enum > .tsd-kind-icon:before {
+    background-position: -170px -170px;
+}
+.tsd-is-static.tsd-kind-function.tsd-parent-kind-enum.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -187px -170px;
+}
+.tsd-is-static.tsd-kind-function.tsd-parent-kind-enum.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -170px;
+}
+.tsd-is-static.tsd-kind-function.tsd-parent-kind-interface
+    > .tsd-kind-icon:before {
+    background-position: -204px -170px;
+}
+.tsd-is-static.tsd-kind-function.tsd-parent-kind-interface.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -221px -170px;
+}
+
+.tsd-is-static.tsd-kind-method > .tsd-kind-icon:before {
+    background-position: -136px -170px;
+}
+.tsd-is-static.tsd-kind-method.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -153px -170px;
+}
+.tsd-is-static.tsd-kind-method.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -170px;
+}
+.tsd-is-static.tsd-kind-method.tsd-parent-kind-class > .tsd-kind-icon:before {
+    background-position: -51px -170px;
+}
+.tsd-is-static.tsd-kind-method.tsd-parent-kind-class.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -68px -170px;
+}
+.tsd-is-static.tsd-kind-method.tsd-parent-kind-class.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -85px -170px;
+}
+.tsd-is-static.tsd-kind-method.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -102px -170px;
+}
+.tsd-is-static.tsd-kind-method.tsd-parent-kind-class.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -170px;
+}
+.tsd-is-static.tsd-kind-method.tsd-parent-kind-enum > .tsd-kind-icon:before {
+    background-position: -170px -170px;
+}
+.tsd-is-static.tsd-kind-method.tsd-parent-kind-enum.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -187px -170px;
+}
+.tsd-is-static.tsd-kind-method.tsd-parent-kind-enum.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -170px;
+}
+.tsd-is-static.tsd-kind-method.tsd-parent-kind-interface
+    > .tsd-kind-icon:before {
+    background-position: -204px -170px;
+}
+.tsd-is-static.tsd-kind-method.tsd-parent-kind-interface.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -221px -170px;
+}
+
+.tsd-is-static.tsd-kind-call-signature > .tsd-kind-icon:before {
+    background-position: -136px -170px;
+}
+.tsd-is-static.tsd-kind-call-signature.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -153px -170px;
+}
+.tsd-is-static.tsd-kind-call-signature.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -170px;
+}
+.tsd-is-static.tsd-kind-call-signature.tsd-parent-kind-class
+    > .tsd-kind-icon:before {
+    background-position: -51px -170px;
+}
+.tsd-is-static.tsd-kind-call-signature.tsd-parent-kind-class.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -68px -170px;
+}
+.tsd-is-static.tsd-kind-call-signature.tsd-parent-kind-class.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -85px -170px;
+}
+.tsd-is-static.tsd-kind-call-signature.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -102px -170px;
+}
+.tsd-is-static.tsd-kind-call-signature.tsd-parent-kind-class.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -170px;
+}
+.tsd-is-static.tsd-kind-call-signature.tsd-parent-kind-enum
+    > .tsd-kind-icon:before {
+    background-position: -170px -170px;
+}
+.tsd-is-static.tsd-kind-call-signature.tsd-parent-kind-enum.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -187px -170px;
+}
+.tsd-is-static.tsd-kind-call-signature.tsd-parent-kind-enum.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -170px;
+}
+.tsd-is-static.tsd-kind-call-signature.tsd-parent-kind-interface
+    > .tsd-kind-icon:before {
+    background-position: -204px -170px;
+}
+.tsd-is-static.tsd-kind-call-signature.tsd-parent-kind-interface.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -221px -170px;
+}
+
+.tsd-is-static.tsd-kind-event > .tsd-kind-icon:before {
+    background-position: -136px -187px;
+}
+.tsd-is-static.tsd-kind-event.tsd-is-protected > .tsd-kind-icon:before {
+    background-position: -153px -187px;
+}
+.tsd-is-static.tsd-kind-event.tsd-is-private > .tsd-kind-icon:before {
+    background-position: -119px -187px;
+}
+.tsd-is-static.tsd-kind-event.tsd-parent-kind-class > .tsd-kind-icon:before {
+    background-position: -51px -187px;
+}
+.tsd-is-static.tsd-kind-event.tsd-parent-kind-class.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -68px -187px;
+}
+.tsd-is-static.tsd-kind-event.tsd-parent-kind-class.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -85px -187px;
+}
+.tsd-is-static.tsd-kind-event.tsd-parent-kind-class.tsd-is-protected.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -102px -187px;
+}
+.tsd-is-static.tsd-kind-event.tsd-parent-kind-class.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -187px;
+}
+.tsd-is-static.tsd-kind-event.tsd-parent-kind-enum > .tsd-kind-icon:before {
+    background-position: -170px -187px;
+}
+.tsd-is-static.tsd-kind-event.tsd-parent-kind-enum.tsd-is-protected
+    > .tsd-kind-icon:before {
+    background-position: -187px -187px;
+}
+.tsd-is-static.tsd-kind-event.tsd-parent-kind-enum.tsd-is-private
+    > .tsd-kind-icon:before {
+    background-position: -119px -187px;
+}
+.tsd-is-static.tsd-kind-event.tsd-parent-kind-interface
+    > .tsd-kind-icon:before {
+    background-position: -204px -187px;
+}
+.tsd-is-static.tsd-kind-event.tsd-parent-kind-interface.tsd-is-inherited
+    > .tsd-kind-icon:before {
+    background-position: -221px -187px;
+}
+
+.no-transition {
+    transition: none !important;
+}
+
+@-webkit-keyframes fade-in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes fade-in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+@-webkit-keyframes fade-out {
+    from {
+        opacity: 1;
+        visibility: visible;
+    }
+    to {
+        opacity: 0;
+    }
+}
+@keyframes fade-out {
+    from {
+        opacity: 1;
+        visibility: visible;
+    }
+    to {
+        opacity: 0;
+    }
+}
+@-webkit-keyframes fade-in-delayed {
+    0% {
+        opacity: 0;
+    }
+    33% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 1;
+    }
+}
+@keyframes fade-in-delayed {
+    0% {
+        opacity: 0;
+    }
+    33% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 1;
+    }
+}
+@-webkit-keyframes fade-out-delayed {
+    0% {
+        opacity: 1;
+        visibility: visible;
+    }
+    66% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 0;
+    }
+}
+@keyframes fade-out-delayed {
+    0% {
+        opacity: 1;
+        visibility: visible;
+    }
+    66% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 0;
+    }
+}
+@-webkit-keyframes shift-to-left {
+    from {
+        -webkit-transform: translate(0, 0);
+        transform: translate(0, 0);
+    }
+    to {
+        -webkit-transform: translate(-25%, 0);
+        transform: translate(-25%, 0);
+    }
+}
+@keyframes shift-to-left {
+    from {
+        -webkit-transform: translate(0, 0);
+        transform: translate(0, 0);
+    }
+    to {
+        -webkit-transform: translate(-25%, 0);
+        transform: translate(-25%, 0);
+    }
+}
+@-webkit-keyframes unshift-to-left {
+    from {
+        -webkit-transform: translate(-25%, 0);
+        transform: translate(-25%, 0);
+    }
+    to {
+        -webkit-transform: translate(0, 0);
+        transform: translate(0, 0);
+    }
+}
+@keyframes unshift-to-left {
+    from {
+        -webkit-transform: translate(-25%, 0);
+        transform: translate(-25%, 0);
+    }
+    to {
+        -webkit-transform: translate(0, 0);
+        transform: translate(0, 0);
+    }
+}
+@-webkit-keyframes pop-in-from-right {
+    from {
+        -webkit-transform: translate(100%, 0);
+        transform: translate(100%, 0);
+    }
+    to {
+        -webkit-transform: translate(0, 0);
+        transform: translate(0, 0);
+    }
+}
+@keyframes pop-in-from-right {
+    from {
+        -webkit-transform: translate(100%, 0);
+        transform: translate(100%, 0);
+    }
+    to {
+        -webkit-transform: translate(0, 0);
+        transform: translate(0, 0);
+    }
+}
+@-webkit-keyframes pop-out-to-right {
+    from {
+        -webkit-transform: translate(0, 0);
+        transform: translate(0, 0);
+        visibility: visible;
+    }
+    to {
+        -webkit-transform: translate(100%, 0);
+        transform: translate(100%, 0);
+    }
+}
+@keyframes pop-out-to-right {
+    from {
+        -webkit-transform: translate(0, 0);
+        transform: translate(0, 0);
+        visibility: visible;
+    }
+    to {
+        -webkit-transform: translate(100%, 0);
+        transform: translate(100%, 0);
+    }
+}
+body {
+    background: #fdfdfd;
+    font-family: "Segoe UI", sans-serif;
+    font-size: 16px;
+    color: #222;
+}
+
+a {
+    color: #4da6ff;
+    text-decoration: none;
+}
+a:hover {
+    text-decoration: underline;
+}
+
+code,
+pre {
+    font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+    padding: 0.2em;
+    margin: 0;
+    font-size: 14px;
+    background-color: rgba(0, 0, 0, 0.04);
+}
+
+pre {
+    padding: 10px;
+}
+pre code {
+    padding: 0;
+    font-size: 100%;
+    background-color: transparent;
+}
+
+.tsd-typography {
+    line-height: 1.333em;
+}
+.tsd-typography ul {
+    list-style: square;
+    padding: 0 0 0 20px;
+    margin: 0;
+}
+.tsd-typography h4,
+.tsd-typography .tsd-index-panel h3,
+.tsd-index-panel .tsd-typography h3,
+.tsd-typography h5,
+.tsd-typography h6 {
+    font-size: 1em;
+    margin: 0;
+}
+.tsd-typography h5,
+.tsd-typography h6 {
+    font-weight: normal;
+}
+.tsd-typography p,
+.tsd-typography ul,
+.tsd-typography ol {
+    margin: 1em 0;
+}
+
+@media (min-width: 901px) and (max-width: 1024px) {
+    html.default .col-content {
+        width: 72%;
+    }
+    html.default .col-menu {
+        width: 28%;
+    }
+    html.default .tsd-navigation {
+        padding-left: 10px;
+    }
+}
+@media (max-width: 900px) {
+    html.default .col-content {
+        float: none;
+        width: 100%;
+    }
+    html.default .col-menu {
+        position: fixed !important;
+        overflow: auto;
+        -webkit-overflow-scrolling: touch;
+        overflow-scrolling: touch;
+        z-index: 1024;
+        top: 0 !important;
+        bottom: 0 !important;
+        left: auto !important;
+        right: 0 !important;
+        width: 100%;
+        padding: 20px 20px 0 0;
+        max-width: 450px;
+        visibility: hidden;
+        background-color: #fff;
+        -webkit-transform: translate(100%, 0);
+        transform: translate(100%, 0);
+    }
+    html.default .col-menu > *:last-child {
+        padding-bottom: 20px;
+    }
+    html.default .overlay {
+        content: "";
+        display: block;
+        position: fixed;
+        z-index: 1023;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: rgba(0, 0, 0, 0.75);
+        visibility: hidden;
+    }
+    html.default.to-has-menu .overlay {
+        -webkit-animation: fade-in 0.4s;
+        animation: fade-in 0.4s;
+    }
+    html.default.to-has-menu header,
+    html.default.to-has-menu footer,
+    html.default.to-has-menu .col-content {
+        -webkit-animation: shift-to-left 0.4s;
+        animation: shift-to-left 0.4s;
+    }
+    html.default.to-has-menu .col-menu {
+        -webkit-animation: pop-in-from-right 0.4s;
+        animation: pop-in-from-right 0.4s;
+    }
+    html.default.from-has-menu .overlay {
+        -webkit-animation: fade-out 0.4s;
+        animation: fade-out 0.4s;
+    }
+    html.default.from-has-menu header,
+    html.default.from-has-menu footer,
+    html.default.from-has-menu .col-content {
+        -webkit-animation: unshift-to-left 0.4s;
+        animation: unshift-to-left 0.4s;
+    }
+    html.default.from-has-menu .col-menu {
+        -webkit-animation: pop-out-to-right 0.4s;
+        animation: pop-out-to-right 0.4s;
+    }
+    html.default.has-menu body {
+        overflow: hidden;
+    }
+    html.default.has-menu .overlay {
+        visibility: visible;
+    }
+    html.default.has-menu header,
+    html.default.has-menu footer,
+    html.default.has-menu .col-content {
+        -webkit-transform: translate(-25%, 0);
+        transform: translate(-25%, 0);
+    }
+    html.default.has-menu .col-menu {
+        visibility: visible;
+        -webkit-transform: translate(0, 0);
+        transform: translate(0, 0);
+    }
+}
+
+.tsd-page-title {
+    padding: 70px 0 20px 0;
+    margin: 0 0 40px 0;
+    background: #fff;
+    box-shadow: 0 0 5px rgba(0, 0, 0, 0.35);
+}
+.tsd-page-title h1 {
+    margin: 0;
+}
+
+.tsd-breadcrumb {
+    margin: 0;
+    padding: 0;
+    color: #808080;
+}
+.tsd-breadcrumb a {
+    color: #808080;
+    text-decoration: none;
+}
+.tsd-breadcrumb a:hover {
+    text-decoration: underline;
+}
+.tsd-breadcrumb li {
+    display: inline;
+}
+.tsd-breadcrumb li:after {
+    content: " / ";
+}
+
+html.minimal .container {
+    margin: 0;
+}
+html.minimal .container-main {
+    padding-top: 50px;
+    padding-bottom: 0;
+}
+html.minimal .content-wrap {
+    padding-left: 300px;
+}
+html.minimal .tsd-navigation {
+    position: fixed !important;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+    overflow-scrolling: touch;
+    box-sizing: border-box;
+    z-index: 1;
+    left: 0;
+    top: 40px;
+    bottom: 0;
+    width: 300px;
+    padding: 20px;
+    margin: 0;
+}
+html.minimal .tsd-member .tsd-member {
+    margin-left: 0;
+}
+html.minimal .tsd-page-toolbar {
+    position: fixed;
+    z-index: 2;
+}
+html.minimal #tsd-filter .tsd-filter-group {
+    right: 0;
+    -webkit-transform: none;
+    transform: none;
+}
+html.minimal footer {
+    background-color: transparent;
+}
+html.minimal footer .container {
+    padding: 0;
+}
+html.minimal .tsd-generator {
+    padding: 0;
+}
+@media (max-width: 900px) {
+    html.minimal .tsd-navigation {
+        display: none;
+    }
+    html.minimal .content-wrap {
+        padding-left: 0;
+    }
+}
+
+dl.tsd-comment-tags {
+    overflow: hidden;
+}
+dl.tsd-comment-tags dt {
+    clear: both;
+    float: left;
+    padding: 1px 5px;
+    margin: 0 10px 0 0;
+    border-radius: 4px;
+    border: 1px solid #808080;
+    color: #808080;
+    font-size: 0.8em;
+    font-weight: normal;
+}
+dl.tsd-comment-tags dd {
+    margin: 0 0 10px 0;
+}
+dl.tsd-comment-tags p {
+    margin: 0;
+}
+
+.tsd-panel.tsd-comment .lead {
+    font-size: 1.1em;
+    line-height: 1.333em;
+    margin-bottom: 2em;
+}
+.tsd-panel.tsd-comment .lead:last-child {
+    margin-bottom: 0;
+}
+
+.toggle-protected .tsd-is-private {
+    display: none;
+}
+
+.toggle-public .tsd-is-private,
+.toggle-public .tsd-is-protected,
+.toggle-public .tsd-is-private-protected {
+    display: none;
+}
+
+.toggle-inherited .tsd-is-inherited {
+    display: none;
+}
+
+.toggle-only-exported .tsd-is-not-exported {
+    display: none;
+}
+
+.toggle-externals .tsd-is-external {
+    display: none;
+}
+
+#tsd-filter {
+    position: relative;
+    display: inline-block;
+    height: 40px;
+    vertical-align: bottom;
+}
+.no-filter #tsd-filter {
+    display: none;
+}
+#tsd-filter .tsd-filter-group {
+    display: inline-block;
+    height: 40px;
+    vertical-align: bottom;
+    white-space: nowrap;
+}
+#tsd-filter input {
+    display: none;
+}
+@media (max-width: 900px) {
+    #tsd-filter .tsd-filter-group {
+        display: block;
+        position: absolute;
+        top: 40px;
+        right: 20px;
+        height: auto;
+        background-color: #fff;
+        visibility: hidden;
+        -webkit-transform: translate(50%, 0);
+        transform: translate(50%, 0);
+        box-shadow: 0 0 4px rgba(0, 0, 0, 0.25);
+    }
+    .has-options #tsd-filter .tsd-filter-group {
+        visibility: visible;
+    }
+    .to-has-options #tsd-filter .tsd-filter-group {
+        -webkit-animation: fade-in 0.2s;
+        animation: fade-in 0.2s;
+    }
+    .from-has-options #tsd-filter .tsd-filter-group {
+        -webkit-animation: fade-out 0.2s;
+        animation: fade-out 0.2s;
+    }
+    #tsd-filter label,
+    #tsd-filter .tsd-select {
+        display: block;
+        padding-right: 20px;
+    }
+}
+
+footer {
+    border-top: 1px solid #eee;
+    background-color: #fff;
+}
+footer.with-border-bottom {
+    border-bottom: 1px solid #eee;
+}
+footer .tsd-legend-group {
+    font-size: 0;
+}
+footer .tsd-legend {
+    display: inline-block;
+    width: 25%;
+    padding: 0;
+    font-size: 16px;
+    list-style: none;
+    line-height: 1.333em;
+    vertical-align: top;
+}
+@media (max-width: 900px) {
+    footer .tsd-legend {
+        width: 50%;
+    }
+}
+
+.tsd-hierarchy {
+    list-style: square;
+    padding: 0 0 0 20px;
+    margin: 0;
+}
+.tsd-hierarchy .target {
+    font-weight: bold;
+}
+
+.tsd-index-panel .tsd-index-content {
+    margin-bottom: -30px !important;
+}
+.tsd-index-panel .tsd-index-section {
+    margin-bottom: 30px !important;
+}
+.tsd-index-panel h3 {
+    margin: 0 -20px 10px -20px;
+    padding: 0 20px 10px 20px;
+    border-bottom: 1px solid #eee;
+}
+.tsd-index-panel ul.tsd-index-list {
+    -webkit-column-count: 3;
+    -moz-column-count: 3;
+    -ms-column-count: 3;
+    -o-column-count: 3;
+    column-count: 3;
+    -webkit-column-gap: 20px;
+    -moz-column-gap: 20px;
+    -ms-column-gap: 20px;
+    -o-column-gap: 20px;
+    column-gap: 20px;
+    padding: 0;
+    list-style: none;
+    line-height: 1.333em;
+}
+@media (max-width: 900px) {
+    .tsd-index-panel ul.tsd-index-list {
+        -webkit-column-count: 1;
+        -moz-column-count: 1;
+        -ms-column-count: 1;
+        -o-column-count: 1;
+        column-count: 1;
+    }
+}
+@media (min-width: 901px) and (max-width: 1024px) {
+    .tsd-index-panel ul.tsd-index-list {
+        -webkit-column-count: 2;
+        -moz-column-count: 2;
+        -ms-column-count: 2;
+        -o-column-count: 2;
+        column-count: 2;
+    }
+}
+.tsd-index-panel ul.tsd-index-list li {
+    -webkit-column-break-inside: avoid;
+    -moz-column-break-inside: avoid;
+    -ms-column-break-inside: avoid;
+    -o-column-break-inside: avoid;
+    column-break-inside: avoid;
+    -webkit-page-break-inside: avoid;
+    -moz-page-break-inside: avoid;
+    -ms-page-break-inside: avoid;
+    -o-page-break-inside: avoid;
+    page-break-inside: avoid;
+}
+
+.tsd-flag {
+    display: inline-block;
+    padding: 1px 5px;
+    border-radius: 4px;
+    color: #fff;
+    background-color: #808080;
+    text-indent: 0;
+    font-size: 14px;
+    font-weight: normal;
+}
+
+.tsd-anchor {
+    position: absolute;
+    top: -100px;
+}
+
+.tsd-member {
+    position: relative;
+}
+.tsd-member .tsd-anchor + h3 {
+    margin-top: 0;
+    margin-bottom: 0;
+    border-bottom: none;
+}
+
+.tsd-navigation {
+    padding: 0 0 0 40px;
+}
+.tsd-navigation a {
+    display: block;
+    padding-top: 2px;
+    padding-bottom: 2px;
+    border-left: 2px solid transparent;
+    color: #222;
+    text-decoration: none;
+    transition: border-left-color 0.1s;
+}
+.tsd-navigation a:hover {
+    text-decoration: underline;
+}
+.tsd-navigation ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+.tsd-navigation li {
+    padding: 0;
+}
+
+.tsd-navigation.primary {
+    padding-bottom: 40px;
+}
+.tsd-navigation.primary a {
+    display: block;
+    padding-top: 6px;
+    padding-bottom: 6px;
+}
+.tsd-navigation.primary ul li a {
+    padding-left: 5px;
+}
+.tsd-navigation.primary ul li li a {
+    padding-left: 25px;
+}
+.tsd-navigation.primary ul li li li a {
+    padding-left: 45px;
+}
+.tsd-navigation.primary ul li li li li a {
+    padding-left: 65px;
+}
+.tsd-navigation.primary ul li li li li li a {
+    padding-left: 85px;
+}
+.tsd-navigation.primary ul li li li li li li a {
+    padding-left: 105px;
+}
+.tsd-navigation.primary > ul {
+    border-bottom: 1px solid #eee;
+}
+.tsd-navigation.primary li {
+    border-top: 1px solid #eee;
+}
+.tsd-navigation.primary li.current > a {
+    font-weight: bold;
+}
+.tsd-navigation.primary li.label span {
+    display: block;
+    padding: 20px 0 6px 5px;
+    color: #808080;
+}
+.tsd-navigation.primary li.globals + li > span,
+.tsd-navigation.primary li.globals + li > a {
+    padding-top: 20px;
+}
+
+.tsd-navigation.secondary ul {
+    transition: opacity 0.2s;
+}
+.tsd-navigation.secondary ul li a {
+    padding-left: 25px;
+}
+.tsd-navigation.secondary ul li li a {
+    padding-left: 45px;
+}
+.tsd-navigation.secondary ul li li li a {
+    padding-left: 65px;
+}
+.tsd-navigation.secondary ul li li li li a {
+    padding-left: 85px;
+}
+.tsd-navigation.secondary ul li li li li li a {
+    padding-left: 105px;
+}
+.tsd-navigation.secondary ul li li li li li li a {
+    padding-left: 125px;
+}
+.tsd-navigation.secondary ul.current a {
+    border-left-color: #eee;
+}
+.tsd-navigation.secondary li.focus > a,
+.tsd-navigation.secondary ul.current li.focus > a {
+    border-left-color: #000;
+}
+.tsd-navigation.secondary li.current {
+    margin-top: 20px;
+    margin-bottom: 20px;
+    border-left-color: #eee;
+}
+.tsd-navigation.secondary li.current > a {
+    font-weight: bold;
+}
+
+@media (min-width: 901px) {
+    .menu-sticky-wrap {
+        position: static;
+    }
+    .no-csspositionsticky .menu-sticky-wrap.sticky {
+        position: fixed;
+    }
+    .no-csspositionsticky .menu-sticky-wrap.sticky-current {
+        position: fixed;
+    }
+    .no-csspositionsticky .menu-sticky-wrap.sticky-current ul.before-current,
+    .no-csspositionsticky .menu-sticky-wrap.sticky-current ul.after-current {
+        opacity: 0;
+    }
+    .no-csspositionsticky .menu-sticky-wrap.sticky-bottom {
+        position: absolute;
+        top: auto !important;
+        left: auto !important;
+        bottom: 0;
+        right: 0;
+    }
+    .csspositionsticky .menu-sticky-wrap.sticky {
+        position: -webkit-sticky;
+        position: sticky;
+    }
+    .csspositionsticky .menu-sticky-wrap.sticky-current {
+        position: -webkit-sticky;
+        position: sticky;
+    }
+}
+
+.tsd-panel {
+    margin: 20px 0;
+    padding: 20px;
+    background-color: #fff;
+    box-shadow: 0 0 4px rgba(0, 0, 0, 0.25);
+}
+.tsd-panel:empty {
+    display: none;
+}
+.tsd-panel > h1,
+.tsd-panel > h2,
+.tsd-panel > h3 {
+    margin: 1.5em -20px 10px -20px;
+    padding: 0 20px 10px 20px;
+    border-bottom: 1px solid #eee;
+}
+.tsd-panel > h1.tsd-before-signature,
+.tsd-panel > h2.tsd-before-signature,
+.tsd-panel > h3.tsd-before-signature {
+    margin-bottom: 0;
+    border-bottom: 0;
+}
+.tsd-panel table {
+    display: block;
+    width: 100%;
+    overflow: auto;
+    margin-top: 10px;
+    word-break: normal;
+    word-break: keep-all;
+}
+.tsd-panel table th {
+    font-weight: bold;
+}
+.tsd-panel table th,
+.tsd-panel table td {
+    padding: 6px 13px;
+    border: 1px solid #ddd;
+}
+.tsd-panel table tr {
+    background-color: #fff;
+    border-top: 1px solid #ccc;
+}
+.tsd-panel table tr:nth-child(2n) {
+    background-color: #f8f8f8;
+}
+
+.tsd-panel-group {
+    margin: 60px 0;
+}
+.tsd-panel-group > h1,
+.tsd-panel-group > h2,
+.tsd-panel-group > h3 {
+    padding-left: 20px;
+    padding-right: 20px;
+}
+
+#tsd-search {
+    transition: background-color 0.2s;
+}
+#tsd-search .title {
+    position: relative;
+    z-index: 2;
+}
+#tsd-search .field {
+    position: absolute;
+    left: 0;
+    top: 0;
+    right: 40px;
+    height: 40px;
+}
+#tsd-search .field input {
+    box-sizing: border-box;
+    position: relative;
+    top: -50px;
+    z-index: 1;
+    width: 100%;
+    padding: 0 10px;
+    opacity: 0;
+    outline: 0;
+    border: 0;
+    background: transparent;
+    color: #222;
+}
+#tsd-search .field label {
+    position: absolute;
+    overflow: hidden;
+    right: -40px;
+}
+#tsd-search .field input,
+#tsd-search .title {
+    transition: opacity 0.2s;
+}
+#tsd-search .results {
+    position: absolute;
+    visibility: hidden;
+    top: 40px;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    box-shadow: 0 0 4px rgba(0, 0, 0, 0.25);
+}
+#tsd-search .results li {
+    padding: 0 10px;
+    background-color: #fdfdfd;
+}
+#tsd-search .results li:nth-child(even) {
+    background-color: #fff;
+}
+#tsd-search .results li.state {
+    display: none;
+}
+#tsd-search .results li.current,
+#tsd-search .results li:hover {
+    background-color: #eee;
+}
+#tsd-search .results a {
+    display: block;
+}
+#tsd-search .results a:before {
+    top: 10px;
+}
+#tsd-search .results span.parent {
+    color: #808080;
+    font-weight: normal;
+}
+#tsd-search.has-focus {
+    background-color: #eee;
+}
+#tsd-search.has-focus .field input {
+    top: 0;
+    opacity: 1;
+}
+#tsd-search.has-focus .title {
+    z-index: 0;
+    opacity: 0;
+}
+#tsd-search.has-focus .results {
+    visibility: visible;
+}
+#tsd-search.loading .results li.state.loading {
+    display: block;
+}
+#tsd-search.failure .results li.state.failure {
+    display: block;
+}
+
+.tsd-signature {
+    margin: 0 0 1em 0;
+    padding: 10px;
+    border: 1px solid #eee;
+    font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+    font-size: 14px;
+}
+.tsd-signature.tsd-kind-icon {
+    padding-left: 30px;
+}
+.tsd-signature.tsd-kind-icon:before {
+    top: 10px;
+    left: 10px;
+}
+.tsd-panel > .tsd-signature {
+    margin-left: -20px;
+    margin-right: -20px;
+    border-width: 1px 0;
+}
+.tsd-panel > .tsd-signature.tsd-kind-icon {
+    padding-left: 40px;
+}
+.tsd-panel > .tsd-signature.tsd-kind-icon:before {
+    left: 20px;
+}
+
+.tsd-signature-symbol {
+    color: #808080;
+    font-weight: normal;
+}
+
+.tsd-signature-type {
+    font-style: italic;
+    font-weight: normal;
+}
+
+.tsd-signatures {
+    padding: 0;
+    margin: 0 0 1em 0;
+    border: 1px solid #eee;
+}
+.tsd-signatures .tsd-signature {
+    margin: 0;
+    border-width: 1px 0 0 0;
+    transition: background-color 0.1s;
+}
+.tsd-signatures .tsd-signature:first-child {
+    border-top-width: 0;
+}
+.tsd-signatures .tsd-signature.current {
+    background-color: #eee;
+}
+.tsd-signatures.active > .tsd-signature {
+    cursor: pointer;
+}
+.tsd-panel > .tsd-signatures {
+    margin-left: -20px;
+    margin-right: -20px;
+    border-width: 1px 0;
+}
+.tsd-panel > .tsd-signatures .tsd-signature.tsd-kind-icon {
+    padding-left: 40px;
+}
+.tsd-panel > .tsd-signatures .tsd-signature.tsd-kind-icon:before {
+    left: 20px;
+}
+.tsd-panel > a.anchor + .tsd-signatures {
+    border-top-width: 0;
+    margin-top: -20px;
+}
+
+ul.tsd-descriptions {
+    position: relative;
+    overflow: hidden;
+    transition: height 0.3s;
+    padding: 0;
+    list-style: none;
+}
+ul.tsd-descriptions.active > .tsd-description {
+    display: none;
+}
+ul.tsd-descriptions.active > .tsd-description.current {
+    display: block;
+}
+ul.tsd-descriptions.active > .tsd-description.fade-in {
+    -webkit-animation: fade-in-delayed 0.3s;
+    animation: fade-in-delayed 0.3s;
+}
+ul.tsd-descriptions.active > .tsd-description.fade-out {
+    -webkit-animation: fade-out-delayed 0.3s;
+    animation: fade-out-delayed 0.3s;
+    position: absolute;
+    display: block;
+    top: 0;
+    left: 0;
+    right: 0;
+    opacity: 0;
+    visibility: hidden;
+}
+ul.tsd-descriptions h4,
+ul.tsd-descriptions .tsd-index-panel h3,
+.tsd-index-panel ul.tsd-descriptions h3 {
+    font-size: 16px;
+    margin: 1em 0 0.5em 0;
+}
+
+ul.tsd-parameters,
+ul.tsd-type-parameters {
+    list-style: square;
+    margin: 0;
+    padding-left: 20px;
+}
+ul.tsd-parameters > li.tsd-parameter-siganture,
+ul.tsd-type-parameters > li.tsd-parameter-siganture {
+    list-style: none;
+    margin-left: -20px;
+}
+ul.tsd-parameters h5,
+ul.tsd-type-parameters h5 {
+    font-size: 16px;
+    margin: 1em 0 0.5em 0;
+}
+ul.tsd-parameters .tsd-comment,
+ul.tsd-type-parameters .tsd-comment {
+    margin-top: -0.5em;
+}
+
+.tsd-sources {
+    font-size: 14px;
+    color: #808080;
+    margin: 0 0 1em 0;
+}
+.tsd-sources a {
+    color: #808080;
+    text-decoration: underline;
+}
+.tsd-sources ul,
+.tsd-sources p {
+    margin: 0 !important;
+}
+.tsd-sources ul {
+    list-style: none;
+    padding: 0;
+}
+
+.tsd-page-toolbar {
+    position: absolute;
+    z-index: 1;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 40px;
+    color: #333;
+    background: #fff;
+    border-bottom: 1px solid #eee;
+}
+.tsd-page-toolbar a {
+    color: #333;
+    text-decoration: none;
+}
+.tsd-page-toolbar a.title {
+    font-weight: bold;
+}
+.tsd-page-toolbar a.title:hover {
+    text-decoration: underline;
+}
+.tsd-page-toolbar .table-wrap {
+    display: table;
+    width: 100%;
+    height: 40px;
+}
+.tsd-page-toolbar .table-cell {
+    display: table-cell;
+    position: relative;
+    white-space: nowrap;
+    line-height: 40px;
+}
+.tsd-page-toolbar .table-cell:first-child {
+    width: 100%;
+}
+
+.tsd-widget {
+    display: inline-block;
+    overflow: hidden;
+    opacity: 0.6;
+    height: 40px;
+    transition: opacity 0.1s, background-color 0.2s;
+    vertical-align: bottom;
+    cursor: pointer;
+}
+.tsd-widget:hover {
+    opacity: 0.8;
+}
+.tsd-widget.active {
+    opacity: 1;
+    background-color: #eee;
+}
+.tsd-widget.no-caption {
+    width: 40px;
+}
+.tsd-widget.no-caption:before {
+    margin: 0;
+}
+.tsd-widget.search:before {
+    background-position: 0 0;
+}
+.tsd-widget.menu:before {
+    background-position: -40px 0;
+}
+.tsd-widget.options:before {
+    background-position: -80px 0;
+}
+.tsd-widget.options,
+.tsd-widget.menu {
+    display: none;
+}
+@media (max-width: 900px) {
+    .tsd-widget.options,
+    .tsd-widget.menu {
+        display: inline-block;
+    }
+}
+input[type="checkbox"] + .tsd-widget:before {
+    background-position: -120px 0;
+}
+input[type="checkbox"]:checked + .tsd-widget:before {
+    background-position: -160px 0;
+}
+
+.tsd-select {
+    position: relative;
+    display: inline-block;
+    height: 40px;
+    transition: opacity 0.1s, background-color 0.2s;
+    vertical-align: bottom;
+    cursor: pointer;
+}
+.tsd-select .tsd-select-label {
+    opacity: 0.6;
+    transition: opacity 0.2s;
+}
+.tsd-select .tsd-select-label:before {
+    background-position: -240px 0;
+}
+.tsd-select.active .tsd-select-label {
+    opacity: 0.8;
+}
+.tsd-select.active .tsd-select-list {
+    visibility: visible;
+    opacity: 1;
+    transition-delay: 0s;
+}
+.tsd-select .tsd-select-list {
+    position: absolute;
+    visibility: hidden;
+    top: 40px;
+    left: 0;
+    margin: 0;
+    padding: 0;
+    opacity: 0;
+    list-style: none;
+    box-shadow: 0 0 4px rgba(0, 0, 0, 0.25);
+    transition: visibility 0s 0.2s, opacity 0.2s;
+}
+.tsd-select .tsd-select-list li {
+    padding: 0 20px 0 0;
+    background-color: #fdfdfd;
+}
+.tsd-select .tsd-select-list li:before {
+    background-position: 40px 0;
+}
+.tsd-select .tsd-select-list li:nth-child(even) {
+    background-color: #fff;
+}
+.tsd-select .tsd-select-list li:hover {
+    background-color: #eee;
+}
+.tsd-select .tsd-select-list li.selected:before {
+    background-position: -200px 0;
+}
+@media (max-width: 900px) {
+    .tsd-select .tsd-select-list {
+        top: 0;
+        left: auto;
+        right: 100%;
+        margin-right: -5px;
+    }
+    .tsd-select .tsd-select-label:before {
+        background-position: -280px 0;
+    }
+}
+
+img {
+    max-width: 100%;
+}
 
 /*****************************************************************************
  * THE FOLLOWING CSS SOURCE CODE WAS ADDED BY THE TRIDACTYL PROJECT
  ****************************************************************************/
 .container.container-main {
-  padding-top: 0px !important;
+    padding-top: 0px !important;
 }
 .tsd-navigation {
-  margin-top: 0px;
+    margin-top: 0px;
 }
 
 /* Unhide return values as they can be used in composite now*/
@@ -934,9 +2981,7 @@ ul.tsd-descriptions h4 {
 .tsd-flag {
     font-size: unset;
     border-radius: 2px;
-
 }
-
 
 /* Other changes:
  * - removed all background images in CSS above


### PR DESCRIPTION
Followup from https://github.com/cmcaine/tridactyl/pull/606#issuecomment-391721005.

**Changes:**

- I ran `prettier` on all of the CSS files in the repository. The main thing it changed was converting all indentation to 4 spaces.
- I added `"*.css"` files to `cachedJS` in `scripts/common` so that all new changes to CSS files will be prettified.