### PR TITLE
Make guiset hoverlink compatible with firefox 61

### DIFF
--- a/src/css_util.ts
+++ b/src/css_util.ts
@@ -29,7 +29,7 @@ export function findCssRules(
  */
 export const potentialRules = {
     hoverlink: {
-        name: `statuspanel[type="overLink"]`,
+        name: `statuspanel[type="overLink"], #statuspanel[type="overLink"]`,
         options: {
             none: `display: none !important;`,
             right: `right: 0; display: inline;`,

--- a/src/static/css/userChrome-minimal.css
+++ b/src/static/css/userChrome-minimal.css
@@ -79,7 +79,8 @@
 
 /* Hide URL notifications that aren't particularly useful and cover up the command line
  * TODO: move it above the command line / bring functionality into status line like Vimperator */
-statuspanel[type="overLink"] {
+statuspanel[type="overLink"],
+#statuspanel[type="overLink"] {
     display: none !important;
 }
 


### PR DESCRIPTION
In firefox 61 there has been a medium change to how the status panel
(that shows the link the user hovers over) is created. Compare firefox
changeset 18bbbdc02213:
https://hg.mozilla.org/releases/mozilla-release/rev/18bbbdc02213

In particular there is no more statuspanel tag. Instead there is an hbox
with id="statuspanel".