### PR TITLE
Fix precommit hook

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -2,7 +2,7 @@
 
 source ./scripts/common
 
-jsfiles=$(cachedJS)
+jsfiles=$(cachedFiles)
 
 [ -z "$jsfiles" ] && exit 0
 


### PR DESCRIPTION
I don't understand how I managed to miss it but I forgot to update the commit hook itself and an error message was being displayed about cachedJS not being defined.