### PR TITLE
Don't delay simple hints.

### DIFF
--- a/src/hinting.ts
+++ b/src/hinting.ts
@@ -436,7 +436,7 @@ function filterHintsVimperator(fstr, reflow = false) {
 
     // Select focused hint if it's the only match
     if (active.length == 1) {
-        selectFocusedHint()
+        selectFocusedHint(true)
     }
 }
 
@@ -620,10 +620,15 @@ export function hintSave(hintType: HintSaveType, saveAs: boolean) {
     })
 }
 
-function selectFocusedHint() {
+function selectFocusedHint(delay = false) {
     logger.debug("Selecting hint.", state.mode)
     const focused = modeState.focusedHint
-    setTimeout(_=>{reset(); focused.select()},config.get("hintdelay"))
+    let select = () => {
+        reset()
+        focused.select()
+    }
+    if (delay) setTimeout(select, config.get("hintdelay"))
+    else select()
 }
 
 import { addListener, attributeCaller } from "./messaging"


### PR DESCRIPTION
This commit makes sure that hint selection for non-vimperator hints is
instantaneous.

In my opinion this important because simple hints don't need to be delayed and since they're the default, new users who won't know about the `hintdelay` config option might believe that Tridactyl is slow.