### PR TITLE
completions: Make selected completion option undefined on change

### DIFF
--- a/src/completions/Bmark.ts
+++ b/src/completions/Bmark.ts
@@ -56,6 +56,7 @@ export class BmarkCompletionSource extends Completions.CompletionSourceFuse {
             return
         }
 
+        this.completion = undefined
         this.options = (await this.scoreOptions(query, 10)).map(
             page => new BmarkCompletionOption(page.url, page),
         )

--- a/src/completions/Buffer.ts
+++ b/src/completions/Buffer.ts
@@ -94,7 +94,7 @@ export class BufferCompletionSource extends Completions.CompletionSourceFuse {
             )
         }
 
-        /* console.log('updateOptions end', this.waiting, this.optionContainer) */
+        this.completion = undefined
         this.options = options
         this.updateChain()
     }

--- a/src/completions/BufferAll.ts
+++ b/src/completions/BufferAll.ts
@@ -92,6 +92,7 @@ export class BufferAllCompletionSource extends Completions.CompletionSourceFuse 
             )
         }
 
+        this.completion = undefined
         this.options = options
         this.updateChain()
     }

--- a/src/completions/History.ts
+++ b/src/completions/History.ts
@@ -80,6 +80,7 @@ export class HistoryCompletionSource extends Completions.CompletionSourceFuse {
         }
         options += options ? " " : ""
 
+        this.completion = undefined
         this.options = (await this.scoreOptions(query, 10)).map(
             page => new HistoryCompletionOption(options + page.url, page),
         )


### PR DESCRIPTION
Before this patch, selected completion options weren't properly
deselected when available options changed. This commit fixes this.

This does not break completion option autoselect because the reset
happens before autoselection.

This fixes https://github.com/cmcaine/tridactyl/issues/833.