### PR TITLE
Keep newtab's changelog button grey once changelog has been read

### DIFF
--- a/scripts/newtab.md.sh
+++ b/scripts/newtab.md.sh
@@ -14,10 +14,11 @@ sed "1,/REPLACETHIS/ d" newtab.template.html >> "$newtabtemp"
 # Why think when you can pattern match?
 
 sed "/REPLACE_ME_WITH_THE_CHANGE_LOG_USING_SED/,$ d" "$newtabtemp" > "$newtab"
+# Note: If you're going to change this HTML, make sure you don't break the JS in src/newtab.ts
 echo """
 <input type="checkbox"  id="spoilerbutton" />
 <label for="spoilerbutton" onclick="">Changelog</label>
-<div class="spoiler">
+<div id="changelog" class="spoiler">
 """ >> "$newtab"
 $(npm bin)/marked ../../CHANGELOG.md >> "$newtab"
 echo """

--- a/src/newtab.ts
+++ b/src/newtab.ts
@@ -1,0 +1,37 @@
+// This file is only included in newtab.html, after content.js has been loaded
+
+// These functions work with the elements created by tridactyl/scripts/newtab.md.sh
+function getChangelogDiv() {
+    const changelogDiv = document.getElementById("changelog")
+    if (!changelogDiv) throw new Error("Couldn't find changelog element!")
+    return changelogDiv
+}
+
+function updateChangelogStatus() {
+    const changelogDiv = getChangelogDiv()
+    const changelogContent = changelogDiv.textContent
+    if (localStorage.changelogContent == changelogContent) {
+        const changelogButton = document.querySelector('input[id^="spoiler"]')
+        if (!changelogButton) {
+            console.error("Couldn't find changelog button!")
+            return
+        }
+        changelogButton.classList.add("seen")
+    }
+}
+
+function readChangelog() {
+    const changelogDiv = getChangelogDiv()
+    localStorage.changelogContent = changelogDiv.textContent
+    updateChangelogStatus()
+}
+
+window.addEventListener("load", updateChangelogStatus)
+window.addEventListener("load", _ => {
+    const spoilerbutton = document.getElementById("spoilerbutton")
+    if (!spoilerbutton) {
+        console.error("Couldn't find spoiler button!")
+        return
+    }
+    spoilerbutton.addEventListener("click", readChangelog)
+})

--- a/src/static/css/newtab.css
+++ b/src/static/css/newtab.css
@@ -26,7 +26,8 @@ input[id^="spoiler"] + label {
     cursor: pointer;
     transition: all 0.6s;
 }
-input[id^="spoiler"]:checked + label {
+input[id^="spoiler"]:checked + label,
+input[id^="spoiler"].seen + label {
     color: #333;
     background: #ccc;
 }

--- a/src/static/newtab.template.html
+++ b/src/static/newtab.template.html
@@ -13,4 +13,5 @@
         REPLACETHIS
     </body>
     <script src="../content.js"></script>
+    <script src="../newtab.js"></script>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = {
         content: "./src/content.ts",
         commandline_frame: "./src/commandline_frame.ts",
         help: "./src/help.ts",
+        newtab: "./src/newtab.ts",
     },
     output: {
         filename: "[name].js",


### PR DESCRIPTION
This is terrible but it's ok because hopefully everything will be rewritten properly with react once a framework has been chosen.
This fixes https://github.com/cmcaine/tridactyl/issues/331 .