### PR TITLE
History.ts: Add missing space when inserting completion options

### DIFF
--- a/src/completions/History.ts
+++ b/src/completions/History.ts
@@ -78,6 +78,7 @@ export class HistoryCompletionSource extends Completions.CompletionSourceFuse {
                 query = query.substring(options.length)
             }
         }
+        options += options ? " " : ""
 
         this.options = (await this.scoreOptions(query, 10)).map(
             page => new HistoryCompletionOption(options + page.url, page),


### PR DESCRIPTION
e5d2be7 introduced a bug while trying to fix
https://github.com/cmcaine/tridactyl/issues/838: when the command line
contains `tabopen -flag ` and the user tries to insert the selected
completion option in the command line by pressing <Space>, the resulting
command line will be `tabopen -flagurl` instead of `tabopen -flag url`.

This is fixed by appending a trailing space to the `options` variable if
it isn't an empty string.