### PR TITLE
Js pipes

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1664,13 +1664,13 @@ export async function composite(...cmds: string[]) {
             .split(";")
             .reduce(
                 async (_, cmd) => {
-                    return cmd.split("|").reduce(
-                        async (pipedValue, cmd) => {
-                            let [fn, args] = excmd_parser.parser(cmd)
-                            return fn.call({}, ...args, await pipedValue)
-                        },
-                        "" as any,
-                    )
+                    await _
+                    let cmds = cmd.split("|")
+                    let [fn, args] = excmd_parser.parser(cmd)
+                    return cmds.slice(1).reduce(async (pipedValue, cmd) => {
+                        let [fn, args] = excmd_parser.parser(cmd)
+                        return fn.call({}, ...args, await pipedValue)
+                    }, fn.call({}, ...args))
                 },
                 null as any,
             )

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2424,10 +2424,18 @@ export async function echo(...str: string[]) {
  *
  * Aliased to `!js`
  *
+ * If you want to pipe an argument to `js`, you need to use the "-p" flag and then use the JS_ARG global variable, e.g:
+ *
+ * `composite get_current_url | js -p alert(JS_ARG)`
  */
 //#content
 export async function js(...str: string[]) {
-    return eval(str.join(" "))
+    if (str[0].startsWith("-p")) {
+        let JS_ARG = str[str.length - 1]
+        return eval(str.slice(1, -1).join(" "))
+    } else {
+        return eval(str.join(" "))
+    }
 }
 
 /**
@@ -2435,7 +2443,12 @@ export async function js(...str: string[]) {
  */
 //#background
 export async function jsb(...str: string[]) {
-    return eval(str.join(" "))
+    if (str[0].startsWith("-p")) {
+        let JS_ARG = str[str.length - 1]
+        return eval(str.slice(1, -1).join(" "))
+    } else {
+        return eval(str.join(" "))
+    }
 }
 
 /**  Open a welcome page on first install.

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1658,21 +1658,25 @@ export function repeat(n = 1, ...exstr: string[]) {
  */
 //#background
 export async function composite(...cmds: string[]) {
-    return cmds
-        .join(" ")
-        .split(";")
-        .reduce(
-            async (_, cmd) => {
-                return cmd.split("|").reduce(
-                    async (pipedValue, cmd) => {
-                        let [fn, args] = excmd_parser.parser(cmd)
-                        return fn.call({}, ...args, await pipedValue)
-                    },
-                    "" as any,
-                )
-            },
-            null as any,
-        )
+    try {
+        return cmds
+            .join(" ")
+            .split(";")
+            .reduce(
+                async (_, cmd) => {
+                    return cmd.split("|").reduce(
+                        async (pipedValue, cmd) => {
+                            let [fn, args] = excmd_parser.parser(cmd)
+                            return fn.call({}, ...args, await pipedValue)
+                        },
+                        "" as any,
+                    )
+                },
+                null as any,
+            )
+    } catch (e) {
+        logger.error(e)
+    }
 }
 
 //#background


### PR DESCRIPTION
Issue with previous discussion: https://github.com/cmcaine/tridactyl/issues/563

My code doesn't have the error handling the previous code had, but I'm not sure passing errors through pipes is a good idea. I believe it's better to just let the whole pipeline break. Are there disadvantages to not doing any "internal" error handling?

Also, I've added an "arg" variable to js and jsb for easy access to the piped value. I thought a bit about how to automatically insert "//" in the evaluated string but I can't come up with something that would be reliable. We could add a flag to js, perhaps "-p" for "pipe", which would be required to be at the very beginning of the command and would let js know it should insert "//" at the end of the string. Not having to manually remove the "//" at the end of a command you're editing from your history could be nice.
Are there alternatives I haven't thought of?