### PR TITLE
predictable numeric hints

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -232,6 +232,7 @@ const DEFAULTS = o({
     homepages: [],
     hintchars: "hjklasdfgyuiopqwertnmzxcvb",
     hintfiltermode: "simple", // "simple", "vimperator", "vimperator-reflow"
+    hintnames: "short",
 
     // Controls whether the page can focus elements for you via js
     // Remember to also change browser.autofocus (autofocusing elements via

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2434,12 +2434,21 @@ import * as hinting from "./hinting_background"
         - "hintchars": "hjklasdfgyuiopqwertnmzxcvb"
         - "hintfiltermode": "simple" | "vimperator" | "vimperator-reflow"
         - "relatedopenpos": "related" | "next" | "last"
-        - "hintnames": "short" | "uniform"
+        - "hintnames": "short" | "uniform" | "numeric"
 
           With "short" names, Tridactyl will generate short hints that
           are never prefixes of each other. With "uniform", Tridactyl
           will generate hints of uniform length. In either case, the
           hints are generated from the set in "hintchars".
+
+          With "numeric" names, hints are always assigned using
+          sequential integers, and "hintchars" is ignored. This has the
+          disadvantage that some hints are prefixes of others (and you
+          need to hit space or enter to select such a hint). But it has
+          the advantage that the hints tend to be more predictable
+          (e.g., a news site will have the same hints for its
+          boilerplate each time you visit it, even if the number of
+          links in the main body changes).
 */
 //#background
 export function hint(option?: string, selectors?: string, ...rest: string[]) {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -806,8 +806,9 @@ export const ABOUT_WHITELIST = ["about:home", "about:license", "about:logo", "ab
  *       - else treat as search parameters for google
  *
  *   Related settings:
- *       "searchengine": "google" or any of [[SEARCH_URLS]]
- *      "historyresults": the n-most-recent results to ask Firefox for before they are sorted by frequency. Reduce this number if you find your results are bad.
+ *      - "searchengine": "google" or any of [[SEARCH_URLS]]
+ *      - "historyresults": the n-most-recent results to ask Firefox for before they are sorted by frequency. Reduce this number if you find your results are bad.
+ *
  * Can only open about:* or file:* URLs if you have the native messenger installed, and on OSX you must set `browser` to something that will open Firefox from a terminal pass it commmand line options.
  *
  */
@@ -2430,9 +2431,9 @@ import * as hinting from "./hinting_background"
     To open a hint in the background, the default bind is `F`.
 
     Related settings:
-        "hintchars": "hjklasdfgyuiopqwertnmzxcvb"
-        "hintfiltermode": "simple" | "vimperator" | "vimperator-reflow"
-        "relatedopenpos": "related" | "next" | "last"
+        - "hintchars": "hjklasdfgyuiopqwertnmzxcvb"
+        - "hintfiltermode": "simple" | "vimperator" | "vimperator-reflow"
+        - "relatedopenpos": "related" | "next" | "last"
 */
 //#background
 export function hint(option?: string, selectors?: string, ...rest: string[]) {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2434,6 +2434,12 @@ import * as hinting from "./hinting_background"
         - "hintchars": "hjklasdfgyuiopqwertnmzxcvb"
         - "hintfiltermode": "simple" | "vimperator" | "vimperator-reflow"
         - "relatedopenpos": "related" | "next" | "last"
+        - "hintnames": "short" | "uniform"
+
+          With "short" names, Tridactyl will generate short hints that
+          are never prefixes of each other. With "uniform", Tridactyl
+          will generate hints of uniform length. In either case, the
+          hints are generated from the set in "hintchars".
 */
 //#background
 export function hint(option?: string, selectors?: string, ...rest: string[]) {

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -120,7 +120,12 @@ function defaultHintFilter() {
 }
 
 function defaultHintChars() {
-    return config.get("hintchars")
+    switch (config.get("hintnames")) {
+        case "numeric":
+            return "1234567890"
+        default:
+            return config.get("hintchars")
+    }
 }
 
 /** An infinite stream of hints
@@ -179,11 +184,19 @@ function* hintnames_uniform(
     }
 }
 
+function* hintnames_numeric(n: number): IterableIterator<string> {
+    for (let i = 1; i <= n; i++) {
+        yield String(i)
+    }
+}
+
 function* hintnames(
     n: number,
     hintchars = defaultHintChars(),
 ): IterableIterator<string> {
     switch (config.get("hintnames")) {
+        case "numeric":
+            yield* hintnames_numeric(n)
         case "uniform":
             yield* hintnames_uniform(n, hintchars)
         default:

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -119,12 +119,16 @@ function defaultHintFilter() {
     }
 }
 
+function defaultHintChars() {
+    return config.get("hintchars")
+}
+
 /** An infinite stream of hints
 
     Earlier hints prefix later hints
 */
 function* hintnames_simple(
-    hintchars = config.get("hintchars"),
+    hintchars = defaultHintChars(),
 ): IterableIterator<string> {
     for (let taglen = 1; true; taglen++) {
         yield* map(permutationsWithReplacement(hintchars, taglen), e =>
@@ -149,7 +153,7 @@ function* hintnames_simple(
 */
 function* hintnames(
     n: number,
-    hintchars = config.get("hintchars"),
+    hintchars = defaultHintChars(),
 ): IterableIterator<string> {
     let source = hintnames_simple(hintchars)
     const num2skip = Math.floor(n / hintchars.length)
@@ -159,7 +163,7 @@ function* hintnames(
 /** Uniform length hintnames */
 function* hintnames_uniform(
     n: number,
-    hintchars = config.get("hintchars"),
+    hintchars = defaultHintChars(),
 ): IterableIterator<string> {
     if (n <= hintchars.length) yield* islice(hintchars[Symbol.iterator](), n)
     else {
@@ -256,9 +260,7 @@ function buildHintsVimperator(els: Element[], onSelect: HintSelectedCallback) {
     let names = hintnames(els.length)
     // escape the hintchars string so that strange things don't happen
     // when special characters are used as hintchars (for example, ']')
-    const escapedHintChars = config
-        .get("hintchars")
-        .replace(/^\^|[-\\\]]/g, "\\$&")
+    const escapedHintChars = defaultHintChars().replace(/^\^|[-\\\]]/g, "\\$&")
     const filterableTextFilter = new RegExp("[" + escapedHintChars + "]", "g")
     for (let [el, name] of izip(els, names)) {
         let ft = elementFilterableText(el)
@@ -322,7 +324,7 @@ function filterHintsVimperator(fstr, reflow = false) {
     /** Partition a fstr into a tagged array of substrings */
     function partitionFstr(fstr): { str: string; isHintChar: boolean }[] {
         const peek = a => a[a.length - 1]
-        const hintChars = config.get("hintchars")
+        const hintChars = defaultHintChars()
 
         // For each char, either add it to the existing run if there is one and
         // it's a matching type or start a new run

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -151,7 +151,7 @@ function* hintnames_simple(
     and so on, but we hardly ever see that many hints, so whatever.
     
 */
-function* hintnames(
+function* hintnames_short(
     n: number,
     hintchars = defaultHintChars(),
 ): IterableIterator<string> {
@@ -176,6 +176,18 @@ function* hintnames_uniform(
                 return perm.join("")
             },
         )
+    }
+}
+
+function* hintnames(
+    n: number,
+    hintchars = defaultHintChars(),
+): IterableIterator<string> {
+    switch (config.get("hintnames")) {
+        case "uniform":
+            yield* hintnames_uniform(n, hintchars)
+        default:
+            yield* hintnames_short(n, hintchars)
     }
 }
 


### PR DESCRIPTION
One of the things I missed moving from pentadactyl to tridactyl is the way the hints are generated. I really like them to be predictable between visits to a page, since I tend to develop muscle memory (e.g., clicking through to the article of a Hacker News page is always "f13"). Switching `hintchars` to numeric isn't quite enough to get there, because the hint-generator tries to avoid prefixes. Which means that the "early" hints are impacted by the exact number of hints later in the page.

This PR introduces a new mode that provides sequential numeric hints. It's triggered by a new config variable rather than `hintfiltermode` because it's really orthogonal to the filtering itself (though I recommend using it with `vimperator-reflow`). I've been using it for a few months and have been pretty happy.

I had to do a little bit of refactoring along the way; see the individual commit messages for details.