### PR TITLE
Fix invalid contextualIdentity when not using a container.

### DIFF
--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -75,7 +75,12 @@ export async function activeTabContainerId() {
 //#background_helper
 export async function activeTabContainer() {
     let containerId = await activeTabContainerId()
-    return await browserBg.contextualIdentities.get(containerId)
+    if (containerId !== "firefox-default")
+        return await browserBg.contextualIdentities.get(containerId)
+    else
+        throw new Error(
+            "firefox-default is not a valid contextualIdentity (activeTabContainer)",
+        )
 }
 
 /** Compare major firefox versions */


### PR DESCRIPTION
Add error handling for the firefox-default cookieStoreId in activeTabContainer.
Fixes #700 