### PR TITLE
Fix Tridacyl not working on about:blank newtab page.

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -74,7 +74,9 @@ if (
         } else if (newtab) {
             excmds.open_quiet(newtab)
         } else {
-            document.documentElement.style.display = "block"
+            document.body.style.height = "100%"
+            document.body.style.opacity = "1"
+            document.body.style.overflow = "auto"
             document.title = "Tridactyl Top Tips & New Tab Page"
         }
     })

--- a/src/static/newtab.template.html
+++ b/src/static/newtab.template.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" style="display: none;" class="TridactylOwnNamespace">
+<html lang="en" class="TridactylOwnNamespace">
     <head>
         <meta charset="utf-8">
         <link rel="stylesheet" href="css/newtab.css">
@@ -9,7 +9,7 @@
         <link rel="shortcut icon" href="logo/Tridactyl_64px.png">
     </head>
     <title>&nbsp;</title>
-    <body>
+    <body style="opacity: 0; height: 0px; overflow: hidden;">
         REPLACETHIS
     </body>
     <script src="../content.js"></script>


### PR DESCRIPTION
Apparently, Firefox can't give you key events for the window if <body>
is `display: none`. This is fixed by turning the page transparent
instead of not displaying it. Since the scrollbar is still visible when
the page is transparent, we also set the page's height to 0px.

All of these modifications are reversed when the page needs to be
displayed.

This fixes https://github.com/cmcaine/tridactyl/issues/828.