### PR TITLE
Fix bufferall selecting the wrong window.

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2324,7 +2324,7 @@ export async function buffer(index: number | "#") {
  */
 //#background
 export async function bufferall(id: string) {
-    let windows = (await browser.windows.getAll()).map(w => w.id).sort()
+    let windows = (await browser.windows.getAll()).map(w => w.id).sort((a, b) => a - b)
     if (id === null || id === undefined || !id.match(/\d+\.\d+/)) {
         const tab = await activeTab()
         let prevId = id


### PR DESCRIPTION
The problem was that when calling sort on an array of numbers without
specifying the sort function that should be used, the array will be
sorted according to the lexicographic order of the elements.

This is fixed by specifying what function should be used to sort the
array.

This fixes https://github.com/cmcaine/tridactyl/issues/819.