### PR TITLE
Add hintuppercase to toggle CSS overriding hint case

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -267,6 +267,7 @@ const DEFAULTS = o({
     hintchars: "hjklasdfgyuiopqwertnmzxcvb",
     hintfiltermode: "simple", // "simple", "vimperator", "vimperator-reflow"
     hintnames: "short",
+    hintuppercase: "true",
 
     // Controls whether the page can focus elements for you via js
     // Remember to also change browser.autofocus (autofocusing elements via

--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -230,6 +230,9 @@ class Hint {
         const rect = target.getClientRects()[0]
         this.flag.textContent = name
         this.flag.className = "TridactylHint"
+        if (config.get("hintuppercase") == "true") {
+            this.flag.classList.add("TridactylHintUppercase")
+        }
         /* this.flag.style.cssText = ` */
         /*     top: ${rect.top}px; */
         /*     left: ${rect.left}px; */

--- a/src/static/css/hint.css
+++ b/src/static/css/hint.css
@@ -3,7 +3,6 @@ span.TridactylHint {
     font-family: var(--tridactyl-hintspan-font-family) !important;
     font-size: var(--tridactyl-hintspan-font-size) !important;
     font-weight: var(--tridactyl-hintspan-font-weight) !important;
-    text-transform: uppercase !important;
     color: var(--tridactyl-hintspan-fg) !important;
     background-color: var(--tridactyl-hintspan-bg) !important;
     border-color: var(--tridactyl-hintspan-border-color) !important;
@@ -13,6 +12,10 @@ span.TridactylHint {
     padding: 0 1pt !important;
     text-align: center !important;
     z-index: 2147483647 !important;
+}
+
+span.TridactylHintUppercase {
+    text-transform: uppercase !important;
 }
 
 .TridactylHintElem,


### PR DESCRIPTION
Removes the text-transform to uppercase. This makes it easier to differentiate O/Q and J/I with the default hintchars, and it fixes the issue when you set hintchars to both upper and lower chars.

Tested as a temp addon in ff 60.1.0.