### PR TITLE
Add DocLoad object to config.ts.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -165,6 +165,7 @@ const DEFAULTS = o({
         "<A-m>": "mute toggle",
     }),
     autocmds: o({
+        DocLoad: o({}),
         DocStart: o({
             // "addons.mozilla.org": "mode ignore",
         }),


### PR DESCRIPTION
This fixes that annoying TypeError in the browser console.