### PR TITLE
completions.ts: Remove unused and buggy code

### DIFF
--- a/src/completions.ts
+++ b/src/completions.ts
@@ -209,41 +209,20 @@ export abstract class CompletionSourceFuse extends CompletionSource {
 
     /** Rtn sorted array of {option, score} */
     scoredOptions(query: string, options = this.options): ScoredOption[] {
-        // This is about as slow.
-        let USE_FUSE = true
-        if (!USE_FUSE) {
-            const searchThis = this.options.map((elem, index) => {
-                return { index, fuseKeys: elem.fuseKeys[0] }
-            })
-
-            return searchThis.map(r => {
-                return {
-                    index: r.index,
-                    option: this.options[r.index],
-                    score: r.fuseKeys.length,
-                }
-            })
-        } else {
-            // Can't sort the real options array because Fuse loses class information.
-
-            if (!this.fuse) {
-                let searchThis = this.options.map((elem, index) => {
-                    return { index, fuseKeys: elem.fuseKeys }
-                })
-
-                this.fuse = new Fuse(searchThis, this.fuseOptions)
+        let searchThis = this.options.map((elem, index) => {
+            return { index, fuseKeys: elem.fuseKeys }
+        })
+        this.fuse = new Fuse(searchThis, this.fuseOptions)
+        return this.fuse.search(query).map(res => {
+            let result = res as any
+            // console.log(result, result.item, query)
+            let index = toNumber(result.item)
+            return {
+                index,
+                option: this.options[index],
+                score: result.score as number,
             }
-            return this.fuse.search(query).map(res => {
-                let result = res as any
-                // console.log(result, result.item, query)
-                let index = toNumber(result.item)
-                return {
-                    index,
-                    option: this.options[index],
-                    score: result.score as number,
-                }
-            })
-        }
+        })
     }
 
     /** Set option state by score


### PR DESCRIPTION
This commit removes an if statement that is always true and a caching
optimization that can go wrong.

The caching optimization is the `if (!this.fuse)` statement. This
optimization can be buggy because it relies on this.options not
changing between two calls to scoredOptions but as far as I can tell,
this.options always changes between two scoredOptions calls.

If this.options changes, the array indexes used in searchThis do not
point to the right elements anymore and everything can break
(completions that should be matched disappear, completions with a lower
score get higher priority etc).

As far as I can tell, removing this optimization does not make
completions slower, but I couldn't test this with a large history.

I noticed this bug while writing a new completion source.