### PR TITLE
native_background.ts: Fix clipboard() adding newlines to copied strings

### DIFF
--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -315,7 +315,8 @@ export async function clipboard(
             heredoc += Math.round(Math.random() * 10)
 
         // Use delimiter to insert str into clipcmd's stdin
-        clipcmd = `${clipcmd} -i <<'${heredoc}'\n${str}\n${heredoc}\n`
+        // We use sed to remove the newline added by the here document
+        clipcmd = `sed -z 's/.$//' <<'${heredoc}' | ${clipcmd} -i \n${str}\n${heredoc}`
         let result = await run(clipcmd)
         if (result.code != 0)
             throw new Error(


### PR DESCRIPTION
Here-documents require a newline at the end of their content and there's
no way around it. In order to prevent the newline to be sent to the
clipboard command, we can do two things: not use here-documents or pipe
the content to sed first to remove the newline.

Not using here-documents means doing a lot of string manipulations to
escape the string properly. Using here-documents is conceptually
simpler.

Hence, we keep using here-documents and pipe the string to sed.

This fixes https://github.com/cmcaine/tridactyl/issues/796. Let me know if you'd rather do manual string escaping rather than piping things to sed.