### PR TITLE
Implement native messenger interaction with the X selection buffer

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -293,6 +293,8 @@ const DEFAULTS = o({
     //          (but we are probably happy to add your terminal to the list if it isn't already there).
     editorcmd: "auto",
     browser: "firefox",
+    externalclipboard: "last", // "only" | "first" | "last" | "never", see excmds.ts:clipboard() to know what this does
+    externalclipboardcmd: "auto",
     nativeinstallcmd:
         "curl -fsSl https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/install.sh | bash",
     win_powershell_nativeinstallcmd:

--- a/src/config.ts
+++ b/src/config.ts
@@ -293,7 +293,8 @@ const DEFAULTS = o({
     //          (but we are probably happy to add your terminal to the list if it isn't already there).
     editorcmd: "auto",
     browser: "firefox",
-    externalclipboard: "last", // "only" | "first" | "last" | "never", see excmds.ts:clipboard() to know what this does
+    yankto: "clipboard", // "clipboard", "selection", "both"
+    putfrom: "clipboard", // "clipboard", "selection"
     externalclipboardcmd: "auto",
     nativeinstallcmd:
         "curl -fsSl https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/install.sh | bash",

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2084,10 +2084,8 @@ async function setclip(str, selection = undefined) {
     let s = () => Native.clipboard("set", str)
     let c = () => messageActiveTab("commandline_frame", "setClipboard", [str])
 
-    if (selection === true)
-        return s()
-    if (selection === false)
-        return c()
+    if (selection === true) return s()
+    if (selection === false) return c()
 
     // "selection" is undefined here so let's try to determine what the user wants
     let external = await config.getAsync("externalclipboard")
@@ -2095,13 +2093,13 @@ async function setclip(str, selection = undefined) {
     switch (external) {
         case "only":
             promises = [s()]
-            break;
+            break
         case "first":
         case "last":
             promises = [s(), c()]
         case "never":
             promises = [c()]
-            break;
+            break
     }
     return Promise.all(promises)
 }
@@ -2117,17 +2115,13 @@ async function setclip(str, selection = undefined) {
 //#background_helper
 async function getclip(selection = undefined) {
     let external = await config.getAsync("externalclipboard")
-    let s = async () => (await Native.clipboard("get", "")).content
+    let s = async () => await Native.clipboard("get", "")
     let c = () => messageActiveTab("commandline_frame", "getClipboard")
-    if (selection === true)
-        return s()
-    if (selection === false)
-        return c()
-    if (["only", "first"].includes(external))
-        return s()
+    if (selection === true) return s()
+    if (selection === false) return c()
+    if (["only", "first"].includes(external)) return s()
     return c()
 }
-
 
 /** Use the system clipboard.
 
@@ -2166,7 +2160,7 @@ export async function clipboard(excmd: "open" | "yank" | "yankshort" | "yankcano
                 fillcmdline_tmp("3000", "# " + urls[0] + " copied to clipboard.")
                 break
             }
-            // Trying yankcanon if yankshort failed...
+        // Trying yankcanon if yankshort failed...
         case "yankcanon":
             urls = await geturlsforlinks("rel", "canonical")
             if (urls.length > 0) {
@@ -2174,7 +2168,7 @@ export async function clipboard(excmd: "open" | "yank" | "yankshort" | "yankcano
                 fillcmdline_tmp("3000", "# " + urls[0] + " copied to clipboard.")
                 break
             }
-            // Trying yank if yankcanon failed...
+        // Trying yank if yankcanon failed...
         case "yank":
             content = content == "" ? (await activeTab()).url : content
             await yank(content)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2097,6 +2097,7 @@ async function setclip(str, selection = undefined) {
         case "first":
         case "last":
             promises = [s(), c()]
+            break
         case "never":
             promises = [c()]
             break
@@ -2114,11 +2115,11 @@ async function setclip(str, selection = undefined) {
  */
 //#background_helper
 async function getclip(selection = undefined) {
-    let external = await config.getAsync("externalclipboard")
     let s = async () => await Native.clipboard("get", "")
     let c = () => messageActiveTab("commandline_frame", "getClipboard")
     if (selection === true) return s()
     if (selection === false) return c()
+    let external = await config.getAsync("externalclipboard")
     if (["only", "first"].includes(external)) return s()
     return c()
 }

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2081,16 +2081,15 @@ async function setclip(str) {
     let c = () => messageActiveTab("commandline_frame", "setClipboard", [str])
 
     let promises = []
-    switch (await config.getAsync("externalclipboard")) {
-        case "only":
+    switch (await config.getAsync("yankto")) {
+        case "selection":
             promises = [s()]
             break
-        case "first":
-        case "last":
-            promises = [s(), c()]
-            break
-        case "never":
+        case "clipboard":
             promises = [c()]
+            break
+        case "both":
+            promises = [s(), c()]
             break
     }
     return Promise.all(promises)
@@ -2102,13 +2101,10 @@ async function setclip(str) {
  */
 //#background_helper
 async function getclip() {
-    switch (await config.getAsync("externalclipboard")) {
-        case "only":
-        case "first":
-            return Native.clipboard("get", "")
-        case "last":
-        case "never":
+    if (await config.getAsync("putfrom") == "selection") {
             return messageActiveTab("commandline_frame", "getClipboard")
+    } else {
+            return Native.clipboard("get", "")
     }
 }
 
@@ -2126,11 +2122,11 @@ async function getclip() {
 
     If `excmd == "yankmd"`, copy the title and url of the open page formatted in Markdown for easy use on sites such as reddit.
 
-    If you're on Linux and the native messenger is installed, Tridactyl will call an external binary (either xclip or xsel) to read or write to your X selection buffer.
+    If you're on Linux and the native messenger is installed, Tridactyl will call an external binary (either xclip or xsel) to read or write to your X selection buffer. If you want another program to be used, set "externalclipboardcmd" to its name and make sure it has the same interface as xsel/xclip ("-i"/"-o" and reading from stdin).
 
-    When doing a read operation (i.e. open or tabopen), if "externalclipboard" is set to "only" or "first", the X selection buffer will be read instead of the clipboard. Set "externalclipboard" to "last" or "never" to use the clipboard.
+    When doing a read operation (i.e. open or tabopen), if "putfrom" is set to "selection", the X selection buffer will be read instead of the clipboard. Set "putfrom" to "clipboard" to use the clipboard.
 
-    When doing a write operation, if "externalclipboard" is set to "only", only the X selection buffer will be written to. If "externalclipboard" is set to "first" or "last", both the X selection and the clipboard will be written to. If "externalclipboard" is set to "never", only the clipboard will be written to.
+    When doing a write operation, if "yankto" is set to "selection", only the X selection buffer will be written to. If "yankto" is set to "both", both the X selection and the clipboard will be written to. If "yankto" is set to "clipboard", only the clipboard will be written to.
 
 */
 //#background


### PR DESCRIPTION
I think I managed to get native_background.ts:clipboard() right but it should be thoroughly reviewed anyway, if I left a bug in there an attacker could potentially execute arbitrary programs on a user's computer when they copy something.

This fixes https://github.com/cmcaine/tridactyl/issues/76 .