### PR TITLE
Add auconenable config check.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -355,9 +355,6 @@ const DEFAULTS = o({
     // If moodeindicator is enabled, containerindicator will color the border of the mode indicator with the container color.
     containerindicator: "true",
 
-    // Enable Autocontainers
-    auconenable: "false",
-
     // Autocontain directives create a container if it doesn't exist already.
     auconcreatecontainer: "true",
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -179,7 +179,6 @@ const DEFAULTS = o({
         DocLoad: o({}),
         DocStart: o({
             // "addons.mozilla.org": "mode ignore",
-            // "github.com": "reopenincontainer Work",
         }),
         DocEnd: o({
             // "emacs.org": "sanitise history",
@@ -356,7 +355,10 @@ const DEFAULTS = o({
     // If moodeindicator is enabled, containerindicator will color the border of the mode indicator with the container color.
     containerindicator: "true",
 
-    // AutoContain directives create a container if it doesn't exist already.
+    // Enable Autocontainers
+    auconenable: "false",
+
+    // Autocontain directives create a container if it doesn't exist already.
     auconcreatecontainer: "true",
 
     // Performance related settings

--- a/src/lib/autocontainers.ts
+++ b/src/lib/autocontainers.ts
@@ -71,9 +71,9 @@ export class AutoContain implements IAutoContain {
     autoContain = async (
         details: IDetails,
     ): Promise<browser.webRequest.BlockingResponse> => {
-        // Lets not break everyone's user experience ok?
-        let enabled = Config.get("auconenable")
-        if (enabled === "false") return { cancel: false }
+        // No autocontain directives, no nothing.
+        let aucons = Config.get("autocontain")
+        if (Object.keys(aucons).length === 0) return { cancel: false }
 
         // Do not handle private tabs or invalid tabIds.
         if (details.tabId === -1) return { cancel: false}

--- a/src/lib/autocontainers.ts
+++ b/src/lib/autocontainers.ts
@@ -71,18 +71,22 @@ export class AutoContain implements IAutoContain {
     autoContain = async (
         details: IDetails,
     ): Promise<browser.webRequest.BlockingResponse> => {
+        // Lets not break everyone's user experience ok?
+        let enabled = Config.get("auconenable")
+        if (enabled === "false") return { cancel: false }
+
         // Do not handle private tabs or invalid tabIds.
-        if (details.tabId === -1) return
+        if (details.tabId === -1) return { cancel: false}
         let tab = await browser.tabs.get(details.tabId)
-        if (tab.incognito) return
+        if (tab.incognito) return { cancel: false }
 
         // Only handle http requests.
-        if (details.url.search("^https?://") < 0) return
+        if (details.url.search("^https?://") < 0) return { cancel: false }
 
         let cookieStoreId = await this.parseAucons(details)
 
         // Silently return if we're already in the correct container.
-        if (tab.cookieStoreId === cookieStoreId) return
+        if (tab.cookieStoreId === cookieStoreId) return { cancel: false }
 
         if (this.cancelEarly(tab, details)) return { cancel: true }
 
@@ -110,14 +114,13 @@ export class AutoContain implements IAutoContain {
             this.cancelRequest(tab, details)
         } else {
             let cancel = false
-            let cr = this.getCancelledRequest(tab.id)
 
-            if (cr.requestIds[details.requestId] || cr.urls[details.url]) {
+            if (this.cancelledRequests[tab.id].requestIds[details.requestId] || this.cancelledRequests[tab.id].urls[details.url]) {
                 cancel = true
             }
 
-            cr.requestIds[details.requestId] = true
-            cr.urls[details.url] = true
+            this.cancelledRequests[tab.id].requestIds[details.requestId] = true
+            this.cancelledRequests[tab.id].urls[details.url] = true
 
             return cancel
         }


### PR DESCRIPTION
Ignores all autocontain directives unless config variable is set to
"true". This can tide us over until I actually sit down and write it 
to be compatible with the Mozilla container extensions.

This resolves #883 and #882 