### PR TITLE
Fix race condition in :sanitise

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2504,9 +2504,9 @@ export async function sanitise(...args: string[]) {
     // Tridactyl-specific items
     if (dts.commandline === true) state.cmdHistory = []
     delete dts.commandline
-    if (dts.tridactyllocal === true) browser.storage.local.clear()
+    if (dts.tridactyllocal === true) await browser.storage.local.clear()
     delete dts.tridactyllocal
-    if (dts.tridactylsync === true) browser.storage.sync.clear()
+    if (dts.tridactylsync === true) await browser.storage.sync.clear()
     delete dts.tridactylsync
     // Global items
     browser.browsingData.remove(since, dts)


### PR DESCRIPTION
This fixes https://github.com/cmcaine/tridactyl/issues/724.
What happened was that sanitise was executed,
browser.storage.{local,sync}.clear() was called, the rest of the
settings were modified and only after this was the onChange event
listener in config.ts called, which then cleared the config.

Awaiting the result of .clear() makes sure that the onChange event
listener is triggered before executing any other command that might
make modifications to the browser storage. This can (and has) been
verified by surrounding the .clear() calls with console.logs and adding
a console.log to the onChange event listener.