### PR TITLE
Swap NVim and vims order in TUI editor choice

### DIFF
--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -124,7 +124,7 @@ export async function getBestEditor(): Promise<string> {
         ]
     }
 
-    tui_editors = ["vim", "nvim", "nano", "emacs -nw"]
+    tui_editors = ["nvim", "vim", "nano", "emacs -nw"]
 
     // Consider GUI editors
     let cmd = await firstinpath(gui_candidates)


### PR DESCRIPTION
Just noticed that the order in which TUI editors are chosen is not very sane. Priority should be given to Nvim as most people have gone out of their way to install it compared to vim.