### PR TITLE
allow passing stdin to native "run" commands

### DIFF
--- a/native/native_main.py
+++ b/native/native_main.py
@@ -14,7 +14,7 @@ import time
 import unicodedata
 
 DEBUG = False
-VERSION = "0.1.6"
+VERSION = "0.1.7"
 
 
 class NoConnectionError(Exception):
@@ -413,15 +413,14 @@ def handleMessage(message):
 
     elif cmd == "run":
         commands = message["command"]
+        stdin = message.get("content", "").encode("utf-8")
 
-        try:
-            p = subprocess.check_output(commands, shell=True)
-            reply["content"] = p.decode("utf-8")
-            reply["code"] = 0
+        p = subprocess.Popen(commands, shell=True,
+                             stdin=subprocess.PIPE,
+                             stdout=subprocess.PIPE)
 
-        except subprocess.CalledProcessError as process:
-            reply["code"] = process.returncode
-            reply["content"] = process.output.decode("utf-8")
+        reply["content"] = p.communicate(stdin)[0].decode("utf-8")
+        reply["code"] = p.returncode
 
     elif cmd == "eval":
         output = eval(message["command"])

--- a/native/native_main.py
+++ b/native/native_main.py
@@ -380,7 +380,7 @@ def write_log(msg):
     debug_log_dirname = ".tridactyl"
     debug_log_filename = "native_main.log"
 
-    debug_log_path = "%s\\%s\\%s" % (
+    debug_log_path = os.path.join(
         os.path.expanduser("~"),
         debug_log_dirname,
         debug_log_filename,

--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -259,8 +259,8 @@ export async function winFirefoxRestart(
     return sendNativeMsg("win_firefox_restart", { profiledir, browsercmd })
 }
 
-export async function run(command: string) {
-    let msg = await sendNativeMsg("run", { command })
+export async function run(command: string, content = "") {
+    let msg = await sendNativeMsg("run", { command, content })
     logger.info(msg)
     return msg
 }

--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -305,19 +305,12 @@ export async function clipboard(
         }
         return result.content
     } else if (action == "set") {
-        // We're going to need to insert str, which we can't trust, in the clipcmd
-        // In order to do this safely we'll use here documents:
-        // http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_07_04
+        let required_version = "0.1.7"
+        if (!await nativegate(required_version, false)) {
+            throw `setting external clipboard requires native messenger >= ${required_version}.`
+        }
 
-        // Find a delimiter that isn't in str
-        let heredoc = "TRIDACTYL"
-        while (str.search(heredoc) != -1)
-            heredoc += Math.round(Math.random() * 10)
-
-        // Use delimiter to insert str into clipcmd's stdin
-        // We use sed to remove the newline added by the here document
-        clipcmd = `sed -z 's/.$//' <<'${heredoc}' | ${clipcmd} -i \n${str}\n${heredoc}`
-        let result = await run(clipcmd)
+        let result = await run(`${clipcmd} -i`, str)
         if (result.code != 0)
             throw new Error(
                 `External command failed with code ${result.code}: ${clipcmd}`,


### PR DESCRIPTION
After reading https://github.com/cmcaine/tridactyl/pull/799 and the surrounding code, I think there's a cleaner way to pass the clipboard data: by giving the `run` native message an optional `content` field to feed to the stdin of the command. It's not a huge amount of code saved, but I think it's a lot easier to reason about (and gives us a good pattern for robustly passing untrusted data to shell commands).

It might also be nice to eventually expose this to the user via an ex cmd, but I'm not sure how. In vim this is really `!cmd` versus `.!cmd`. But of course we don't have an editor buffer, so selecting lines doesn't make sense. I guess people would probably be most interested in feeding things like the current URL, or hint-text (but I don't have an immediate use, personally).

I left some notes on the implementation in the commit messages, especially fb0bfc0807c887f052918ea867fbee566404b7f7.

/cc @glacambre 