### PR TITLE
native_messenger: fix invalid syntax

### DIFF
--- a/native/native_main.py
+++ b/native/native_main.py
@@ -95,7 +95,7 @@ def findUserConfigFile():
     candidate_files = [
         os.path.join(config_dir, "tridactyl", "tridactylrc"),
         os.path.join(home, ".tridactylrc"),
-        os.path.join(home, , "_config", "tridactyl", "tridactylrc"),
+        os.path.join(home, "_config", "tridactyl", "tridactylrc"),
         os.path.join(home, "_tridactylrc"),
     ]
 


### PR DESCRIPTION
fix invalid syntax for `os.path.join(...`

this fixes "Native messenager not found" bug after installation on a Gentoo linux system.