### PR TITLE
add autocmd! to remove specific autocmds

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -161,6 +161,8 @@ const DEFAULTS = o({
     exaliases: o({
         alias: "command",
         au: "autocmd",
+        "au!": "rmautocmd",
+        "autocmd!": "rmautocmd",
         b: "buffer",
         o: "open",
         w: "winopen",

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2352,6 +2352,17 @@ export function autocmd(event: string, url: string, ...excmd: string[]) {
     config.set("autocmds", event, url, excmd.join(" "))
 }
 
+/** Remove autocmds
+ @param event Curently, 'TriStart', 'DocStart', 'DocEnd', 'TabEnter' and 'TabLeft' are supported.
+
+ @param url For DocStart, DocEnd, TabEnter, and TabLeft: a fragment of the URL on which the events will trigger, or a JavaScript regex (e.g, `/www\.amazon\.co.*\/`)
+*/
+//#background
+export function rmautocmd(event: string, url: string) {
+    if (!["DocStart", "DocEnd", "TriStart", "TabEnter", "TabLeft"].includes(event)) throw event + " is not a supported event."
+    config.unset("autocmds", event, url)
+}
+
 /**
  *  Helper function to put Tridactyl into ignore mode on the provided URL.
  *


### PR DESCRIPTION
I had some trouble with an autocmd and couldn't find an easy way to remove it, since that state is persistent. Adds `rmautocmd <event> <url>` to clear that state.  Aliased to `autocmd!` and `au!` to attempt to be more vim-like.