### PR TITLE
Add `mute` excmd.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -192,6 +192,7 @@ const DEFAULTS = o({
         sanitize: "sanitise",
         tutorial: "tutor",
         h: "help",
+        unmute: "mute -u",
         authors: "credits",
         openwith: "hint -W",
         "!": "exclaim",

--- a/src/config.ts
+++ b/src/config.ts
@@ -192,7 +192,7 @@ const DEFAULTS = o({
         sanitize: "sanitise",
         tutorial: "tutor",
         h: "help",
-        unmute: "mute -u",
+        unmute: "mute unmute",
         authors: "credits",
         openwith: "hint -W",
         "!": "exclaim",

--- a/src/config.ts
+++ b/src/config.ts
@@ -141,6 +141,7 @@ const DEFAULTS = o({
         ".": "repeat",
         "<SA-ArrowUp><SA-ArrowUp><SA-ArrowDown><SA-ArrowDown><SA-ArrowLeft><SA-ArrowRight><SA-ArrowLeft><SA-ArrowRight>ba":
             "open https://www.youtube.com/watch?v=M3iOROuTuMA",
+        "<A-m>": "mute toggle",
     }),
     autocmds: o({
         DocStart: o({

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1802,7 +1802,7 @@ export async function pin() {
 /**  Mute current tab or all tabs.
 
  Passing "all" to the excmd will operate on  the mute state of all tabs.
- Passing "-u" to the excmd will unmute.
+ Passing "unmute" to the excmd will unmute.
  Passing "toggle" to the excmd will toggle the state of `browser.tabs.tab.MutedInfo`
  @param string[] muteArgs 
  */
@@ -1819,7 +1819,7 @@ export async function mute(...muteArgs: string[]): Promise<void> {
             args.shift()
             argParse(args)
         } 
-        if (args[0] === "-u") {
+        if (args[0] === "unmute") {
             mute = false
             args.shift()
             argParse(args)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1799,6 +1799,54 @@ export async function pin() {
     browser.tabs.update(aTab.id, { pinned: !aTab.pinned })
 }
 
+/**  Mute current tab or all tabs.
+
+ Passing "all" to the excmd will operate on  the mute state of all tabs.
+ Passing "-u" to the excmd will unmute.
+ Passing "toggle" to the excmd will toggle the state of `browser.tabs.tab.MutedInfo`
+ @param string[] muteArgs 
+ */
+//#background
+export async function mute(...muteArgs: string[]): Promise<void> {
+    let mute = true
+    let toggle = false
+    let all = false
+
+    let argParse = (args: string[]) => {
+        if (args == null) { return }
+        if (args[0] === "all") {
+            all = true
+            args.shift()
+            argParse(args)
+        } 
+        if (args[0] === "-u") {
+            mute = false
+            args.shift()
+            argParse(args)
+        }
+        if (args[0] === "toggle") {
+            toggle = true
+            args.shift()
+            argParse(args)
+        }
+    }
+
+    argParse(muteArgs)
+
+    let updateObj = { muted: false}
+    if(mute) { updateObj.muted = true }
+    if (all) { 
+        let tabs = await browser.tabs.query({currentWindow: true})
+        for (let tab of tabs) {
+            if(toggle) { updateObj.muted = !tab.mutedInfo.muted}
+            browser.tabs.update(tab.id, updateObj) 
+        }
+    } else {
+        let tab = await activeTab()
+        if(toggle) { updateObj.muted = !tab.mutedInfo.muted}
+        browser.tabs.update(tab.id, updateObj) 
+    }
+}
 // }}}
 
 // {{{ WINDOWS


### PR DESCRIPTION
Mute takes a couple of arguments that are a bit loosely defined. `-u`
unmutes, as seen by the `unmute` exalias. `toggle` toggles between the
states. `all` applies `mute/unmute/toggle` on all the tabs in the current window.

Addresses features requested in #812 