### PR TITLE
Implement notification mechanism that does not steal focus

### DIFF
--- a/src/commandline_background.ts
+++ b/src/commandline_background.ts
@@ -45,10 +45,12 @@ async function allWindowTabs(): Promise<browser.tabs.Tab[]> {
     return allTabs
 }
 
-export async function show() {
+export async function show(focus = true) {
     Messaging.messageActiveTab("commandline_content", "show")
-    Messaging.messageActiveTab("commandline_content", "focus")
-    Messaging.messageActiveTab("commandline_frame", "focus")
+    if (focus) {
+        await Messaging.messageActiveTab("commandline_content", "focus")
+        await Messaging.messageActiveTab("commandline_frame", "focus")
+    }
 }
 
 export async function hide() {

--- a/src/commandline_content.ts
+++ b/src/commandline_content.ts
@@ -4,6 +4,7 @@ import Logger from "./logging"
 import * as config from "./config"
 import { theme } from "./styling"
 const logger = new Logger("messaging")
+const cmdline_logger = new Logger("cmdline")
 
 /* TODO:
     CSS
@@ -55,28 +56,38 @@ try {
 
 export function show() {
     try {
+        cmdline_iframe.classList.remove("hidden")
         const height =
             cmdline_iframe.contentWindow.document.body.offsetHeight + "px"
         cmdline_iframe.setAttribute("style", `height: ${height} !important;`)
-    } catch (e) {}
+    } catch (e) {
+        cmdline_logger.error(e)
+    }
 }
 
 export function hide() {
     try {
+        cmdline_iframe.classList.add("hidden")
         cmdline_iframe.setAttribute("style", "height: 0px !important;")
-    } catch (e) {}
+    } catch (e) {
+        cmdline_logger.error(e)
+    }
 }
 
 export function focus() {
     try {
         cmdline_iframe.focus()
-    } catch (e) {}
+    } catch (e) {
+        cmdline_logger.error(e)
+    }
 }
 
 export function blur() {
     try {
         cmdline_iframe.blur()
-    } catch (e) {}
+    } catch (e) {
+        cmdline_logger.error(e)
+    }
 }
 
 export function executeWithoutCommandLine(fn) {
@@ -89,7 +100,7 @@ export function executeWithoutCommandLine(fn) {
     try {
         result = fn()
     } catch (e) {
-        console.log(e)
+        cmdline_logger.error(e)
     }
     if (cmdline_iframe) parent.appendChild(cmdline_iframe)
     return result

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2000,8 +2000,8 @@ export async function sleep(time_ms: number) {
 
 /** @hidden */
 //#background
-function showcmdline() {
-    CommandLineBackground.show()
+function showcmdline(focus = true) {
+    CommandLineBackground.show(focus)
 }
 
 /** Set the current value of the commandline to string *with* a trailing space */
@@ -2019,6 +2019,26 @@ export function fillcmdline_notrail(...strarr: string[]) {
     let trailspace = false
     showcmdline()
     messageActiveTab("commandline_frame", "fillcmdline", [str, trailspace])
+}
+
+/** Show and fill the command line without focusing it */
+//#background
+export function fillcmdline_nofocus(...strarr: string[]) {
+    showcmdline(false)
+    return messageActiveTab("commandline_frame", "fillcmdline", [strarr.join(" "), false, false])
+}
+
+/** Shows str in the command line for ms milliseconds */
+//#background
+export async function fillcmdline_tmp(ms: string, ...strarr: string[]) {
+    let milliseconds = parseInt(ms)
+    await fillcmdline_nofocus(...strarr)
+    return new Promise(resolve =>
+        setTimeout(async () => {
+            await messageActiveTab("commandline_frame", "hide_and_clear", [])
+            resolve()
+        }, milliseconds),
+    )
 }
 
 /**


### PR DESCRIPTION
This PR implements a way to display a message on the commandline without stealing focus. There's also a way to show messages only for a limited amount of time.

This should unblock https://github.com/cmcaine/tridactyl/pull/583 and could also be useful for https://github.com/cmcaine/tridactyl/issues/708 .