### PR TITLE
{excmds,webext,messaging}.ts: Remove l() promise logger

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -87,7 +87,7 @@
 
 // Shared
 import * as Messaging from "./messaging"
-import { l, browserBg, activeTabId, activeTabContainerId } from "./lib/webext"
+import { browserBg, activeTabId, activeTabContainerId } from "./lib/webext"
 import * as Container from "./lib/containers"
 import state from "./state"
 import * as UrlUtil from "./url_util"
@@ -1244,7 +1244,7 @@ export async function zoom(level = 0, rel = "false") {
  */
 //#background
 export async function reader() {
-    if (await l(firefoxVersionAtLeast(58))) {
+    if (await firefoxVersionAtLeast(58)) {
         let aTab = await activeTab()
         if (aTab.isArticle) {
             browser.tabs.toggleReaderMode()
@@ -1569,15 +1569,13 @@ async function idFromIndex(index?: number | "%" | "#" | string): Promise<number>
     } else if (index !== undefined && index !== "%") {
         // Wrap
         index = Number(index)
-        index = (index - 1).mod((await l(browser.tabs.query({ currentWindow: true }))).length) + 1
+        index = (index - 1).mod((await browser.tabs.query({ currentWindow: true })).length) + 1
 
         // Return id of tab with that index.
-        return (await l(
-            browser.tabs.query({
-                currentWindow: true,
-                index: index - 1,
-            }),
-        ))[0].id
+        return (await browser.tabs.query({
+            currentWindow: true,
+            index: index - 1,
+        }))[0].id
     } else {
         return await activeTabId()
     }

--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -34,22 +34,6 @@ if (inContentScript()) {
     browserBg = browser
 }
 
-/** await a promise and console.error and rethrow if it errors
-
-    Errors from promises don't get logged unless you seek them out.
-
-    There's an event for catching these, but it's not implemented in firefox
-    yet: https://bugzilla.mozilla.org/show_bug.cgi?id=1269371
-*/
-export async function l(promise) {
-    try {
-        return await promise
-    } catch (e) {
-        console.error(e)
-        throw e
-    }
-}
-
 /** The first active tab in the currentWindow.
  *
  * TODO: Highlander theory: Can there ever be more than one?
@@ -57,9 +41,10 @@ export async function l(promise) {
  */
 //#background_helper
 export async function activeTab() {
-    return (await l(
-        browserBg.tabs.query({ active: true, currentWindow: true }),
-    ))[0]
+    return (await browserBg.tabs.query({
+        active: true,
+        currentWindow: true,
+    }))[0]
 }
 
 //#background_helper
@@ -124,7 +109,7 @@ export async function openInNewTab(
     switch (pos) {
         case "next":
             options.index = thisTab.index + 1
-            if (kwargs.related && (await l(firefoxVersionAtLeast(57))))
+            if (kwargs.related && (await firefoxVersionAtLeast(57)))
                 options.openerTabId = thisTab.id
             break
         case "last":
@@ -132,7 +117,7 @@ export async function openInNewTab(
             options.index = 99999
             break
         case "related":
-            if (await l(firefoxVersionAtLeast(57))) {
+            if (await firefoxVersionAtLeast(57)) {
                 options.openerTabId = thisTab.id
             } else {
                 options.index = thisTab.index + 1

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -1,4 +1,4 @@
-import { l, browserBg, activeTabId } from "./lib/webext"
+import { browserBg, activeTabId } from "./lib/webext"
 import Logger from "./logging"
 const logger = new Logger("messaging")
 
@@ -64,8 +64,7 @@ export function attributeCaller(obj) {
 
 /** Send a message to non-content scripts */
 export async function message(type: NonTabMessageType, command, args?) {
-    // One day typescript will be smart enough to back propagate this cast.
-    return l(browser.runtime.sendMessage({ type, command, args } as Message))
+    return browser.runtime.sendMessage({ type, command, args } as Message)
 }
 
 /** Message the active tab of the currentWindow */
@@ -84,7 +83,7 @@ export async function messageTab(tabId, type: TabMessageType, command, args?) {
         command,
         args,
     }
-    return l(browserBg.tabs.sendMessage(tabId, message))
+    return browserBg.tabs.sendMessage(tabId, message)
 }
 
 export async function messageAllTabs(


### PR DESCRIPTION
When a promise throws an error in l(), the error is automatically logged
in the console. This is a problem because it happens even when the error
is catched by the code that called l(), which might not want to log
errors at all.

l() was necessary when errors thrown in promises didn't reach the
toplevel. Now that they do, it is safe to remove l().

This will enable better error handling. For example, it accidentally fixes a
bug triggered by `:buffer/bufferall` where the console would be
spammed with errors because  `containers.ts:getFromId()` relies on
exceptions to return a default container.