### PR TITLE
config.ts: Fix :sanitise tridacyl{local,sync} breaking config.get()

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -475,9 +475,15 @@ async function init() {
 
 // Listen for changes to the storage and update the USERCONFIG if appropriate.
 // TODO: BUG! Sync and local storage are merged at startup, but not by this thing.
-browser.storage.onChanged.addListener((changes, areaname) => {
+browser.storage.onChanged.addListener(async (changes, areaname) => {
     if (CONFIGNAME in changes) {
-        USERCONFIG = changes[CONFIGNAME].newValue
+        // newValue is undefined when calling browser.storage.AREANAME.clear()
+        if (changes[CONFIGNAME].newValue !== undefined) {
+            USERCONFIG = changes[CONFIGNAME].newValue
+        } else if (areaname === (await get("storageloc"))) {
+            // If newValue is undefined and AREANAME is the same value as STORAGELOC, the user wants to clean their config
+            USERCONFIG = o({})
+        }
     }
 })
 


### PR DESCRIPTION
This fixes https://github.com/cmcaine/tridactyl/issues/322 and https://github.com/cmcaine/tridactyl/issues/686 .