### PR TITLE
Improve documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,8 @@ This is a (non-exhaustive) list of the most common normal-mode bindings. Type `:
 *   `ZZ` — close all tabs and windows, but only "save" them if your about:preferences are set to "show your tabs and windows from last time"
 *   `.` — repeat the last command
 
+You can try `:help key` to know more about `key`. If it is an existing binding, it will take you to the help section of the command that will be executed when pressing `key`. For example `:help .` will take you to the help section of the `repeat` command.
+
 #### Navigating with the current page
 
 *   `j`/`k` — scroll down/up

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -910,7 +910,10 @@ export async function help(excmd?: string) {
     if (excmd === undefined) excmd = ""
     else {
         let aliases = await config.getAsync("exaliases")
-        if (aliases[excmd] && !aliases[excmd].startsWith("composite")) excmd = aliases[excmd].split(" ")[0]
+        while (aliases[excmd]) {
+            excmd = aliases[excmd].split(" ")
+            excmd = excmd[0] == "composite" ? excmd[1] : excmd[0]
+        }
     }
     if ((await activeTab()).url.startsWith(docpage)) {
         open(docpage + "#" + excmd)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -531,6 +531,10 @@ export function loggingsetlevel(logModule: string, level: string) {
 //#content_helper
 export let JUMPED: boolean
 
+/** This is used as an ID for the current page in the jumplist.
+ *  It has a potentially confusing behavior: if you visit site A, then site B, then visit site A again, the jumplist that was created for your first visit on A will be re-used for your second visit.
+ *  An ideal solution would be to have a counter that is incremented every time a new page is visited within the tab and use that as the return value for getJumpPageId but this doesn't seem to be trivial to implement.
+ */
 //#content_helper
 export function getJumpPageId() {
     return document.location.href
@@ -546,12 +550,14 @@ export async function curJumps() {
     let tabid = await activeTabId()
     let jumps = await browserBg.sessions.getTabValue(tabid, "jumps")
     if (!jumps) jumps = {}
+    // This makes sure that `key` exists in `obj`, setting it to `def` if it doesn't
     let ensure = (obj, key, def) => {
         if (obj[key] === null || obj[key] === undefined) obj[key] = def
     }
     let page = getJumpPageId()
     ensure(jumps, page, {})
-    ensure(jumps[page], "list", [{ x: 0, y: 0 }])
+    let dummy = new UIEvent("scroll")
+    ensure(jumps[page], "list", [{ x: dummy.pageX, y: dummy.pageY }])
     ensure(jumps[page], "cur", 0)
     saveJumps(jumps)
     return jumps

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -888,6 +888,10 @@ export function home(all: "false" | "true" = "false") {
 export async function help(excmd?: string) {
     const docpage = browser.extension.getURL("static/docs/modules/_src_excmds_.html")
     if (excmd === undefined) excmd = ""
+    else {
+        let aliases = await config.getAsync("exaliases")
+        if (aliases[excmd] && !aliases[excmd].startsWith("composite")) excmd = aliases[excmd].split(" ")[0]
+    }
     if ((await activeTab()).url.startsWith(docpage)) {
         open(docpage + "#" + excmd)
     } else {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -528,23 +528,30 @@ export function loggingsetlevel(logModule: string, level: string) {
 
 // {{{ PAGE CONTEXT
 
+/** @hidden */
 //#content_helper
-export let JUMPED: boolean
+let JUMPED: boolean
 
 /** This is used as an ID for the current page in the jumplist.
- *  It has a potentially confusing behavior: if you visit site A, then site B, then visit site A again, the jumplist that was created for your first visit on A will be re-used for your second visit.
- *  An ideal solution would be to have a counter that is incremented every time a new page is visited within the tab and use that as the return value for getJumpPageId but this doesn't seem to be trivial to implement.
+    It has a potentially confusing behavior: if you visit site A, then site B, then visit site A again, the jumplist that was created for your first visit on A will be re-used for your second visit.
+    An ideal solution would be to have a counter that is incremented every time a new page is visited within the tab and use that as the return value for getJumpPageId but this doesn't seem to be trivial to implement.
+    @hidden
  */
 //#content_helper
 export function getJumpPageId() {
     return document.location.href
 }
 
+/** @hidden */
 //#content_helper
 export async function saveJumps(jumps) {
     browserBg.sessions.setTabValue(await activeTabId(), "jumps", jumps)
 }
 
+/** Returns a promise for an object containing the jumplist of all pages accessed in the current tab.
+    The keys of the object currently are the page's URL, however this might change some day. Use [[getJumpPageId]] to access the jumplist of a specific page.
+    @hidden
+ */
 //#content_helper
 export async function curJumps() {
     let tabid = await activeTabId()
@@ -563,14 +570,14 @@ export async function curJumps() {
     return jumps
 }
 
+/** Calls [[jumpprev]](-n) */
 //#content
 export function jumpnext(n = 1) {
     jumpprev(-n)
 }
 
 /** Similar to Pentadactyl or vim's jump list.
-    Should be bound to <C-o> when modifiers are implemented
-*/
+ */
 //#content
 export function jumpprev(n = 1) {
     curJumps().then(alljumps => {
@@ -600,6 +607,7 @@ export function jumpprev(n = 1) {
     The setTimeout call is required because sometimes a user wants to move
     somewhere by pressing 'j' multiple times and we don't want to add the
     in-between locations to the jump list
+    @hidden
 */
 //#content_helper
 export function addJump(scrollEvent: UIEvent) {
@@ -645,14 +653,17 @@ export function unfocus() {
     state.mode = "normal"
 }
 
+/** Scrolls the window or any scrollable child element by a pixels on the horizontal axis and b pixels on the vertical axis.
+ */
 //#content
 export async function scrollpx(a: number, b: number) {
     if (!await scrolling.scroll(a, b, document.documentElement)) scrolling.recursiveScroll(a, b)
 }
 
 /** If two numbers are given, treat as x and y values to give to window.scrollTo
-    If one number is given, scroll to that percentage along a chosen axis,
-        defaulting to the y-axis
+    If one number is given, scroll to that percentage along a chosen axis, defaulting to the y-axis
+
+    Note that if `a` is 0 or 100 and if the document is not scrollable in the given direction, Tridactyl will attempt to scroll the first scrollable element until it reaches the very bottom of that element.
 */
 //#content
 export function scrollto(a: number, b: number | "x" | "y" = "y") {
@@ -678,8 +689,13 @@ export function scrollto(a: number, b: number | "x" | "y" = "y") {
     }
 }
 
+/** @hidden */
 //#content_helper
 let lineHeight = null
+/** Scrolls the document of its first scrollable child element by n lines.
+ *
+ *  The height of a line is defined by the site's CSS. If Tridactyl can't get it, it'll default to 22 pixels.
+ */
 //#content
 export function scrollline(n = 1) {
     if (lineHeight === null) {
@@ -693,6 +709,10 @@ export function scrollline(n = 1) {
     scrolling.recursiveScroll(0, lineHeight * n)
 }
 
+/** Scrolls the document by n pages.
+ *
+ *  The height of a page is the current height of the window.
+ */
 //#content
 export function scrollpage(n = 1) {
     scrollpx(0, window.innerHeight * n)
@@ -1333,6 +1353,7 @@ export async function changelistjump(n?: number) {
     // state.prevInputs = arr
 }
 
+/** @hidden */
 //#content
 export function focusbyid(id: string) {
     document.getElementById(id).focus()
@@ -1802,6 +1823,9 @@ export async function composite(...cmds: string[]) {
     }
 }
 
+/** Sleep time_ms milliseconds.
+ *  This is probably only useful for composite commands that need to wait until the previous asynchronous command has finished running.
+ */
 //#background
 export async function sleep(time_ms: number) {
     await new Promise(resolve => setTimeout(resolve, time_ms))
@@ -2035,6 +2059,8 @@ export function searchsetkeyword(keyword: string, url: string) {
     e.g.
         set searchurls.google https://www.google.com/search?q=
         set logging.messaging info
+
+    If no value is given, the value of the of the key will be displayed
 */
 //#background
 export function set(key: string, ...values: string[]) {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -909,6 +909,11 @@ export async function help(excmd?: string) {
     const docpage = browser.extension.getURL("static/docs/modules/_src_excmds_.html")
     if (excmd === undefined) excmd = ""
     else {
+        let bindings = await config.getAsync("nmaps")
+        if (excmd in bindings) {
+            excmd = bindings[excmd].split(" ")
+            excmd = ["composite", "fillcmdline"].includes(excmd[0]) ? excmd[1] : excmd[0]
+        }
         let aliases = await config.getAsync("exaliases")
         while (aliases[excmd]) {
             excmd = aliases[excmd].split(" ")

--- a/src/help.ts
+++ b/src/help.ts
@@ -1,0 +1,80 @@
+// This file is only loaded in tridacyl's help pages
+
+import * as config from "./config"
+
+/** Creates the element that should contain alias information */
+function initTridactylAliases(elem: HTMLElement) {
+    let aliasNode = elem.getElementsByClassName("TridactylAliases")[0]
+    // If the node already exists
+    if (aliasNode) {
+        // Empty it
+        Array.from(aliasNode.children)
+            .filter(e => e.tagName == "LI")
+            .forEach(e => e.parentNode.removeChild(e))
+    } else {
+        // Otherwise, create it
+        aliasNode = document.createElement("ul")
+        aliasNode.className = "TridactylAliases"
+        aliasNode.textContent = "Aliases: "
+        elem.insertBefore(aliasNode, elem.children[2])
+    }
+    return aliasNode
+}
+
+/** Returns an object that maps excmd names to excmd documentation element */
+function getCommandElements() {
+    return Array.from(
+        document.querySelectorAll("section.tsd-panel-group:nth-child(3) h3"),
+    ).reduce((all, elem) => {
+        all[elem.textContent] = elem.parentElement
+        return all
+    }, {})
+}
+
+/** Updates the doc with aliases fetched from the config */
+async function setCommandAliases() {
+    let commandElems = getCommandElements()
+    // We're ignoring composite because it combines multiple excmds
+    delete commandElems["composite"]
+
+    // Initialize or reset the <ul> element that will contain aliases in each commandElem
+    let aliasElems = Object.keys(commandElems).reduce((aliasElems, cmdName) => {
+        aliasElems[cmdName] = initTridactylAliases(commandElems[cmdName])
+        return aliasElems
+    }, {})
+
+    let aliases = await config.getAsync("exaliases")
+    // For each alias
+    for (let alias in aliases) {
+        let excmd = aliases[alias].split(" ")[0]
+        // Find the corresponding alias
+        // We do this in a loop because aliases can be aliases for other aliases
+        while (aliases[excmd]) excmd = aliases[excmd].split(" ")[0]
+
+        // If there is an HTML element for aliases that correspond to the excmd we just found
+        if (aliasElems[excmd]) {
+            let aliasLi = document.createElement("li")
+            aliasLi.innerText = alias
+            aliasLi.title = aliases[alias]
+            // Add the alias to the element
+            aliasElems[excmd].appendChild(aliasLi)
+        }
+    }
+}
+
+browser.storage.onChanged.addListener((changes, areaname) => {
+    if ("userconfig" in changes) {
+        // JSON.stringify for comparisons like it's 2012
+        if (
+            JSON.stringify(changes.userconfig.newValue.exaliases) !=
+            JSON.stringify(changes.userconfig.oldValue.exaliases)
+        )
+            setCommandAliases()
+    }
+})
+
+addEventListener("load", () => {
+    setCommandAliases()
+    // setCommandAliases() can change the height of nodes in the page so we need to scroll to the right place again
+    document.location.href = document.location.href
+})

--- a/src/help.ts
+++ b/src/help.ts
@@ -60,6 +60,14 @@ async function setCommandAliases() {
             aliasElems[excmd].appendChild(aliasLi)
         }
     }
+
+    // Remove all aliasElems that do not have at least one alias
+    Object.values(aliasElems)
+        .filter(
+            (e: HTMLElement) =>
+                !Array.from(e.children).find(c => c.tagName == "LI"),
+        )
+        .forEach((e: HTMLElement) => e.parentNode.removeChild(e))
 }
 
 browser.storage.onChanged.addListener((changes, areaname) => {

--- a/src/static/clippy/command_mode.md
+++ b/src/static/clippy/command_mode.md
@@ -7,6 +7,7 @@ Command mode, i.e, "the console", is used for accessing less frequently used com
 *   `viewsource` to view the current page's source
 *   `viewconfig nmaps` to view the current normal mode bindings
 *   `help [command]` to access help on a command
+*   `help [key]` to access help on an existing binding
 *   `composite [command 1]; [command 2]; [command 3]...` lets you execute commands sequentially, useful for binding. If you want the results of each command to be piped to the other, use pipes `|` instead of semi-colons.
 
 We support a handful of keybinds in the console:

--- a/src/static/newtab.md
+++ b/src/static/newtab.md
@@ -37,6 +37,7 @@ REPLACE_ME_WITH_THE_CHANGE_LOG_USING_SED
 *   `[[`/`]]` — navigate forward/backward though paginated pages.
 *   `ZZ` — close all tabs and windows, but it will only "save" them if your about:preferences are set to "show your tabs and windows from last time".
 *   [`:help hint`][help-hint] to see all the other useful hint modes (this is the `f` magic. :) ).
+*   `:help <keybinding>` to learn more about what a specific key binding does.
 
 ## Important limitations due to WebExtensions
 
@@ -53,6 +54,8 @@ Tridactyl overrides your newtab page because it cannot insert its content script
 
 *   `:set newtab [URL]`
     *   e.g, `:set newtab about:blank`
+
+Also, if you want to use a new tab page provided by another extension, make sure to install said extension after Tridactyl. Uninstalling and re-installing the other extension should work too.
 
 ## FAQ
 

--- a/src/static/typedoc/assets/css/main.css
+++ b/src/static/typedoc/assets/css/main.css
@@ -2992,8 +2992,14 @@ ul.TridactylSetting {
     white-space: nowrap;
 }
 
+ul.TridactylSetting li {
+    font-family: Monospace;
+    font-weight: bold;
+}
+
 ul.TridactylSetting li:not(:last-child):after {
     content: ", ";
+    font-weight: normal;
 }
 
 /* Other changes:

--- a/src/static/typedoc/assets/css/main.css
+++ b/src/static/typedoc/assets/css/main.css
@@ -2983,7 +2983,7 @@ ul.tsd-descriptions h4 {
     border-radius: 2px;
 }
 
-ul.TridactylAliases {
+ul.TridactylSetting {
     display: flex;
     flex-direction: row;
     justify-content: flex-start;
@@ -2992,7 +2992,7 @@ ul.TridactylAliases {
     white-space: nowrap;
 }
 
-ul.TridactylAliases li:not(:last-child):after {
+ul.TridactylSetting li:not(:last-child):after {
     content: ", ";
 }
 

--- a/src/static/typedoc/assets/css/main.css
+++ b/src/static/typedoc/assets/css/main.css
@@ -2983,6 +2983,19 @@ ul.tsd-descriptions h4 {
     border-radius: 2px;
 }
 
+ul.TridactylAliases {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    list-style: none;
+    padding: 0;
+    white-space: nowrap;
+}
+
+ul.TridactylAliases li:not(:last-child):after {
+    content: ", ";
+}
+
 /* Other changes:
  * - removed all background images in CSS above
  * - reset all links to default FF colour

--- a/src/static/typedoc/layouts/default.hbs
+++ b/src/static/typedoc/layouts/default.hbs
@@ -7,6 +7,7 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="/content.js"></script>
+    <script src="/help.js"></script>
     <link rel="stylesheet" href="/static/css/content.css">
     <link rel="stylesheet" href="/static/css/hint.css">
     <link rel="stylesheet" href="/static/typedoc/assets/css/main.css">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ module.exports = {
         background: "./src/background.ts",
         content: "./src/content.ts",
         commandline_frame: "./src/commandline_frame.ts",
+        help: "./src/help.ts",
     },
     output: {
         filename: "[name].js",


### PR DESCRIPTION
These are various improvements to the help page.

- The first commit is contained in https://github.com/cmcaine/tridactyl/pull/640 .
- The second commit makes using `:help $aliasedcommand` work.
- The third commit hides a few variables and functions that should be hidden from the user.
- The fourth commit embeds current aliases into the documentation. For example, `:help tabprev` will show you that `tabprev` is aliased to `tp`.
- The fifth commit hides unnecessary elements in the documentation.
- The sixth commit displays current bindings in the documentation. E.g. if you do `:help tabprev`, you'll now know that `tabprev` is bound to `gT`.
- The seventh commit makes `:help` for aliases of aliases. E.g., before this commit, `:help colourscheme` would bring you to `set` but `:help colours` wouldn't. Now it works.
- The eighth commit makes searching for bindings work (e.g. `:help j`).