### PR TITLE
Issue template

### DIFF
--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -1,0 +1,32 @@
+
+# Settings that can fix websites
+If changing one of these settings fixes your bug, please visit the corresponding Github issue and let us know you encountered the bug.
+- `:set noiframeon $URL_OF_THE_WEBSITE` and then reload the page.
+  This disables the Tridactyl commandline on a specific url. [CREATE CORRESPONDING ISSUE]
+- `:set allowautofocus true` and then reload the page.
+  This allows website to use the javascript `focus()` function. [#550](https://github.com/cmcaine/tridactyl/issues/550)
+- `:set modeindicator false` and then reload the page.
+  This disables the mode indicator. [#821](https://github.com/cmcaine/tridactyl/issues/821)
+- `:get csp`. If the value returned is "untouched", try `:set csp clobber`. If the value is "clobber", try `:set csp untouched`. In both cases, please reload the page.
+  This disables (or prevents disabling) some security settings of the page. [#109](https://github.com/cmcaine/tridactyl/issues/109)
+
+# Native Editor/Messenger issues
+If you're having trouble running your editor on OSX, you might be having $PATH issues: [#684](https://github.com/cmcaine/tridactyl/issues/684). The solution is to specify the absolute path to your editor, like this: `:set editorcmd /usr/local/bin/vimr`.
+
+If you're encountering problems on windows, you might want to try some of the workarounds mentioned here: [#797](https://github.com/cmcaine/tridactyl/issues/797).
+
+
+# Getting logging information
+Tridactyl can selectively display logs for certain components. These components are the following:
+- messaging
+- cmdline
+- controller
+- containers
+- hinting
+- state
+- styling
+- excmds
+
+In order to activate logging for a component, you can use the following command: `:set logging.$COMPONENT DEBUG`. Then, to get the log, you can open a new tab, navigate to about:debugging, enable the "enable add-on debugging" checkbox at the top if it isn't enabled and then find Tridactyl in the addon list and click on "Debug".
+
+This will open a console where Tridactyl's messages are logged. You can then go back to the tab where you encountered the bug, click on the little bin icon in the console in order to remove previous messages and try to re-trigger the bug.

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,0 +1,13 @@
+If you're opening this issue for a feature request, feel free to delete all of this and to just tell us what you need (although it'd be nice if you could make sure that there isn't an issue already open about this!).
+
+If you're opening this issue to report a bug, please read the "Settings that can fix websites" paragraph of the (troubleshooting steps)[https://github.com/cmcaine/tridactyl/tree/master/doc/troubleshooting.md] first.
+
+- Tridactyl version (`:version`):
+- Firefox version (Top right menu > Help > About Firefox):
+- URL of the website the bug happens on:
+- Config (run `:viewconfig`, copy the url and paste it somewhere like gist.github.com): 
+
+If your bug is about Tridactyl's native executable, please add the following information:
+- Operating System:
+- Result of running `printf '%c\0\0\0{"cmd": "run", "command": "echo $PATH"}' 39 | ~/.local/share/tridactyl/native_main.py` in a terminal:
+- Result of running `:! echo $PATH` in tridactyl:


### PR DESCRIPTION
What's mentioned in https://github.com/cmcaine/tridactyl/issues/522 and https://github.com/cmcaine/tridactyl/issues/662:

- Should include a primer on getting logs out of Tridactyl with clear "delete me once read" tickers
  + I added this to troubleshooting.md instead of the issue templates because the steps are slightly complicated and users might not be able to guess what logs they need to check. I believe it'll be easier to just ask for logs on a case-by-case basis.
- Accessing tri through the console on the new tab page and about:debugging
  + Same here, I believe this is complicated and too general for the issue template. This could go in troubleshooting.md though.
- Including configuration by copying viewconfig URI
  + Done
- Including user.js, prefs.js and userChrome.css
  + This seems unnecessary to me. I haven't seen a single issue where user/pref.js were at fault and I only remember a single userChrome.css issue.
- Native messenger stuff
  + All here