### PR TITLE
Add private window indicator to bufferall

### DIFF
--- a/src/static/css/commandline.css
+++ b/src/static/css/commandline.css
@@ -68,8 +68,9 @@ input {
     padding-left: 0.5em;
     text-align: center;
 }
+#completions table tr td.container,
 #completions table tr td.icon,
-#completions table tr td.container {
+#completions table tr td.privatewindow {
     width: 1.5em;
 }
 /* #completions table tr td:nth-of-type(3) { width: 5em; } */
@@ -148,8 +149,13 @@ a.url:hover {
     background: var(--tridactyl-of-bg);
 }
 
+.option.incognito .privatewindow {
+    background-image: var(--tridactyl-private-window-icon-url);
+}
+
 /* Still completions, but container-related stuff */
-.option .container {
+.option .container,
+.option .privatewindow {
     background-size: 1em;
     background-repeat: no-repeat;
     background-position: center;

--- a/src/static/themes/default.css
+++ b/src/static/themes/default.css
@@ -97,6 +97,8 @@
     --tridactyl-highlight-box-bg: #eee;
     --tridactyl-highlight-box-fg: var(--tridactyl-fg);
 
+    --tridactyl-private-window-icon-url: url("chrome://browser/skin/privatebrowsing/private-browsing.svg");
+
     --tridactyl-container-fingerprint-url: url("resource://usercontext-content/fingerprint.svg");
     --tridactyl-container-briefcase-url: url("resource://usercontext-content/briefcase.svg");
     --tridactyl-container-dollar-url: url("resource://usercontext-content/dollar.svg");


### PR DESCRIPTION
This is an attempt to solve https://github.com/cmcaine/tridactyl/issues/712 .
I've used the same pattern as for bufferall, which means that themes that prefer hiding private windows could easily do so.
