### PR TITLE
Fix aliases breaking excmd completion

### DIFF
--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -14,7 +14,6 @@ import * as SELF from "./commandline_frame"
 import "./number.clamp"
 import state from "./state"
 import Logger from "./logging"
-import * as aliases from "./aliases"
 import { theme } from "./styling"
 const logger = new Logger("cmdline")
 
@@ -207,13 +206,12 @@ clInput.addEventListener("keydown", function(keyevent) {
 
 clInput.addEventListener("input", () => {
     const exstr = clInput.value
-    const expandedCmd = aliases.expandExstr(exstr)
 
     // Fire each completion and add a callback to resize area
     enableCompletions()
     logger.debug(activeCompletions)
     activeCompletions.forEach(comp =>
-        comp.filter(expandedCmd).then(() => resizeArea()),
+        comp.filter(exstr).then(() => resizeArea()),
     )
 })
 

--- a/src/completions/Bmark.ts
+++ b/src/completions/Bmark.ts
@@ -36,7 +36,7 @@ export class BmarkCompletionSource extends Completions.CompletionSourceFuse {
     public options: BmarkCompletionOption[]
 
     constructor(private _parent) {
-        super(["bmarks "], "BmarkCompletionSource", "Bookmarks")
+        super(["bmarks"], "BmarkCompletionSource", "Bookmarks")
 
         this._parent.appendChild(this.node)
     }

--- a/src/completions/Buffer.ts
+++ b/src/completions/Buffer.ts
@@ -57,7 +57,7 @@ export class BufferCompletionSource extends Completions.CompletionSourceFuse {
 
     constructor(private _parent) {
         super(
-            ["buffer ", "tabclose ", "tabdetach ", "tabduplicate ", "tabmove "],
+            ["buffer", "tabclose", "tabdetach", "tabduplicate", "tabmove"],
             "BufferCompletionSource",
             "Buffers",
         )

--- a/src/completions/BufferAll.ts
+++ b/src/completions/BufferAll.ts
@@ -42,7 +42,7 @@ export class BufferAllCompletionSource extends Completions.CompletionSourceFuse 
     public options: BufferAllCompletionOption[]
 
     constructor(private _parent) {
-        super(["bufferall "], "BufferAllCompletionSource", "All Buffers")
+        super(["bufferall"], "BufferAllCompletionSource", "All Buffers")
 
         this.updateOptions()
         this._parent.appendChild(this.node)

--- a/src/completions/History.ts
+++ b/src/completions/History.ts
@@ -35,7 +35,7 @@ export class HistoryCompletionSource extends Completions.CompletionSourceFuse {
 
     constructor(private _parent) {
         super(
-            ["open ", "tabopen ", "winopen "],
+            ["open", "tabopen", "winopen"],
             "HistoryCompletionSource",
             "History",
         )


### PR DESCRIPTION
As mentioned in https://github.com/cmcaine/tridactyl/issues/912, there
was a problem with aliases preventing some excmd completion options from
being displayed. For example, `b` would be expanded to `buffer` in the
command line completion mechanism and thus prevent `back` from being
displayed.

This commit fixes that by treating aliases as "real" excmds when
building completion sources. Basically, we check for aliases to the
prefixes given as CompletionSource parameter and add them to the list of
prefixes that can trigger the completion source.

We use this opportunity to remove the constraint of having to add a
space to each prefix, they're instead automatically added by the
CompletionSource constructor.