### PR TITLE
guiset: added none option to navbar

### DIFF
--- a/src/css_util.ts
+++ b/src/css_util.ts
@@ -79,6 +79,22 @@ export const potentialRules = {
             show: ``,
         },
     },
+    // All children except add-on panels
+    navbarnonaddonchildren: {
+        name: `:root:not([customizing]) #nav-bar > :not(#customizationui-widget-panel)`,
+        options: {
+            hide: `display: none !important;`,
+            show: ``,
+        },
+    },
+    // Set navbar height to 0
+    navbarnoheight: {
+        name: `:root:not([customizing]) #nav-bar`,
+        options: {
+            hide: ``,
+            show: `max-height: 0; min-height: 0 !important;`,
+        },
+    },
     // This inherits transparency if we aren't careful
     menubar: {
         name: `#navigator-toolbox:not(:hover):not(:focus-within) #toolbar-menubar > *`,
@@ -155,11 +171,22 @@ export const metaRules = {
             navbarunfocused: "hide",
             navtoolboxunfocused: "hide",
             navbarafter: "hide",
+            navbarnonaddonchildren: "show",
+            navbarnoheight: "hide",
         },
         always: {
             navbarunfocused: "show",
             navtoolboxunfocused: "show",
             navbarafter: "show",
+            navbarnonaddonchildren: "show",
+            navbarnoheight: "hide",
+        },
+        none: {
+            navbarunfocused: "show",
+            navtoolboxunfocused: "show",
+            navbarafter: "hide",
+            navbarnonaddonchildren: "hide",
+            navbarnoheight: "show",
         },
     },
 }

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -221,6 +221,7 @@ import * as css_util from "./css_util"
  * - navbar
  *      - always
  *      - autohide
+ *      - none
  *
  * - hoverlink (the little link that appears when you hover over a link)
  *      - none


### PR DESCRIPTION
This guiset navbar option completely removes the bar (except during
customization), rather than auto-hiding it when not in focus.

Since add-on panels are appended as children of #nav-bar, care has been
taken not to hide them to keep functionality.

Signed-off-by: Franklin "Snaipe" Mathieu <me@snai.pe>