### PR TITLE
Fix scrolling on bugzilla.mozilla.org

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -711,7 +711,7 @@ export async function scrollpx(a: number, b: number) {
 //#content
 export function scrollto(a: number, b: number | "x" | "y" = "y") {
     a = Number(a)
-    let elem = window.document.scrollingElement || window.document.body
+    let elem = window.document.scrollingElement || window.document.documentElement
     let percentage = a.clamp(0, 100)
     if (b === "y") {
         let top = elem.getClientRects()[0].top
@@ -742,10 +742,14 @@ let lineHeight = null
 //#content
 export function scrollline(n = 1) {
     if (lineHeight === null) {
-        // Get line height
-        const cssHeight = window.getComputedStyle(document.body).getPropertyValue("line-height")
-        // Remove the "px" at the end
-        lineHeight = parseInt(cssHeight.substr(0, cssHeight.length - 2))
+        let getLineHeight = elem => {
+            // Get line height
+            const cssHeight = window.getComputedStyle(elem).getPropertyValue("line-height")
+            // Remove the "px" at the end
+            return parseInt(cssHeight.substr(0, cssHeight.length - 2))
+        }
+        lineHeight = getLineHeight(document.documentElement)
+        if (!lineHeight) lineHeight = getLineHeight(document.body)
         // Is there a better way to compute a fallback? Maybe fetch from about:preferences?
         if (!lineHeight) lineHeight = 22
     }

--- a/src/scrolling.ts
+++ b/src/scrolling.ts
@@ -62,7 +62,7 @@ class ScrollingData {
         let elapsed = performance.now() - this.startTime
 
         // If the animation should be done, return the position the element should have
-        if (elapsed > this.duration || this.elem[this.pos] == this.endPos)
+        if (elapsed >= this.duration || this.elem[this.pos] == this.endPos)
             return this.endPos
 
         let result = (this.endPos - this.startPos) * elapsed / this.duration
@@ -96,7 +96,8 @@ class ScrollingData {
         this.endPos = this.elem[this.pos] + distance
         this.duration = duration
         // If we're already scrolling we don't need to try to scroll
-        if (this.scrolling) return true
+        if (this.scrolling) return true;
+        (this.elem.style as any).scrollBehavior = "unset"
         this.scrolling = this.scrollStep()
         if (this.scrolling)
             // If the element can be scrolled, scroll until animation completion


### PR DESCRIPTION
The problem was caused by elements having their scroll-behavior set to
"smooth". This meant that offsetTop was updated with a delay. The delay
made Tridactyl that the element couldn't be scrolled at all and thus
scrolling failed.

This commit has the nice side-effect of disabling smooth scrolling if
"smoothscroll" isn't set to "true" in the config.

This fixes https://github.com/cmcaine/tridactyl/issues/762.