### PR TITLE
Remove try/catch in excmd completion

### DIFF
--- a/src/completions/Excmd.ts
+++ b/src/completions/Excmd.ts
@@ -7,8 +7,8 @@ class ExcmdCompletionOption extends Completions.CompletionOptionHTML
     public fuseKeys = []
     constructor(
         public value: string,
-        public ttype: string,
-        public documentation: string,
+        public ttype: string = "",
+        public documentation: string = "",
     ) {
         super()
         this.fuseKeys.push(this.value)
@@ -49,13 +49,7 @@ export class ExcmdCompletionSource extends Completions.CompletionSourceFuse {
         let fns = Metadata.everything["src/excmds.ts"]
         this.options = (await this.scoreOptions(
             Object.keys(fns).filter(f => f.startsWith(exstr)),
-        )).map(f => {
-            try {
-                return new ExcmdCompletionOption(f, fns[f].type, fns[f].doc)
-            } catch {
-                return new ExcmdCompletionOption("", "", "")
-            }
-        })
+        )).map(f => new ExcmdCompletionOption(f, fns[f].type, fns[f].doc))
         this.options.forEach(o => (o.state = "normal"))
         this.updateChain()
     }


### PR DESCRIPTION
This commit removes the try/catch in the excmd completion source and
instead makes the ExcmdCompletionOption constructor default to a string
for missing values.

This is useful for three reasons:
- The try/catch discarded excmds that didn't have a type/documentation,
  but being able to autocomplete the name of these functions could still
  be useful
- Try/catch are usually expensive
- TypeScript wrongly complained about a missing parenthesis when the
  try/catch was there