### PR TITLE
scripts/{pretty,common}: Fix pretty failing on multiple files

### DIFF
--- a/scripts/common
+++ b/scripts/common
@@ -1,19 +1,26 @@
 #!/bin/bash
 
-cachedJS() {
-    git diff --cached --name-only --diff-filter=ACM "*.js" "*.jsx" "*.ts" "*.tsx" "*.md" "*.css" | tr '\n' ' '
+# Accepts no arguments
+# Returns git-add'ed files as a list of filenames separated by a newline character
+cachedFiles() {
+    git diff --cached --name-only --diff-filter=ACM "*.js" "*.jsx" "*.ts" "*.tsx" "*.md" "*.css"
 }
 
+# Accepts a single argument which is the name of a file tracked by git
+# Returns a string which is the content of the file as stored in the git index
 staged() {
     git show :"$1"
 }
 
+# Accepts a single string argument made of multiple file names separated by a newline
+# Returns an array of files that prettier wants to lint
 ugly() {
-    local acc=()
-    for jsfile in "$@"; do
-        diff <(staged $jsfile) <(staged $jsfile | $(npm bin)/prettier --stdin-filepath $jsfile) >/dev/null || acc+=("$jsfile")
+    local acc=""
+    local IFS=$'\n'
+    for jsfile in $1; do
+        diff <(staged "$jsfile") <(staged "$jsfile" | "$(npm bin)/prettier" --stdin-filepath "$jsfile") >/dev/null || acc="$jsfile"$'\n'"$acc"
     done
-    echo ${acc[@]}
+    echo "$acc"
 }
 
 noisy() {

--- a/scripts/pretty
+++ b/scripts/pretty
@@ -4,20 +4,21 @@ source ./scripts/common
 
 set -e
 
-uglyFiles=$(ugly $(cachedJS))
+uglyFiles="$(ugly "$(cachedFiles)")"
 
 if [ -n "$uglyFiles" ]; then
-  for file in "$uglyFiles"; do
-    if cmp -s <(staged $file) "$file"; then
+  IFS=$'\n'
+  for file in $uglyFiles; do
+    if cmp -s <(staged "$file") "$file"; then
       prettier --write "$file"
       git add "$file"
     else
       echo "WARN: Staged and working file differ: '$file'"
       echo "WARN: Moving working file temporarily (this might upset your editor)"
       # Get crazy: backup the working copy of the file, paste the staged version in its place, prettify, add, restore backup
-      backup=$(mktemp -p . $file.XXXXXXXXX)
+      backup=$(mktemp -p . "$file.XXXXXXXXX")
       mv "$file" "$backup"
-      staged "$file"|prettier --stdin-filepath "$file" > "$file"
+      staged "$file" | prettier --stdin-filepath "$file" > "$file"
       git add "$file"
       mv "$backup" "$file"
       echo "WARN: Working file restored"


### PR DESCRIPTION
When trying to run scripts/pretty with multiple ugly files staged, the for loop would treat two space-separated file names as a single file name. This prevented pretty from working on my machine.

I fixed this issue by making cachedJS() (renamed to cachedFiles since it returns more than js files) return file names as a newline-separated list and using IFS=$'\n' to split them.