### PR TITLE
Add TabEnter and TabLeft autocommands

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -104,3 +104,11 @@ browser.runtime.onStartup.addListener(_ => {
         }
     })
 })
+
+let curTab = null
+browser.tabs.onActivated.addListener(ev => {
+    if (curTab !== null)
+        messaging.messageTab(curTab, "excmd_content", "loadaucmds", ["TabLeft"])
+    curTab = ev.tabId
+    messaging.messageTab(curTab, "excmd_content", "loadaucmds", ["TabEnter"])
+})

--- a/src/config.ts
+++ b/src/config.ts
@@ -146,6 +146,14 @@ const DEFAULTS = o({
         TriStart: o({
             ".*": "source_quiet",
         }),
+        TabEnter: o({
+            // "gmail.com": "mode ignore",
+        }),
+        TabLeft: o({
+            // Actually, this doesn't work because tabclose closes the current tab
+            // Too bad :/
+            // "emacs.org": "tabclose",
+        }),
     }),
     exaliases: o({
         alias: "command",

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1168,13 +1168,12 @@ export async function reader() {
 
 //@hidden
 //#content_helper
-loadaucmds()
+loadaucmds("DocStart")
 
 /** @hidden */
 //#content
-export async function loadaucmds() {
-    // for some reason, this never changes from the default, even when there is user config (e.g. set via `aucmd bbc.co.uk mode ignore`)
-    let aucmds = await config.getAsync("autocmds", "DocStart")
+export async function loadaucmds(cmdType: "DocStart" | "TabEnter" | "TabLeft") {
+    let aucmds = await config.getAsync("autocmds", cmdType)
     const ausites = Object.keys(aucmds)
     // yes, this is lazy
     const aukey = ausites.find(e => window.document.location.href.search(e) >= 0)
@@ -2087,7 +2086,7 @@ export function set(key: string, ...values: string[]) {
 export function autocmd(event: string, url: string, ...excmd: string[]) {
     // rudimentary run time type checking
     // TODO: Decide on autocmd event names
-    if (!["DocStart", "TriStart"].includes(event)) throw event + " is not a supported event."
+    if (!["DocStart", "TriStart", "TabEnter", "TabLeft"].includes(event)) throw event + " is not a supported event."
     config.set("autocmds", event, url, excmd.join(" "))
 }
 


### PR DESCRIPTION
The autocommand is "TabLeft" rather than "TabLeave" because it is triggered after the active tab has changed.
This will let people hack a true "ignore mode" for gmail & others.