### PR TITLE
{excmds,controller}.ts: Fix race condition in state.mode synchronization

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -100,13 +100,15 @@ export function acceptKey(keyevent: MsgSafeKeyboardEvent) {
     generator.next(keyevent)
 }
 
+export let last_ex_str = ""
+
 /** Parse and execute ExCmds */
 export async function acceptExCmd(exstr: string): Promise<any> {
     // TODO: Errors should go to CommandLine.
     try {
         let [func, args] = exmode_parser(exstr)
         // Stop the repeat excmd from recursing.
-        if (func !== repeat) state.last_ex_str = exstr
+        if (func !== repeat) last_ex_str = exstr
         try {
             return await func(...args)
         } catch (e) {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1752,7 +1752,7 @@ import * as controller from "./controller"
 */
 //#background
 export function repeat(n = 1, ...exstr: string[]) {
-    let cmd = state.last_ex_str
+    let cmd = controller.last_ex_str
     if (exstr.length > 0) cmd = exstr.join(" ")
     logger.debug("repeating " + cmd + " " + n + " times")
     for (let i = 0; i < n; i++) controller.acceptExCmd(cmd)

--- a/src/state.ts
+++ b/src/state.ts
@@ -35,7 +35,6 @@ class State {
             jumppos: undefined,
         },
     ]
-    last_ex_str: string = ""
 }
 
 // Don't change these from const or you risk breaking the Proxy below.


### PR DESCRIPTION
This fixes https://github.com/cmcaine/tridactyl/issues/613.
This was a really fun bug. What happened was this:
- First, the content script set state.mode to "hint", which was then
  synchronized
- The event listener in the background script noticed the update and set
  state.mode to "hint" in the background script
- Then, the content script translated the hint selection into an excmd
  that needed to be executed in the background script and sent said
  command to the controller, which lives in the background script
- The content script then set state.mode to "normal"
- The background script executed the command and saved it in
  state.last_ex_str, which was then synchronized
- The event listener in the content script noticed the update and set
  last_ex_str to the last executed str and "state.mode" to "hint"

So basically, the problem was that the background script didn't notice
the state.mode update right after it happened. I fixed this by moving
last_ex_str out of "state" since it doesn't need to be synchronized with
the content script.

This means that the same kind of race condition can still happen. I'm
not sure how to fix this. We could just kill state completely and
instead have state be updated through message passing, but this probably
wouldn't be very ergonomic.
Another solution, the one envisioned for Tridactylv2, is to move state to the
content script entirely. This is probably the best option.