### PR TITLE
Make <Esc> dismiss fillcmdline_tmp messages

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -128,6 +128,7 @@ const DEFAULTS = o({
         "<S-Insert>": "mode ignore",
         "<CA-Esc>": "mode ignore",
         "<CA-`>": "mode ignore",
+        "<Esc>": "composite mode normal ; hidecmdline",
         I:
             "fillcmdline Ignore mode is now toggled by pressing <S-Insert> or <C-A-`>",
         a: "current_url bmark",

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2003,6 +2003,12 @@ function showcmdline(focus = true) {
     CommandLineBackground.show(focus)
 }
 
+/** @hidden */
+//#background
+export function hidecmdline() {
+    CommandLineBackground.hide()
+}
+
 /** Set the current value of the commandline to string *with* a trailing space */
 //#background
 export function fillcmdline(...strarr: string[]) {


### PR DESCRIPTION
This fixes https://github.com/cmcaine/tridactyl/issues/744 but in my opinion it still feels weird because when I press "t" while the command line is open I expect it to be added to the command line, not replace everything with "tabopen".

Perhaps the problem isn't actually that `<Esc>` doesn't close the command line but that it's hard to tell when the command line is and isn't focused?