### PR TITLE
Containers 2: documented boogaloo

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -270,6 +270,7 @@ const DEFAULTS = o({
         messaging: 2,
         cmdline: 2,
         controller: 2,
+        containers: 2,
         hinting: 2,
         state: 2,
         excmd: 1,

--- a/src/config.ts
+++ b/src/config.ts
@@ -297,6 +297,9 @@ const DEFAULTS = o({
     // If enabled, tabopen opens a new tab in the currently active tab's container.
     tabopencontaineraware: "false",
 
+    // If moodeindicator is enabled, containerindicator will color the border of the mode indicator with the container color.
+    containerindicator: "true",
+
     // Performance related settings
 
     // number of most recent results to ask Firefox for. We display the top 20 or so most frequently visited ones.

--- a/src/content.ts
+++ b/src/content.ts
@@ -83,6 +83,9 @@ if (
 config.getAsync("modeindicator").then(mode => {
     if (mode !== "true") return
 
+    // Do we want container indicators?
+    let containerIndicator = config.get("containerindicator")
+
     // Hide indicator in print mode
     // CSS not explicitly added to the dom doesn't make it to print mode:
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1448507
@@ -100,6 +103,22 @@ config.getAsync("modeindicator").then(mode => {
         : ""
     statusIndicator.className =
         "cleanslate TridactylStatusIndicator " + privateMode
+
+    // Dynamically sets the border container color.
+    if (containerIndicator === "true") {
+        webext
+            .activeTabContainer()
+            .then(container => {
+                statusIndicator.setAttribute(
+                    "style",
+                    `border: ${container.colorCode} solid 1.5px !important`,
+                )
+            })
+            .catch(error => {
+                logger.debug(error)
+            })
+    }
+
     // This listener makes the modeindicator disappear when the mouse goes over it
     statusIndicator.addEventListener("mouseenter", ev => {
         let target = ev.target as any

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1771,12 +1771,8 @@ export async function containerclose(containerId: string) {
 }
 
 //#background
-export async function containerexists() {
-    //let container = { name: "tridactyl-container-test", color: "red" as browser.contextualIdentities.IdentityColor, icon: "fingerprint" as browser.contextualIdentities.IdentityIcon }
-    let container = { name: "ridiculous", color: "blue" as browser.contextualIdentities.IdentityColor, icon: "fingerprint" as browser.contextualIdentities.IdentityIcon }
-    console.log(container)
-    let res = await containerExists(container)
-    console.log(res)
+export async function containercreate(name: string, color: string, icon: string) {
+    containerCreate(name, color, icon)
 }
 
 // }}}

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1962,6 +1962,7 @@ export async function clipboard(excmd: "open" | "yank" | "yankshort" | "yankcano
     switch (excmd) {
         case "yankshort":
             urls = await geturlsforlinks("rel", "shortlink")
+            console.log(urls)
             if (urls.length == 0) {
                 urls = await geturlsforlinks("rev", "canonical")
             }

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -88,7 +88,7 @@
 // Shared
 import * as Messaging from "./messaging"
 import { l, browserBg, activeTabId, activeTabContainerId } from "./lib/webext"
-import { containerCreate, containerExists, containerGetId } from "./lib/containers"
+import { containerCreate, containerExists, containerFuzzyMatch } from "./lib/containers"
 import state from "./state"
 import * as UrlUtil from "./url_util"
 import * as config from "./config"
@@ -1486,23 +1486,16 @@ export async function tabopen(...addressarr: string[]) {
             args.shift()
             argParse(args)
         } else if (args[0] === "-c") {
-            if (await containerExists(args[1])) {
-                container = await containerGetId(args[1]) // Fetches the first matching result.
-                args.shift()
-                args.shift()
-            } else {
-                let msg = args[1]
-                args.shift()
-                logger.error("[tabopen] container does not exist")
-                throw new Error(`[tabopen] container does not exist: ${msg}`)
-            }
+            container = await containerFuzzyMatch(args[1])
+            args.shift()
+            args.shift()
             argParse(args)
         }
         return args
     }
+
     let url: string
-    let parsedAddress = await argParse(addressarr)
-    let address = parsedAddress.join(" ")
+    let address = (await argParse(addressarr)).join(" ")
 
     if (!ABOUT_WHITELIST.includes(address) && address.match(/^(about|file):.*/)) {
         if ((await browser.runtime.getPlatformInfo()).os === "mac" && (await browser.windows.getCurrent()).incognito) {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1962,7 +1962,6 @@ export async function clipboard(excmd: "open" | "yank" | "yankshort" | "yankcano
     switch (excmd) {
         case "yankshort":
             urls = await geturlsforlinks("rel", "shortlink")
-            console.log(urls)
             if (urls.length == 0) {
                 urls = await geturlsforlinks("rev", "canonical")
             }

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1757,11 +1757,11 @@ export async function qall() {
 // {{{ CONTAINERS
 
 /** Closes all tabs open in the same container across all windows.
- *  @param containerId
- *      The string represtation of the container id.
+ * @param name The container name.
  */
 //#background
-export async function containerclose(containerId: string) {
+export async function containerclose(name: string) {
+    let containerId = await Container.getId(name)
     browser.tabs.query({ cookieStoreId: containerId }).then(tabs => {
         browser.tabs.remove(
             tabs.map(tab => {
@@ -1787,8 +1787,7 @@ export async function containercreate(name: string, color?: string, icon?: strin
  */
 //#background
 export async function containerremove(name: string) {
-    let cid = await Container.getId(name)
-    await containerclose(cid)
+    await containerclose(name)
     await Container.remove(name)
 }
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -88,6 +88,7 @@
 // Shared
 import * as Messaging from "./messaging"
 import { l, browserBg, activeTabId, activeTabContainerId } from "./lib/webext"
+import { containerCreate, containerExists, containerGetFromId } from "./lib/containers"
 import state from "./state"
 import * as UrlUtil from "./url_util"
 import * as config from "./config"
@@ -1753,6 +1754,7 @@ export async function qall() {
 // }}}
 
 // {{{ CONTAINERS
+
 /** Closes all tabs open in the same container across all windows.
  * @param containerId
  *      The string represtation of the container id.
@@ -1767,6 +1769,16 @@ export async function containerclose(containerId: string) {
         )
     })
 }
+
+//#background
+export async function containerexists() {
+    //let container = { name: "tridactyl-container-test", color: "red" as browser.contextualIdentities.IdentityColor, icon: "fingerprint" as browser.contextualIdentities.IdentityIcon }
+    let container = { name: "ridiculous", color: "blue" as browser.contextualIdentities.IdentityColor, icon: "fingerprint" as browser.contextualIdentities.IdentityIcon }
+    console.log(container)
+    let res = await containerExists(container)
+    console.log(res)
+}
+
 // }}}
 //
 // {{{ MISC

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -88,7 +88,7 @@
 // Shared
 import * as Messaging from "./messaging"
 import { l, browserBg, activeTabId, activeTabContainerId } from "./lib/webext"
-import { containerCreate, containerExists, containerGetFromId } from "./lib/containers"
+import { containerCreate, containerExists, containerGetId } from "./lib/containers"
 import state from "./state"
 import * as UrlUtil from "./url_util"
 import * as config from "./config"
@@ -1480,26 +1480,29 @@ export async function tabopen(...addressarr: string[]) {
     let container
 
     // Lets us pass both -b and -c in no particular order as long as they are up front.
-    function argParse(args): string[] {
+    async function argParse(args): Promise<string[]> {
         if (args[0] === "-b") {
             active = false
             args.shift()
             argParse(args)
         } else if (args[0] === "-c") {
-            if (args[1].length !== 1) {
-                logger.debug("Container Id missing, opening tab with no container specified.")
+            if (await containerExists(args[1])) {
+                container = await containerGetId(args[1]) // Fetches the first matching result.
+                args.shift()
                 args.shift()
             } else {
-                container = args[1]
+                let msg = args[1]
                 args.shift()
-                args.shift()
+                logger.error("[tabopen] container does not exist")
+                throw new Error(`[tabopen] container does not exist: ${msg}`)
             }
             argParse(args)
         }
         return args
     }
     let url: string
-    let address = argParse(addressarr).join(" ")
+    let parsedAddress = await argParse(addressarr)
+    let address = parsedAddress.join(" ")
 
     if (!ABOUT_WHITELIST.includes(address) && address.match(/^(about|file):.*/)) {
         if ((await browser.runtime.getPlatformInfo()).os === "mac" && (await browser.windows.getCurrent()).incognito) {
@@ -1513,8 +1516,9 @@ export async function tabopen(...addressarr: string[]) {
     else url = forceURI(config.get("newtab"))
 
     activeTabContainerId().then(containerId => {
-        if (containerId && config.get("tabopencontaineraware") === "true") openInNewTab(url, { active: active, cookieStoreId: containerId })
-        else if (container) openInNewTab(url, { active: active, cookieStoreId: "firefox-container-" + container })
+        if (container) openInNewTab(url, { active: active, cookieStoreId: container })
+        // Ensure -c has priority.
+        else if (containerId && config.get("tabopencontaineraware") === "true") openInNewTab(url, { active: active, cookieStoreId: containerId })
         else openInNewTab(url, { active })
     })
 }

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1486,7 +1486,11 @@ export async function tabopen(...addressarr: string[]) {
             args.shift()
             argParse(args)
         } else if (args[0] === "-c") {
-            container = await containerFuzzyMatch(args[1])
+            // Ignore the -c flag if incognito as containers are disabled.
+            let win = await browser.windows.getCurrent()
+            if (!win["incognito"]) container = await containerFuzzyMatch(args[1])
+            else logger.error("[tabopen] can't open a container in a private browsing window.")
+
             args.shift()
             args.shift()
             argParse(args)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1793,7 +1793,7 @@ export async function containerupdate(name: string, uname: string, ucolor: strin
     try {
         let containerId = await Container.fuzzyMatch(name)
         let containerObj = Container.fromString(uname, ucolor, uicon)
-        Container.update(containerId, containerObj)
+        await Container.update(containerId, containerObj)
     } catch (e) {
         throw e
     }

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1770,15 +1770,20 @@ export async function containerclose(containerId: string) {
         )
     })
 }
-
+/** Creates a new container.
+ *
+ *  Further reading https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/contextualIdentities/ContextualIdentity
+ * @param name The container name. Must be unique.
+ * @param color The container color. Valid colors are: "blue", "turquoise", "green", "yellow", "orange", "red", "pink", "purple". If no color is chosen a random one will be selected from the list of valid colors.
+ * @param icon The container icon. Valid icons are: "fingerprint", "briefcase", "dollar", "cart", "circle", "gift", "vacation", "food", "fruit", "pet", "tree", "chill". If no icon is chosen, it defaults to "fingerprint".
+ */
 //#background
-export async function containercreate(name: string, color: string, icon: string) {
+export async function containercreate(name: string, color?: string, icon?: string) {
     await Container.create(name, color, icon)
 }
 
 /** Delete a container. Closes all tabs associated with that container beforehand.
- * @param name
- *      The container name
+ * @param name The container name.
  */
 //#background
 export async function containerremove(name: string) {
@@ -1787,6 +1792,21 @@ export async function containerremove(name: string) {
     await Container.remove(name)
 }
 
+/** Update a container's information. Note that none of the parameters are optional.
+ *
+ *  Example usage:
+ *
+ *  - Changing the container name: `containerupdate banking blockchain green dollar`
+ *
+ *  - Changing the container icon: `containerupdate banking banking green briefcase`
+ *
+ *  - Changing the container color: `containerupdate banking banking purple dollar`
+ *
+ * @param name The container name.
+ * @param uname The new container name. Must be unique.
+ * @param ucolor The new container color. Valid colors are: "blue", "turquoise", "green", "yellow", "orange", "red", "pink", "purple". If no color is chosen a random one will be selected from the list of valid colors.
+ * @param uicon The new container icon. Valid icons are: "fingerprint", "briefcase", "dollar", "cart", "circle", "gift", "vacation", "food", "fruit", "pet", "tree", "chill".
+ */
 //#background
 export async function containerupdate(name: string, uname: string, ucolor: string, uicon: string) {
     logger.debug("containerupdate parameters: " + name + ", " + uname + ", " + ucolor + ", " + uicon)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1757,12 +1757,12 @@ export async function qall() {
 // {{{ CONTAINERS
 
 /** Closes all tabs open in the same container across all windows.
- * @param containerId
+ *  @param containerId
  *      The string represtation of the container id.
  */
 //#background
 export async function containerclose(containerId: string) {
-    browser.tabs.query({ cookieStoreId: "firefox-container-" + containerId }).then(tabs => {
+    browser.tabs.query({ cookieStoreId: containerId }).then(tabs => {
         browser.tabs.remove(
             tabs.map(tab => {
                 return tab.id
@@ -1776,8 +1776,14 @@ export async function containercreate(name: string, color: string, icon: string)
     await Container.create(name, color, icon)
 }
 
+/** Delete a container. Closes all tabs associated with that container beforehand.
+ * @param name
+ *      The container name
+ */
 //#background
 export async function containerremove(name: string) {
+    let cid = await Container.getId(name)
+    await containerclose(cid)
     await Container.remove(name)
 }
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1733,6 +1733,24 @@ export async function qall() {
 
 // }}}
 
+// {{{ CONTAINERS
+/** Closes all tabs open in the same container across all windows.
+ * @param containerId
+ *      The string represtation of the container id.
+ */
+//#background
+export async function containerclose(containerId: string) {
+    browser.tabs.query({ cookieStoreId: "firefox-container-" + containerId }).then(tabs => {
+        console.log(tabs)
+        browser.tabs.remove(
+            tabs.map(tab => {
+                return tab.id
+            }),
+        )
+    })
+}
+// }}}
+//
 // {{{ MISC
 
 /** Deprecated

--- a/src/lib/containers.ts
+++ b/src/lib/containers.ts
@@ -29,6 +29,44 @@ export async function containerRemove(containerId: string) {
             console.log(`Removed container: ${removedContainer.cookieStoreId}`),
         )
 }
-export async function containerUpdate({}) {}
-export async function containerGet({}) {}
-export async function containerQuery({}) {}
+
+/** Updates the specified container
+ *  @param containerId - expects a single digit string.
+ *  @param containerUpdate - an object containing all parameters to update.
+ */
+export async function containerUpdate(containerId: string, {}) {}
+
+/** Gets a container object from a supplied container id string.
+ *  @param containerId - expects a single digit string.
+ */
+export async function containerGetFromId(containerId: string): Promise<{}> {
+    let container = await browser.contextualIdentities.get(
+        "firefox-container-" + containerId,
+    )
+    return container
+}
+
+/** Queries Firefox's contextual identities API for a container with a specific
+ *  name, icon and color. This is done to impose a unique constraint on those
+ *  parameters. function returns true if all the parameters have not been
+ *  supplied to ensure that checks for uniqueness can't be circumvented.
+ *  @params container
+ */
+export async function containerExists(container: {
+    name: string
+    color: browser.contextualIdentities.IdentityColor
+    icon: browser.contextualIdentities.IdentityIcon
+}): Promise<boolean> {
+    let exists = true
+    let res = await browser.contextualIdentities.query({ name: container.name })
+    if (res.length > 0) {
+        for (let c of res) {
+            console.log(c)
+            if (c.color !== container.color && c.icon !== container.icon)
+                exists = false
+        }
+    } else {
+        exists = false
+    }
+    return exists
+}

--- a/src/lib/containers.ts
+++ b/src/lib/containers.ts
@@ -1,73 +1,128 @@
 import * as Logging from "../logging"
-const logger = new Logging.Logger("excmd")
+const logger = new Logging.Logger("containers")
 
-/** Creates a container from the specified parameters. Unlike the official Mozilla addon, does not
- *  allow multiple  containers with the same (name, color, icon) constraint.
+const ContainerColor = [
+    "blue",
+    "turquoise",
+    "green",
+    "yellow",
+    "orange",
+    "red",
+    "pink",
+    "purple",
+]
+const ContainerIcon = [
+    "fingerprint",
+    "briefcase",
+    "dollar",
+    "cart",
+    "circle",
+    "gift",
+    "vacation",
+    "food",
+    "fruit",
+    "pet",
+    "tree",
+    "chill",
+]
+
+/** Creates a container from the specified parameters.Does not allow multiple containers with the same name.
  *  @param name  The container name.
- *  @param color  The container color, must be one of: "blue", "turquoise", "green", "yellow", "orange", "red", "pink" or "purple"
+ *  @param color  The container color, must be one of: "blue", "turquoise", "green", "yellow", "orange", "red", "pink" or "purple". If nothing is supplied, it selects one at random.
  *  @param icon  The container icon, must be one of: "fingerprint", "briefcase", "dollar", "cart", "circle", "gift", "vacation", "food", "fruit", "pet", "tree", "chill"
  */
-export async function containerCreate(
+export async function create(
     name: string,
-    color = "blue",
+    color = "random",
     icon = "fingerprint",
-) {
-    let container = containerFromString(name, color, icon)
-    if (await containerExists(name)) {
-        logger.error("[containerCreate] Container already exists, aborting.")
-        logger.debug(container)
+): Promise<string> {
+    if (color === "random") color = chooseRandomColor()
+    let container = fromString(name, color, icon)
+
+    if (await exists(name)) {
+        logger.debug(`[Container.create] container already exists ${container}`)
+        throw new Error(
+            `[Container.create] container already exists, aborting.`,
+        )
     } else {
-        browser.contextualIdentities
-            .create(container)
-            .then(newContainer =>
-                logger.info("Created container:", newContainer.cookieStoreId),
+        try {
+            let res = await browser.contextualIdentities.create(container)
+            logger.info(
+                "[Container.create] created container:",
+                res["cookieStoreId"],
             )
+            return res["cookieStoreId"]
+        } catch (e) {
+            throw e.message
+        }
     }
 }
 
-/** Removes specified container.
- *  @param containerId Expects a cookieStringId e.g. "firefox-container-n".
+/** Removes specified container. No fuzzy matching is intentional here. If there are multiple containers with the same name (allowed by other container plugins), it chooses the one with the lowest cookieStoreId
+ *  @param name The container name
  */
-export async function containerRemove(containerId: string) {
-    browser.contextualIdentities
-        .remove(containerId)
-        .then(removedContainer =>
-            logger.info("Removed container:", removedContainer.cookieStoreId),
-        )
+export async function remove(name: string) {
+    try {
+        let id = await getId(name)
+        let res = await browser.contextualIdentities.remove(id)
+        logger.debug("[Container.remove] removed container:", res.cookieStoreId)
+    } catch (e) {
+        throw e.message
+    }
 }
 
-/** Updates the specified container
+/** Updates the specified container.
  *  @param containerId Expects a cookieStringId e.g. "firefox-container-n".
- *  @param c An object containing all parameters to update.
+ *  @param name optional the new name of the container
+ *  @param color optional the new color of the container
+ *  @param icon optional the new icon of the container
  *  TODO: pass an object to this when tridactyl gets proper flag parsing
  */
-export async function containerUpdate(
+export async function update(
     containerId: string,
-    name: string,
-    color: string,
-    icon: string,
+    updateObj: {
+        name: string
+        color: browser.contextualIdentities.IdentityColor
+        icon: browser.contextualIdentities.IdentityIcon
+    },
 ) {
-    let currcontainer = await containerGetFromId(containerId)
-    let container = containerFromString(name, color, icon)
-    if (await containerExists(name)) {
-        logger.error("[containerUpdate] No values changed, aborting.")
-    } else {
-        browser.contextualIdentities.update(containerId, container)
+    try {
+        if (
+            isValidColor(updateObj["color"]) &&
+            isValidIcon(updateObj["icon"])
+        ) {
+            browser.contextualIdentities.update(containerId, updateObj)
+        } else {
+            logger.debug("[Container.update] invalid icon or color name")
+            logger.debug(updateObj)
+            throw new Error("[Container.update] invalid icon or color name")
+        }
+    } catch (e) {
+        throw e
     }
 }
 
 /** Gets a container object from a supplied container id string.
  *  @param containerId Expects a cookieStringId e.g. "firefox-container-n"
  */
-export async function containerGetFromId(containerId: string): Promise<{}> {
-    return await browser.contextualIdentities.get(containerId)
+export async function getFromId(containerId: string): Promise<{}> {
+    try {
+        return await browser.contextualIdentities.get(containerId)
+    } catch (e) {
+        logger.debug(
+            `[Container.getFromId] could not find a container with id: ${containerId}`,
+        )
+        throw new Error(
+            "[Container.getFromId] could not find a container with that id",
+        )
+    }
 }
 
 /** Queries Firefox's contextual identities API for a container with a specific name.
  *  @param string cname
  *  @returns boolean Returns true when cname matches an existing container or on query error.
  */
-export async function containerExists(cname: string): Promise<boolean> {
+export async function exists(cname: string): Promise<boolean> {
     let exists = false
     try {
         let res = await browser.contextualIdentities.query({ name: cname })
@@ -77,7 +132,7 @@ export async function containerExists(cname: string): Promise<boolean> {
     } catch (e) {
         exists = true // Make sure we don't accidentally break the constraint on query error.
         logger.error(
-            "[containerExists] Error querying contextualIdentities:",
+            "[Container.exists] Error querying contextualIdentities:",
             e,
         )
     }
@@ -85,23 +140,27 @@ export async function containerExists(cname: string): Promise<boolean> {
 }
 
 /** Takes string parameters and returns them as a pseudo container object
- *  for use in otherfunctions in the library.
+ *  for use in other functions in the library.
  *  @param name
  *  @param color
  *  @param icon
  */
-export function containerFromString(name: string, color: string, icon: string) {
-    return {
-        name: name,
-        color: color as browser.contextualIdentities.IdentityColor,
-        icon: icon as browser.contextualIdentities.IdentityIcon,
+export function fromString(name: string, color: string, icon: string) {
+    try {
+        return {
+            name: name,
+            color: color as browser.contextualIdentities.IdentityColor,
+            icon: icon as browser.contextualIdentities.IdentityIcon,
+        }
+    } catch (e) {
+        throw e
     }
 }
 
 /**
  *  @returns An array representation of all containers.
  */
-export async function containerGetAll(): Promise<any[]> {
+export async function getAll(): Promise<any[]> {
     return await browser.contextualIdentities.query({})
 }
 
@@ -109,18 +168,22 @@ export async function containerGetAll(): Promise<any[]> {
  * @param name The container name
  * @returns The cookieStoreId of the first match of the query.
  */
-export async function containerGetId(name: string): Promise<string> {
-    return (await browser.contextualIdentities.query({ name: name }))[0][
-        "cookieStoreId"
-    ]
+export async function getId(name: string): Promise<string> {
+    try {
+        return (await browser.contextualIdentities.query({ name: name }))[0][
+            "cookieStoreId"
+        ]
+    } catch (e) {
+        throw new Error(
+            "[Container.getId] could not find a container with that name.",
+        )
+    }
 }
 
-/**
- *
+/** Tries some simple ways to match containers to your input.
+ *  @param partialName The (partial) name of the container.
  */
-export async function containerFuzzyMatch(
-    partialName: string,
-): Promise<string> {
+export async function fuzzyMatch(partialName: string): Promise<string> {
     let exactMatch = await browser.contextualIdentities.query({
         name: partialName,
     })
@@ -128,11 +191,11 @@ export async function containerFuzzyMatch(
         return exactMatch[0]["cookieStoreId"]
     } else if (exactMatch.length > 1) {
         throw new Error(
-            "[containerFuzzyMatch] more than one container with this name exists.",
+            "[Container.fuzzyMatch] more than one container with this name exists.",
         )
     } else {
         let fuzzyMatches = []
-        let containers = await containerGetAll()
+        let containers = await getAll()
         for (let c of containers) {
             if (c["name"].indexOf(partialName) === 0) {
                 // Only match start of name.
@@ -143,12 +206,33 @@ export async function containerFuzzyMatch(
             return fuzzyMatches[0]["cookieStoreId"]
         } else if (fuzzyMatches.length > 1) {
             throw new Error(
-                "[containerFuzzyMatch] ambiguous match, provide more characters",
+                "[Container.fuzzyMatch] ambiguous match, provide more characters",
             )
         } else {
             throw new Error(
-                "[containerFuzzyMatch] no container matched that string",
+                "[Container.fuzzyMatch] no container matched that string",
             )
         }
     }
+}
+
+/** Helper function for create, returns a random valid IdentityColor for use if no color is applied at creation.*/
+export function chooseRandomColor(): string {
+    let max = Math.floor(ContainerColor.length)
+    let n = Math.floor(Math.random() * max)
+    return ContainerColor[n]
+}
+
+export function isValidColor(color: string): boolean {
+    for (let c of ContainerColor) {
+        if (c === color) return true
+    }
+    return false
+}
+
+export function isValidIcon(icon: string): boolean {
+    for (let i of ContainerIcon) {
+        if (i === icon) return true
+    }
+    return false
 }

--- a/src/lib/containers.ts
+++ b/src/lib/containers.ts
@@ -1,8 +1,6 @@
-import * as Logging from '../logging'
+import * as Logging from "../logging"
 const logger = new Logging.Logger("excmd")
 //TODO: refactor the whole "firefox-container" + containerId thing into something more sensible.
-
-
 
 /** Creates a container from the specified parameters. Unlike the official Mozilla addon, does not
  *  allow multiple  containers with the same (name, color, icon) constraint.
@@ -15,58 +13,61 @@ export async function containerCreate(
     color: string,
     icon: string,
 ) {
-    let c = containerFromString(name, color, icon);
+    let c = containerFromString(name, color, icon)
     let exists = await containerExists(c)
     if (!exists) {
         browser.contextualIdentities
             .create(c)
             .then(newContainer =>
-                logger.debug(`Created container: ${newContainer.cookieStoreId}`),
+                logger.info("Created container:", newContainer.cookieStoreId),
             )
     } else {
-        logger.warning('This container exists already')
+        logger.error("containerCreate: Container already exists, aborting.")
         logger.debug(c)
     }
 }
 
 /** Removes specified container.
- *  @param containerId  Expects a single digit string.
+ *  @param containerId Expects a cookieStringId e.g. "firefox-container-n".
  */
 export async function containerRemove(containerId: string) {
     browser.contextualIdentities
-        .remove("firefox-container" + containerId)
+        .remove(containerId)
         .then(removedContainer =>
-            logger.debug(`Removed container: ${removedContainer.cookieStoreId}`),
+            logger.info("Removed container:", removedContainer.cookieStoreId),
         )
 }
 
 /** Updates the specified container
- *  @param containerId  Expects a single digit string.
- *  @param containerUpdate  An object containing all parameters to update.
+ *  @param containerId Expects a cookieStringId e.g. "firefox-container-n".
+ *  @param c An object containing all parameters to update.
+ *  TODO: pass an object to this when tridactyl gets proper flag parsing
  */
-export async function containerUpdate(containerId: string, c: {} ) {
-    currcontainer = await browser.contextualIdentities.get(containerId)
-
-    if (!containerExists(c)) {
-    browser.contextualIdentities.update(containerId, 
+export async function containerUpdate(
+    containerId: string,
+    name: string,
+    color: string,
+    icon: string,
+) {
+    let currcontainer = await containerGetFromId(containerId)
+    let container = containerFromString(name, color, icon)
+    if (!containerExists(container)) {
+        browser.contextualIdentities.update(containerId, container)
     } else {
-        logger.debug("Cannot update container, target container already exists.");
+        logger.error("containerUpdate: No values changed, aborting.")
     }
 }
 
 /** Gets a container object from a supplied container id string.
- *  @param containerId  expects a single digit string.
+ *  @param containerId Expects a cookieStringId e.g. "firefox-container-n"
  */
 export async function containerGetFromId(containerId: string): Promise<{}> {
-    let container = await browser.contextualIdentities.get(
-        "firefox-container-" + containerId,
-    )
-    return container
+    return await browser.contextualIdentities.get(containerId)
 }
 
 /** Queries Firefox's contextual identities API for a container with a specific
  *  name. The color and icon are then compared. This is done to impose a unique
- *  constraint on those parameters. 
+ *  constraint on those parameters.
  *  The function returns true if all the parameters have not been
  *  supplied to ensure that checks for uniqueness can't be circumvented.
  *  @params container
@@ -79,36 +80,39 @@ export async function containerExists(container: {
 }): Promise<boolean> {
     let exists = false
     try {
-        let res = await browser.contextualIdentities.query({ name: container.name })
+        let res = await browser.contextualIdentities.query({
+            name: container.name,
+        })
         if (res.length > 0) {
             for (let c of res) {
                 if (c.color === container.color && c.icon === container.icon)
                     exists = true
             }
-        } 
-    }
-    catch (e) {
-        exists = true // Makes sure we don't accidentally break the constraint on query error.
-        logger.debug(e)
+        }
+    } catch (e) {
+        exists = true // Make sure we don't accidentally break the constraint on query error.
+        logger.error("Error querying contextualIdentities:", e)
     }
     return exists
 }
 
-/** Takes string parameters and returns them as a pseudo container object 
+/** Takes string parameters and returns them as a pseudo container object
  *  for use in otherfunctions in the library.
  *  @params name
  *  @params color
  *  @params icon
  */
 export function containerFromString(name: string, color: string, icon: string) {
-    return { 
+    return {
         name: name,
         color: color as browser.contextualIdentities.IdentityColor,
         icon: icon as browser.contextualIdentities.IdentityIcon,
     }
 }
 
-/** Returns all containers in an array */
+/** Returns an array representation of all containers.
+ *  Something something completions?
+ */
 export async function containerGetAll(): Promise<any[]> {
-    return await browser.contextualIdentities.query({});
+    return await browser.contextualIdentities.query({})
 }

--- a/src/lib/containers.ts
+++ b/src/lib/containers.ts
@@ -1,5 +1,34 @@
-export async function containerCreate({}) {}
-export async function containerRemove(containerId: string) {}
+/** Creates a container from the specified parameters.
+ *  @param containerName - The container name.
+ *  @param containerColor - The container color, limited to browser.contextualIdentities.IdentityColor.
+ *  @param containerIcon - The container icon, limited to browser.contextualIdentities.IdentityIcon.
+ */
+export async function containerCreate(
+    containerName: string,
+    containerColor: string,
+    containerIcon: string,
+) {
+    browser.contextualIdentities
+        .create({
+            name: containerName,
+            color: containerColor as browser.contextualIdentities.IdentityColor,
+            icon: containerIcon as browser.contextualIdentities.IdentityIcon,
+        })
+        .then(newContainer =>
+            console.log(`Created container: ${newContainer.cookieStoreId}`),
+        )
+}
+
+/** Removes specified container.
+ *  @param containerId - expects a single digit string.
+ */
+export async function containerRemove(containerId: string) {
+    browser.contextualIdentities
+        .remove("firefox-container" + containerId)
+        .then(removedContainer =>
+            console.log(`Removed container: ${removedContainer.cookieStoreId}`),
+        )
+}
 export async function containerUpdate({}) {}
 export async function containerGet({}) {}
 export async function containerQuery({}) {}

--- a/src/lib/containers.ts
+++ b/src/lib/containers.ts
@@ -1,6 +1,7 @@
 import * as Logging from "../logging"
 const logger = new Logging.Logger("containers")
 
+// As per Mozilla specification: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/contextualIdentities/ContextualIdentity
 const ContainerColor = [
     "blue",
     "turquoise",
@@ -11,6 +12,8 @@ const ContainerColor = [
     "pink",
     "purple",
 ]
+
+// As per Mozilla specification: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/contextualIdentities/ContextualIdentity
 const ContainerIcon = [
     "fingerprint",
     "briefcase",
@@ -217,20 +220,20 @@ export async function fuzzyMatch(partialName: string): Promise<string> {
 }
 
 /** Helper function for create, returns a random valid IdentityColor for use if no color is applied at creation.*/
-export function chooseRandomColor(): string {
+function chooseRandomColor(): string {
     let max = Math.floor(ContainerColor.length)
     let n = Math.floor(Math.random() * max)
     return ContainerColor[n]
 }
 
-export function isValidColor(color: string): boolean {
+function isValidColor(color: string): boolean {
     for (let c of ContainerColor) {
         if (c === color) return true
     }
     return false
 }
 
-export function isValidIcon(icon: string): boolean {
+function isValidIcon(icon: string): boolean {
     for (let i of ContainerIcon) {
         if (i === icon) return true
     }

--- a/src/lib/containers.ts
+++ b/src/lib/containers.ts
@@ -104,6 +104,7 @@ export function containerFromString(name: string, color: string, icon: string) {
 export async function containerGetAll(): Promise<any[]> {
     return await browser.contextualIdentities.query({})
 }
+
 /**
  * @param name The container name
  * @returns The cookieStoreId of the first match of the query.
@@ -112,4 +113,42 @@ export async function containerGetId(name: string): Promise<string> {
     return (await browser.contextualIdentities.query({ name: name }))[0][
         "cookieStoreId"
     ]
+}
+
+/**
+ *
+ */
+export async function containerFuzzyMatch(
+    partialName: string,
+): Promise<string> {
+    let exactMatch = await browser.contextualIdentities.query({
+        name: partialName,
+    })
+    if (exactMatch.length === 1) {
+        return exactMatch[0]["cookieStoreId"]
+    } else if (exactMatch.length > 1) {
+        throw new Error(
+            "[containerFuzzyMatch] more than one container with this name exists.",
+        )
+    } else {
+        let fuzzyMatches = []
+        let containers = await containerGetAll()
+        for (let c of containers) {
+            if (c["name"].indexOf(partialName) === 0) {
+                // Only match start of name.
+                fuzzyMatches.push(c)
+            }
+        }
+        if (fuzzyMatches.length === 1) {
+            return fuzzyMatches[0]["cookieStoreId"]
+        } else if (fuzzyMatches.length > 1) {
+            throw new Error(
+                "[containerFuzzyMatch] ambiguous match, provide more characters",
+            )
+        } else {
+            throw new Error(
+                "[containerFuzzyMatch] no container matched that string",
+            )
+        }
+    }
 }

--- a/src/lib/containers.ts
+++ b/src/lib/containers.ts
@@ -92,10 +92,7 @@ export async function update(
         icon: browser.contextualIdentities.IdentityIcon
     },
 ) {
-    if (
-        isValidColor(updateObj["color"]) &&
-        isValidIcon(updateObj["icon"])
-    ) {
+    if (isValidColor(updateObj["color"]) && isValidIcon(updateObj["icon"])) {
         try {
             browser.contextualIdentities.update(containerId, updateObj)
         } catch (e) {
@@ -114,12 +111,7 @@ export async function getFromId(containerId: string): Promise<{}> {
     try {
         return await browser.contextualIdentities.get(containerId)
     } catch (e) {
-        logger.debug(
-            `[Container.getFromId] could not find a container with id: ${containerId}`,
-        )
-        throw new Error(
-            "[Container.getFromId] could not find a container with that id",
-        )
+        throw e
     }
 }
 

--- a/src/lib/containers.ts
+++ b/src/lib/containers.ts
@@ -1,43 +1,61 @@
-/** Creates a container from the specified parameters.
- *  @param containerName - The container name.
- *  @param containerColor - The container color, limited to browser.contextualIdentities.IdentityColor.
- *  @param containerIcon - The container icon, limited to browser.contextualIdentities.IdentityIcon.
+import * as Logging from '../logging'
+const logger = new Logging.Logger("excmd")
+//TODO: refactor the whole "firefox-container" + containerId thing into something more sensible.
+
+
+
+/** Creates a container from the specified parameters. Unlike the official Mozilla addon, does not
+ *  allow multiple  containers with the same (name, color, icon) constraint.
+ *  @param containerName  The container name.
+ *  @param containerColor  The container color, limited to browser.contextualIdentities.IdentityColor.
+ *  @param containerIcon  The container icon, limited to browser.contextualIdentities.IdentityIcon.
  */
 export async function containerCreate(
-    containerName: string,
-    containerColor: string,
-    containerIcon: string,
+    name: string,
+    color: string,
+    icon: string,
 ) {
-    browser.contextualIdentities
-        .create({
-            name: containerName,
-            color: containerColor as browser.contextualIdentities.IdentityColor,
-            icon: containerIcon as browser.contextualIdentities.IdentityIcon,
-        })
-        .then(newContainer =>
-            console.log(`Created container: ${newContainer.cookieStoreId}`),
-        )
+    let c = containerFromString(name, color, icon);
+    let exists = await containerExists(c)
+    if (!exists) {
+        browser.contextualIdentities
+            .create(c)
+            .then(newContainer =>
+                logger.debug(`Created container: ${newContainer.cookieStoreId}`),
+            )
+    } else {
+        logger.warning('This container exists already')
+        logger.debug(c)
+    }
 }
 
 /** Removes specified container.
- *  @param containerId - expects a single digit string.
+ *  @param containerId  Expects a single digit string.
  */
 export async function containerRemove(containerId: string) {
     browser.contextualIdentities
         .remove("firefox-container" + containerId)
         .then(removedContainer =>
-            console.log(`Removed container: ${removedContainer.cookieStoreId}`),
+            logger.debug(`Removed container: ${removedContainer.cookieStoreId}`),
         )
 }
 
 /** Updates the specified container
- *  @param containerId - expects a single digit string.
- *  @param containerUpdate - an object containing all parameters to update.
+ *  @param containerId  Expects a single digit string.
+ *  @param containerUpdate  An object containing all parameters to update.
  */
-export async function containerUpdate(containerId: string, {}) {}
+export async function containerUpdate(containerId: string, c: {} ) {
+    currcontainer = await browser.contextualIdentities.get(containerId)
+
+    if (!containerExists(c)) {
+    browser.contextualIdentities.update(containerId, 
+    } else {
+        logger.debug("Cannot update container, target container already exists.");
+    }
+}
 
 /** Gets a container object from a supplied container id string.
- *  @param containerId - expects a single digit string.
+ *  @param containerId  expects a single digit string.
  */
 export async function containerGetFromId(containerId: string): Promise<{}> {
     let container = await browser.contextualIdentities.get(
@@ -47,26 +65,50 @@ export async function containerGetFromId(containerId: string): Promise<{}> {
 }
 
 /** Queries Firefox's contextual identities API for a container with a specific
- *  name, icon and color. This is done to impose a unique constraint on those
- *  parameters. function returns true if all the parameters have not been
+ *  name. The color and icon are then compared. This is done to impose a unique
+ *  constraint on those parameters. 
+ *  The function returns true if all the parameters have not been
  *  supplied to ensure that checks for uniqueness can't be circumvented.
  *  @params container
+ *  @returns boolean Returns true when all container fields match or if the query fails.
  */
 export async function containerExists(container: {
     name: string
     color: browser.contextualIdentities.IdentityColor
     icon: browser.contextualIdentities.IdentityIcon
 }): Promise<boolean> {
-    let exists = true
-    let res = await browser.contextualIdentities.query({ name: container.name })
-    if (res.length > 0) {
-        for (let c of res) {
-            console.log(c)
-            if (c.color !== container.color && c.icon !== container.icon)
-                exists = false
-        }
-    } else {
-        exists = false
+    let exists = false
+    try {
+        let res = await browser.contextualIdentities.query({ name: container.name })
+        if (res.length > 0) {
+            for (let c of res) {
+                if (c.color === container.color && c.icon === container.icon)
+                    exists = true
+            }
+        } 
+    }
+    catch (e) {
+        exists = true // Makes sure we don't accidentally break the constraint on query error.
+        logger.debug(e)
     }
     return exists
+}
+
+/** Takes string parameters and returns them as a pseudo container object 
+ *  for use in otherfunctions in the library.
+ *  @params name
+ *  @params color
+ *  @params icon
+ */
+export function containerFromString(name: string, color: string, icon: string) {
+    return { 
+        name: name,
+        color: color as browser.contextualIdentities.IdentityColor,
+        icon: icon as browser.contextualIdentities.IdentityIcon,
+    }
+}
+
+/** Returns all containers in an array */
+export async function containerGetAll(): Promise<any[]> {
+    return await browser.contextualIdentities.query({});
 }

--- a/src/lib/containers.ts
+++ b/src/lib/containers.ts
@@ -3,14 +3,14 @@ const logger = new Logging.Logger("excmd")
 
 /** Creates a container from the specified parameters. Unlike the official Mozilla addon, does not
  *  allow multiple  containers with the same (name, color, icon) constraint.
- *  @param containerName  The container name.
- *  @param containerColor  The container color, limited to browser.contextualIdentities.IdentityColor.
- *  @param containerIcon  The container icon, limited to browser.contextualIdentities.IdentityIcon.
+ *  @param name  The container name.
+ *  @param color  The container color, must be one of: "blue", "turquoise", "green", "yellow", "orange", "red", "pink" or "purple"
+ *  @param icon  The container icon, must be one of: "fingerprint", "briefcase", "dollar", "cart", "circle", "gift", "vacation", "food", "fruit", "pet", "tree", "chill"
  */
 export async function containerCreate(
     name: string,
-    color: string,
-    icon: string,
+    color = "blue",
+    icon = "fingerprint",
 ) {
     let container = containerFromString(name, color, icon)
     if (await containerExists(name)) {

--- a/src/lib/containers.ts
+++ b/src/lib/containers.ts
@@ -1,0 +1,5 @@
+export async function containerCreate({}) {}
+export async function containerRemove(containerId: string) {}
+export async function containerUpdate({}) {}
+export async function containerGet({}) {}
+export async function containerQuery({}) {}

--- a/src/lib/containers.ts
+++ b/src/lib/containers.ts
@@ -80,9 +80,9 @@ export async function remove(name: string) {
  *  TODO: pass an object to this when tridactyl gets proper flag parsing
  *  NOTE: while browser.contextualIdentities.create does check for valid color/icon combos, browser.contextualIdentities.update does not.
  *  @param containerId Expects a cookieStringId e.g. "firefox-container-n".
- *  @param name optional the new name of the container
- *  @param color optional the new color of the container
- *  @param icon optional the new icon of the container
+ *  @param name the new name of the container
+ *  @param color the new color of the container
+ *  @param icon the new icon of the container
  */
 export async function update(
     containerId: string,

--- a/src/lib/containers.ts
+++ b/src/lib/containers.ts
@@ -1,6 +1,5 @@
 import * as Logging from "../logging"
 const logger = new Logging.Logger("excmd")
-//TODO: refactor the whole "firefox-container" + containerId thing into something more sensible.
 
 /** Creates a container from the specified parameters. Unlike the official Mozilla addon, does not
  *  allow multiple  containers with the same (name, color, icon) constraint.

--- a/src/lib/containers.ts
+++ b/src/lib/containers.ts
@@ -41,6 +41,7 @@ export async function create(
 ): Promise<string> {
     if (color === "random") color = chooseRandomColor()
     let container = fromString(name, color, icon)
+    logger.debug(container)
 
     if (await exists(name)) {
         logger.debug(`[Container.create] container already exists ${container}`)
@@ -56,7 +57,7 @@ export async function create(
             )
             return res["cookieStoreId"]
         } catch (e) {
-            throw e.message
+            throw e
         }
     }
 }
@@ -65,21 +66,23 @@ export async function create(
  *  @param name The container name
  */
 export async function remove(name: string) {
+    logger.debug(name)
     try {
         let id = await getId(name)
         let res = await browser.contextualIdentities.remove(id)
         logger.debug("[Container.remove] removed container:", res.cookieStoreId)
     } catch (e) {
-        throw e.message
+        throw e
     }
 }
 
 /** Updates the specified container.
+ *  TODO: pass an object to this when tridactyl gets proper flag parsing
+ *  NOTE: while browser.contextualIdentities.create does check for valid color/icon combos, browser.contextualIdentities.update does not.
  *  @param containerId Expects a cookieStringId e.g. "firefox-container-n".
  *  @param name optional the new name of the container
  *  @param color optional the new color of the container
  *  @param icon optional the new icon of the container
- *  TODO: pass an object to this when tridactyl gets proper flag parsing
  */
 export async function update(
     containerId: string,
@@ -89,19 +92,18 @@ export async function update(
         icon: browser.contextualIdentities.IdentityIcon
     },
 ) {
-    try {
-        if (
-            isValidColor(updateObj["color"]) &&
-            isValidIcon(updateObj["icon"])
-        ) {
+    if (
+        isValidColor(updateObj["color"]) &&
+        isValidIcon(updateObj["icon"])
+    ) {
+        try {
             browser.contextualIdentities.update(containerId, updateObj)
-        } else {
-            logger.debug("[Container.update] invalid icon or color name")
-            logger.debug(updateObj)
-            throw new Error("[Container.update] invalid icon or color name")
+        } catch (e) {
+            throw e
         }
-    } catch (e) {
-        throw e
+    } else {
+        logger.debug(updateObj)
+        throw new Error("[Container.update] invalid container icon or color")
     }
 }
 

--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -72,6 +72,12 @@ export async function activeTabContainerId() {
     return (await activeTab()).cookieStoreId
 }
 
+//#background_helper
+export async function activeTabContainer() {
+    let containerId = await activeTabContainerId()
+    return await browserBg.contextualIdentities.get(containerId)
+}
+
 /** Compare major firefox versions */
 export async function firefoxVersionAtLeast(desiredmajor: number) {
     const versionstr = (await browserBg.runtime.getBrowserInfo()).version


### PR DESCRIPTION
**New excmds:**
- containerclose: closes all tabs using specified container
- containercreate: creates a new container
- containerupdate: updates an existing container
- containerremove: removes an existing container (calls containerclose before removing container)

**Edits to tabopen:**
- Now takes the `-c` flag, allowing you to open a new tab in a specified container.
- Both `-b` and `-c` can be supplied in any order via argparse, in lieu of a proper flag parsing mechanism.

**Requested changes from old PR:**
- [x] `tabopen -c` takes precedence
- [x] improve excmd documentation wrt new container cmds
- [x] improve error handling 

**Closing thoughts:**
- I'm not very happy about how the `containerupdate` function works but I can't see any way around that as long as there's no flag parsing available.
- I should probably add more debug points in `src/lib/containers.ts` but I'm not sure what the convention is/should be.
- `open -c` is not supported in this PR since it's not possible to "move" a tab into a container. The container must be specified on tab creation meaning that the only way to support `open -c` would be to close and reopen the current tab.