### PR TITLE
Improve robustness of Get-PythonVersionStatus

### DIFF
--- a/native/win_install.ps1
+++ b/native/win_install.ps1
@@ -13,7 +13,7 @@ $global:MessengerBinPyName = "native_main.py"
 $global:MessengerBinExeName = "native_main.exe"
 $global:MessengerBinWrapperFilename = "native_main.bat"
 $global:MessengerManifestFilename = "tridactyl.json"
-$global:PythonVersionStr = "Python 3"
+$global:PythonVersionStr = "^3\."
 $global:WinPython3Command = "py -3 -u"
 $global:MessengerManifestReplaceStr = "REPLACE_ME_WITH_SED"
 
@@ -46,12 +46,12 @@ $global:DebugDirBase = $DebugDirBase.Trim()
 function Get-PythonVersionStatus() {
     try {
         $pythonVersion = Invoke-Expression `
-            "$global:WinPython3Command --version"
+            "$global:WinPython3Command -c ""import sys; print(sys.version)"""
     } catch {
         $pythonVersion = ""
     }
 
-    if ($pythonVersion.IndexOf($global:PythonVersionStr) -ge 0) {
+    if ($pythonVersion -match $global:PythonVersionStr) {
         return $true
     } else {
         return $false


### PR DESCRIPTION
The current way to get Python version is volatile, e.g. Anaconda bundled Python 3 won't get recognised as such.

As of now the `--version` flag is used. This results in inconsistent behaviour, e.g. reference Python will print the version to stderr but Anaconda Python will print to stdout. Thus the version is found using the sys module. The output is more standardised.

Regex matching is now employed.