### PR TITLE
excmds.ts: Actually make guiset error message easier to understand

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -206,10 +206,8 @@ import * as css_util from "./css_util"
  */
 //#background
 export async function guiset_quiet(rule: string, option: string) {
-    if (!rule || !option) {
-        fillcmdline(":guiset requires two arguments. See `:help guiset` for more information.")
-        return
-    }
+    if (!rule || !option)
+        throw new Error(":guiset requires two arguments. See `:help guiset` for more information.")
     // Could potentially fall back to sending minimal example to clipboard if native not installed
 
     // Check for native messenger and make sure we have a plausible profile directory


### PR DESCRIPTION
The previous version correctly displayed an error on `:guiset_quiet` but
hid error messages for `guiset`.

Sorry about that :/