### PR TITLE
Make scrolling faster

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -628,7 +628,7 @@ export function unfocus() {
 
 //#content
 export async function scrollpx(a: number, b: number) {
-    if (!await scrolling.scroll(a, b, document.documentElement)) scrolling.recursiveScroll(a, b, [document.documentElement])
+    if (!await scrolling.scroll(a, b, document.documentElement)) scrolling.recursiveScroll(a, b)
 }
 
 /** If two numbers are given, treat as x and y values to give to window.scrollTo
@@ -671,7 +671,7 @@ export function scrollline(n = 1) {
         // Is there a better way to compute a fallback? Maybe fetch from about:preferences?
         if (!lineHeight) lineHeight = 22
     }
-    scrolling.recursiveScroll(0, lineHeight * n, [document.documentElement])
+    scrolling.recursiveScroll(0, lineHeight * n)
 }
 
 //#content

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -659,13 +659,19 @@ export function scrollto(a: number, b: number | "x" | "y" = "y") {
     }
 }
 
+//#content_helper
+let lineHeight = null
 //#content
 export function scrollline(n = 1) {
-    const cssHeight = window.getComputedStyle(document.body).getPropertyValue("line-height")
-    // Remove the "px" at the end
-    const lineHeight = parseInt(cssHeight.substr(0, cssHeight.length - 2))
-    // lineHeight probably can't be NaN but let's make sure
-    if (lineHeight) scrolling.recursiveScroll(0, lineHeight * n, [document.documentElement])
+    if (lineHeight === null) {
+        // Get line height
+        const cssHeight = window.getComputedStyle(document.body).getPropertyValue("line-height")
+        // Remove the "px" at the end
+        lineHeight = parseInt(cssHeight.substr(0, cssHeight.length - 2))
+        // Is there a better way to compute a fallback? Maybe fetch from about:preferences?
+        if (!lineHeight) lineHeight = 22
+    }
+    scrolling.recursiveScroll(0, lineHeight * n, [document.documentElement])
 }
 
 //#content

--- a/src/scrolling.ts
+++ b/src/scrolling.ts
@@ -7,20 +7,33 @@ let horizontallyScrolling = new Map()
 // Stores elements that are currently being vertically scrolled
 let verticallyScrolling = new Map()
 
+let opts = { smooth: null, duration: null }
 async function getSmooth() {
-    return await Native.getConfElsePrefElseDefault(
-        "smoothscroll",
-        "general.smoothScroll",
-        "false",
-    )
+    if (opts.smooth === null)
+        opts.smooth = await Native.getConfElsePrefElseDefault(
+            "smoothscroll",
+            "general.smoothScroll",
+            "false",
+        )
+    return opts.smooth
 }
 async function getDuration() {
-    return await Native.getConfElsePrefElseDefault(
-        "scrollduration",
-        "general.smoothScroll.lines.durationMinMs",
-        100,
-    )
+    if (opts.duration === null)
+        opts.duration = await Native.getConfElsePrefElseDefault(
+            "scrollduration",
+            "general.smoothScroll.lines.durationMinMs",
+            100,
+        )
+    return opts.duration
 }
+browser.storage.onChanged.addListener(changes => {
+    if ("userconfig" in changes) {
+        if ("smoothscroll" in changes.userconfig.newValue)
+            opts.smooth = changes.userconfig.newValue["smoothscroll"]
+        if ("scrollduration" in changes.userconfig.newValue)
+            opts.duration = changes.userconfig.newValue["scrollduration"]
+    }
+})
 
 class ScrollingData {
     // time at which the scrolling animation started
@@ -117,21 +130,22 @@ export async function scroll(
         // Don't create a new ScrollingData object if the element is already
         // being scrolled
         let scrollData = horizontallyScrolling.get(e)
-        if (!scrollData || !scrollData.scrolling)
-            scrollData = new ScrollingData(e, "scrollLeft")
+        if (!scrollData) scrollData = new ScrollingData(e, "scrollLeft")
         horizontallyScrolling.set(e, scrollData)
         result = result || scrollData.scroll(x, duration)
     }
     if (y != 0) {
         let scrollData = verticallyScrolling.get(e)
-        if (!scrollData || !scrollData.scrolling)
-            scrollData = new ScrollingData(e, "scrollTop")
+        if (!scrollData) scrollData = new ScrollingData(e, "scrollTop")
         verticallyScrolling.set(e, scrollData)
         result = result || scrollData.scroll(y, duration)
     }
     return result
 }
 
+let lastRecursiveScrolled = null
+let lastX = 0
+let lastY = 0
 /** Tries to find a node which can be scrolled either x pixels to the right or
  *  y pixels down among the Elements in {nodes} and children of these Elements.
  *
@@ -141,22 +155,50 @@ export async function scroll(
 export async function recursiveScroll(
     x: number,
     y: number,
-    nodes: Element[],
-    duration: number = undefined,
+    nodes: Element[] = undefined,
+    ignore: Element[] = [],
 ) {
-    // Determine whether to smoothscroll or not
-    let smooth = await getSmooth()
-    if (smooth == "false") duration = 0
-    else if (duration === undefined) duration = await getDuration()
-
+    let startingFromCached = false
+    if (!nodes) {
+        // Check if x and lastX have the same sign and if y and lastY have the same sign
+        if (lastRecursiveScrolled && (x ^ lastX) >= 0 && (y ^ lastY) >= 0) {
+            // We're scrolling in the same direction as the previous time so
+            // let's try to pick up from where we left
+            startingFromCached = true
+            nodes = [lastRecursiveScrolled]
+        } else {
+            nodes = [document.documentElement]
+        }
+    }
     let index = 0
     let now = performance.now()
     do {
-        let node = nodes[index++] as any
-        // Save the node's position
-        if (await scroll(x, y, node, duration)) return
+        let node
+        do {
+            node = nodes[index++] as any
+        } while (ignore.includes(node))
+        // If node is undefined or if we managed to scroll it
+        if (!node || (await scroll(x, y, node))) {
+            // Cache the node for next time and stop trying to scroll
+            lastRecursiveScrolled = node
+            return
+        }
         // Otherwise, add its children to the nodes that could be scrolled
         nodes = nodes.concat(Array.from(node.children))
         if (node.contentDocument) nodes.push(node.contentDocument.body)
     } while (index < nodes.length)
+    // If we reached this part, this means that we couldn't find an element to scroll
+    // If we started from a cached element, we can try to start again from the
+    // top of the document and ignore the cached element this time.
+    // It might be possible to further improve performance by first trying to
+    // recursiveScroll lastRecursiveScrolled sibling elements and only if
+    // that fails its parents but this seems unnecessary for now
+    if (startingFromCached) {
+        recursiveScroll(
+            x,
+            y,
+            [document.documentElement],
+            [lastRecursiveScrolled],
+        )
+    }
 }


### PR DESCRIPTION
I'm having a hard time reproducing the slowness I experienced when I reported https://github.com/cmcaine/tridactyl/issues/627 because I'm currently using a different computer but, if we can trust the profiler, it seems that caching the last element scrolled by `recursiveScroll` had a very positive impact, especially on https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html .