### PR TITLE
Refactor hinting.pipe to return a tuple.

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2856,7 +2856,7 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
 
     // Open in background
     if (option === "-b") {
-        let link = await hinting.pipe(DOM.HINTTAGS_selectors)
+        let [link, hintCount] = await hinting.pipe(DOM.HINTTAGS_selectors)
         link.focus()
         if (link.href) {
             let containerId = await activeTabContainerId()
@@ -2875,7 +2875,7 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
         } else {
             DOM.simulateClick(link)
         }
-        return link.href
+        return [link.href, hintCount]
     }
 
     // Yank link
@@ -2900,7 +2900,7 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
         let link = await hinting.pipe_elements(DOM.anchors())
         anchorUrl.hash = link.id || link.name
         run_exstr("yank " + anchorUrl.href)
-    } else if (option === "-c") DOM.simulateClick(await hinting.pipe(selectors))
+    } else if (option === "-c") DOM.simulateClick(await hinting.pipe(selectors)[0])
     // Deprecated: hint exstr
     else if (option === "-W") run_exstr(selectors + " " + rest.join(" ") + " " + (await hinting.pipe(DOM.HINTTAGS_selectors)))
     else if (option === "-pipe") return (await hinting.pipe(selectors))[rest.join(" ")]
@@ -2908,12 +2908,8 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
         let lasthref = ""
         let starttime = window.performance.now()
         while (true) {
-            let href = await hint("-b")
-            let endtime = window.performance.now()
-            // Hacky "if there's only one link on the page, don't spam it"
-            if (href == lasthref && endtime - starttime < 100) break
-            else lasthref = href
-            starttime = endtime
+            let [_, hintCount] = await hint("-b")
+            if (hintCount < 2) break
         }
     }
 
@@ -2929,7 +2925,7 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
     else if (option === "-r") hinting.hintRead()
     else if (option === "-w") hinting.hintPageWindow()
     else if (option === "-wp") hinting.hintPageWindowPrivate()
-    else DOM.simulateClick(await hinting.pipe(DOM.HINTTAGS_selectors))
+    else DOM.simulateClick(await hinting.pipe(DOM.HINTTAGS_selectors)[0])
 }
 
 // how 2 crash pc

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2900,10 +2900,10 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
         let link = await hinting.pipe_elements(DOM.anchors())
         anchorUrl.hash = link.id || link.name
         run_exstr("yank " + anchorUrl.href)
-    } else if (option === "-c") DOM.simulateClick(await hinting.pipe(selectors)[0])
+    } else if (option === "-c") DOM.simulateClick((await hinting.pipe(selectors))[0])
     // Deprecated: hint exstr
-    else if (option === "-W") run_exstr(selectors + " " + rest.join(" ") + " " + (await hinting.pipe(DOM.HINTTAGS_selectors)[0]))
-    else if (option === "-pipe") return (await hinting.pipe(selectors)[0])[rest.join(" ")]
+    else if (option === "-W") run_exstr(selectors + " " + rest.join(" ") + " " + (await hinting.pipe(DOM.HINTTAGS_selectors))[0])
+    else if (option === "-pipe") return (await hinting.pipe(selectors))[0][rest.join(" ")]
     else if (option === "-br") {
         while (true) {
             let [_, hintCount] = await hint("-b")
@@ -2923,7 +2923,7 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
     else if (option === "-r") hinting.hintRead()
     else if (option === "-w") hinting.hintPageWindow()
     else if (option === "-wp") hinting.hintPageWindowPrivate()
-    else DOM.simulateClick(await hinting.pipe(DOM.HINTTAGS_selectors)[0])
+    else DOM.simulateClick((await hinting.pipe(DOM.HINTTAGS_selectors))[0])
 }
 
 // how 2 crash pc

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2852,7 +2852,7 @@ import * as hinting from "./hinting"
 */
 //#content
 export async function hint(option?: string, selectors?: string, ...rest: string[]) {
-    // NB: if you want something to work with rapid hinting, make it return something
+    // NB: if you want something to work with rapid hinting, make it return a tuple of [something, hintCount] see option === "-b" below.
 
     // Open in background
     if (option === "-b") {
@@ -2880,7 +2880,7 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
 
     // Yank link
     else if (option === "-y") {
-        run_exstr("yank " + (await hinting.pipe(DOM.HINTTAGS_selectors))["href"])
+        run_exstr("yank " + (await hinting.pipe(DOM.HINTTAGS_selectors)[0])["href"])
     }
 
     // Yank text content
@@ -2902,11 +2902,9 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
         run_exstr("yank " + anchorUrl.href)
     } else if (option === "-c") DOM.simulateClick(await hinting.pipe(selectors)[0])
     // Deprecated: hint exstr
-    else if (option === "-W") run_exstr(selectors + " " + rest.join(" ") + " " + (await hinting.pipe(DOM.HINTTAGS_selectors)))
-    else if (option === "-pipe") return (await hinting.pipe(selectors))[rest.join(" ")]
+    else if (option === "-W") run_exstr(selectors + " " + rest.join(" ") + " " + (await hinting.pipe(DOM.HINTTAGS_selectors)[0]))
+    else if (option === "-pipe") return (await hinting.pipe(selectors)[0])[rest.join(" ")]
     else if (option === "-br") {
-        let lasthref = ""
-        let starttime = window.performance.now()
         while (true) {
             let [_, hintCount] = await hint("-b")
             if (hintCount < 2) break

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -472,7 +472,9 @@ function hintableImages() {
 /** Array of items that can be killed with hint kill
  */
 function killables() {
-    return DOM.getElemsBySelector(DOM.HINTTAGS_killable_selectors, [DOM.isVisible])
+    return DOM.getElemsBySelector(DOM.HINTTAGS_killable_selectors, [
+        DOM.isVisible,
+    ])
 }
 
 import { openInNewTab, activeTabContainerId } from "./lib/webext"
@@ -499,18 +501,21 @@ export function hintPageWindowPrivate() {
     })
 }
 
-export async function pipe(selectors = DOM.HINTTAGS_selectors) {
-    let hint =  await new Promise(resolve => {
+export async function pipe(
+    selectors = DOM.HINTTAGS_selectors,
+): Promise<[any, number]> {
+    let hintCount = hintables(selectors, true).length
+    let hint = await new Promise(resolve => {
         hintPage(hintables(selectors, true), resolve)
     })
-    return (hint as any).target
+    return [(hint as any).target, hintCount]
     // Promise takes function which it calls immediately with another function
-    // as its argument. When this second function is called, it gives its 
+    // as its argument. When this second function is called, it gives its
     // argument to the promise as its value
 }
 
-export async function pipe_elements(elements: any=DOM.elementsWithText) {
-    let hint =  await new Promise(resolve => {
+export async function pipe_elements(elements: any = DOM.elementsWithText) {
+    let hint = await new Promise(resolve => {
         hintPage(elements, resolve)
     })
     return (hint as any).target


### PR DESCRIPTION
Now returns a tuple of the element and the number of hints available
when the function was run. This mainly fixes the rapid hint bug
encountered when the user enters rapid hint mode with only one link
available.

Another application idea would be modeline info or something in that
vein.

Partially addresses #848 

(PS, idk why pretty is changing up all that stuff in hinting.ts)