### PR TITLE
Fix fillcmdline_tmp not closing the cmdline when changing tabs

### DIFF
--- a/src/commandline_background.ts
+++ b/src/commandline_background.ts
@@ -1,3 +1,4 @@
+import { activeTabId } from "./lib/webext"
 import * as Messaging from "./messaging"
 
 export type onLineCallback = (exStr: string) => void
@@ -53,9 +54,10 @@ export async function show(focus = true) {
     }
 }
 
-export async function hide() {
-    Messaging.messageActiveTab("commandline_content", "hide")
-    Messaging.messageActiveTab("commandline_content", "blur")
+export async function hide(tabid?) {
+    if (!tabid) tabid = await activeTabId()
+    Messaging.messageTab(tabid, "commandline_content", "hide")
+    Messaging.messageTab(tabid, "commandline_content", "blur")
 }
 
 Messaging.addListener(

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -218,11 +218,19 @@ clInput.addEventListener("input", () => {
 let cmdline_history_position = 0
 let cmdline_history_current = ""
 
-export async function hide_and_clear() {
-    clInput.removeEventListener("blur", noblur)
+/** Clears the command line.
+ *  If you intend to close the command line after this, set evlistener to true in order to enable losing focus.
+ *  Otherwise, no need to pass an argument.
+ */
+export function clear(evlistener = false) {
+    if (evlistener) clInput.removeEventListener("blur", noblur)
     clInput.value = ""
     cmdline_history_position = 0
     cmdline_history_current = ""
+}
+
+export async function hide_and_clear() {
+    clear(true)
 
     // Try to make the close cmdline animation as smooth as possible.
     Messaging.message("commandline_background", "hide")

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2048,7 +2048,10 @@ export async function fillcmdline_tmp(ms: string, ...strarr: string[]) {
     messageTab(tabId, "commandline_frame", "fillcmdline", [strarr.join(" "), false, false])
     return new Promise(resolve =>
         setTimeout(async () => {
-            if ((await messageTab(tabId, "commandline_frame", "getContent", [])) == str) await messageTab(tabId, "commandline_frame", "hide_and_clear", [])
+            if ((await messageTab(tabId, "commandline_frame", "getContent", [])) == str) {
+                CommandLineBackground.hide(tabId)
+                await messageTab(tabId, "commandline_frame", "clear", [true])
+            }
             resolve()
         }, milliseconds),
     )


### PR DESCRIPTION
This fixes https://github.com/cmcaine/tridactyl/issues/761 .

Fillcmdline_tmp was a mistake. I'm sorry.