### PR TITLE
styling.ts: Avoir errors when calling capitalise on 0-length strings

### DIFF
--- a/src/styling.ts
+++ b/src/styling.ts
@@ -8,6 +8,7 @@ const logger = new Logging.Logger("styling")
 const THEMES = ["dark", "greenmat", "shydactyl", "quake"]
 
 function capitalise(str) {
+    if (str === "") return str
     return str[0].toUpperCase() + str.slice(1)
 }
 


### PR DESCRIPTION
I promise this actually fixes https://github.com/cmcaine/tridactyl/issues/586 .