### PR TITLE
Make sure bind/unbind use the same binding format

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,7 @@ function schlepp(settings) {
 let USERCONFIG = o({})
 const DEFAULTS = o({
     configversion: "0.0",
+    // When creating new <modifier-letter> maps, make sure to make the modifier uppercase (e.g. <C-a> instead of <c-a>) otherwise some commands might not be able to find them (e.g. `bind <c-a>`)
     nmaps: o({
         "<F1>": "help",
         o: "fillcmdline open",
@@ -44,8 +45,8 @@ const DEFAULTS = o({
         "[[": "followpage prev",
         "[c": "urlincrement -1",
         "]c": "urlincrement 1",
-        "<c-x>": "urlincrement -1",
-        "<c-a>": "urlincrement 1",
+        "<C-x>": "urlincrement -1",
+        "<C-a>": "urlincrement 1",
         T: "current_url tabopen",
         yy: "clipboard yank",
         ys: "clipboard yankshort",
@@ -55,26 +56,26 @@ const DEFAULTS = o({
         p: "clipboard open",
         P: "clipboard tabopen",
         j: "scrollline 10",
-        "<c-e>": "scrollline 10",
+        "<C-e>": "scrollline 10",
         k: "scrollline -10",
-        "<c-y>": "scrollline 10",
+        "<C-y>": "scrollline 10",
         h: "scrollpx -50",
         l: "scrollpx 50",
         G: "scrollto 100",
         gg: "scrollto 0",
-        "<c-u>": "scrollpage -0.5",
-        "<c-d>": "scrollpage 0.5",
+        "<C-u>": "scrollpage -0.5",
+        "<C-d>": "scrollpage 0.5",
         // Disabled while our find mode is bad
-        /* "<c-f>": "scrollpage -1", */
-        // "<c-b>": "scrollpage -1",
+        /* "<C-f>": "scrollpage -1", */
+        // "<C-b>": "scrollpage -1",
         $: "scrollto 100 x",
         // "0": "scrollto 0 x", // will get interpreted as a count
         "^": "scrollto 0 x",
-        "<c-6>": "buffer #",
+        "<C-6>": "buffer #",
         H: "back",
         L: "forward",
-        "<c-o>": "jumpprev",
-        "<c-i>": "jumpnext",
+        "<C-o>": "jumpprev",
+        "<C-i>": "jumpnext",
         d: "tabclose",
         D: "composite tabprev; sleep 100; tabclose #",
         gx0: "tabclosealltoleft",

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -121,6 +121,7 @@ import { activeTab, firefoxVersionAtLeast, openInNewTab } from "./lib/webext"
 import * as CommandLineBackground from "./commandline_background"
 import * as rc from "./config_rc"
 import * as excmd_parser from "./parsers/exmode"
+import { mapstrToKeyseq } from "./keyseq"
 
 //#background_helper
 import * as Native from "./native_background"
@@ -2216,6 +2217,8 @@ export function comclear(name: string) {
 */
 //#background
 export function bind(key: string, ...bindarr: string[]) {
+    // Convert key to internal representation
+    key = mapstrToKeyseq(key).map(k => k.toMapstr()).join("")
     if (bindarr.length) {
         let exstring = bindarr.join(" ")
         config.set("nmaps", key, exstring)
@@ -2338,6 +2341,8 @@ export function blacklistadd(url: string) {
 */
 //#background
 export async function unbind(key: string) {
+    // Convert key to internal representation
+    key = mapstrToKeyseq(key).map(k => k.toMapstr()).join("")
     config.set("nmaps", key, "")
 }
 


### PR DESCRIPTION
This should fix https://github.com/cmcaine/tridactyl/issues/435 .
Ideally we should also add an updater in `config.ts:update()` that would make sure existing bindings use the same format as `bind/unbind` but I'm quite reluctant to the idea of adding dependencies to `config.ts`, even if they're small ones. 