### PR TITLE
Prevent cutting off a few pixels at the top

### DIFF
--- a/src/static/css/userChrome-minimal.css
+++ b/src/static/css/userChrome-minimal.css
@@ -77,6 +77,10 @@
     padding-top: 7px !important;
 }
 
+#main-window[sizemode="maximized"] #content-deck {
+    padding-top: 8px;
+}
+
 /* Hide URL notifications that aren't particularly useful and cover up the command line
  * TODO: move it above the command line / bring functionality into status line like Vimperator */
 statuspanel[type="overLink"],


### PR DESCRIPTION
The minimal userChrome file causes 8 pixels to be cut off from the top of the "content" part of the page, but only when the navbar is hidden. This change, as written, will reverse the situation: it will add 8 pixels of extraneous padding when the navbar is not hidden. Given that we spend most of our browsing time with the navbar hidden, this optimises for the common case instead of the uncommon case.