### PR TITLE
Make Excmd completion type simpler

### DIFF
--- a/compiler/gen_metadata.ts
+++ b/compiler/gen_metadata.ts
@@ -2,6 +2,93 @@ import * as ts from "typescript"
 import * as fs from "fs"
 import * as commandLineArgs from "command-line-args"
 
+class SimpleType {
+    name: string
+    kind: string
+    // Support for generics is mostly done but it might not be needed for now
+    // generics: Array<SimpleType>
+    arguments: Array<SimpleType>
+    type: SimpleType
+
+    constructor(typeNode) {
+        switch (typeNode.kind) {
+            case ts.SyntaxKind.VoidKeyword:
+                this.kind = "void"
+                break
+            case ts.SyntaxKind.AnyKeyword:
+                this.kind = "any"
+                break
+            case ts.SyntaxKind.BooleanKeyword:
+                this.kind = "boolean"
+                break
+            case ts.SyntaxKind.NumberKeyword:
+                this.kind = "number"
+                break
+            case ts.SyntaxKind.ObjectKeyword:
+                this.kind = "object"
+                break
+            case ts.SyntaxKind.StringKeyword:
+                this.kind = "string"
+                break
+            case ts.SyntaxKind.Parameter:
+                // 149 is "Parameter". We don't care about that so let's
+                // convert its type into a SimpleType and grab what we need from it
+                let ttype = new SimpleType(typeNode.type)
+                this.kind = ttype.kind
+                // this.generics = ttype.generics
+                this.arguments = ttype.arguments
+                this.type = ttype.type
+                this.name = typeNode.name.original.escapedText
+                break
+            case ts.SyntaxKind.TypeReference:
+                // 162 is "TypeReference". Not sure what the rules are here but it seems to be used for generics
+                this.kind = typeNode.typeName.escapedText
+                if (typeNode.typeArguments) {
+                    this.arguments = typeNode.typeArguments.map(
+                        t => new SimpleType(typeNode.typeArguments[0]),
+                    )
+                }
+                break
+            case ts.SyntaxKind.FunctionType:
+                this.kind = "function"
+                // Probably don't need generics for now
+                // this.generics = (typeNode.typeParameters || []).map(p => new SimpleType(p))
+                this.arguments = typeNode.parameters.map(p => new SimpleType(p))
+                this.type = new SimpleType(typeNode.type)
+                break
+            case ts.SyntaxKind.TypeLiteral:
+                // This is a type literal. i.e., something like this: { [str: string]: string[] }
+                // Very complicated and perhaps not useful to know about. Let's just say "object" for now
+                this.kind = "object"
+                break
+            case ts.SyntaxKind.ArrayType:
+                this.kind = "array"
+                this.type = new SimpleType(typeNode.elementType)
+                break
+            case ts.SyntaxKind.TupleType:
+                this.kind = "tuple"
+                this.arguments = typeNode.elementTypes.map(
+                    t => new SimpleType(t),
+                )
+                break
+            case ts.SyntaxKind.UnionType:
+                this.kind = "union"
+                this.arguments = typeNode.types.map(t => new SimpleType(t))
+                break
+            case ts.SyntaxKind.LiteralType:
+                // "LiteralType". I'm not sure what this is. Probably things like type a = "b" | "c"
+                this.kind = "LiteralType"
+                this.name = typeNode.literal.text
+                break
+            default:
+                console.log(typeNode)
+                throw new Error(
+                    `Unhandled kind (${typeNode.kind}) for ${typeNode}`,
+                )
+        }
+    }
+}
+
 /** True if this is visible outside this file, false otherwise */
 function isNodeExported(node: ts.Node): boolean {
     return (
@@ -35,7 +122,11 @@ function visit(checker: any, filename: string, node: any, everything: any) {
                     symbol,
                     symbol.valueDeclaration!,
                 )
-                if (ttype) nodeInfo["type"] = checker.typeToString(ttype)
+                if (ttype) {
+                    nodeInfo["type"] = new SimpleType(
+                        checker.typeToTypeNode(ttype),
+                    )
+                }
             }
             break
         // Other declaration syntaxkinds:

--- a/src/completions/Excmd.ts
+++ b/src/completions/Excmd.ts
@@ -19,10 +19,10 @@ class ExcmdCompletionOption extends Completions.CompletionOptionHTML
         // Create HTMLElement
         this.html = html`<tr class="ExcmdCompletionOption option">
             <td class="excmd">${value}</td>
-            <td class="type">${ttype}</td>
             <td class="documentation">${documentation}</td>
         </tr>`
     }
+    // <td class="type">${ttype}</td>
 }
 
 export class ExcmdCompletionSource extends Completions.CompletionSourceFuse {

--- a/src/completions/Excmd.ts
+++ b/src/completions/Excmd.ts
@@ -1,4 +1,5 @@
 import * as Completions from "../completions"
+import { typeToSimpleString } from "../metadata"
 import * as Metadata from "../.metadata.generated"
 import state from "../state"
 import * as config from "../config"
@@ -51,7 +52,11 @@ export class ExcmdCompletionSource extends Completions.CompletionSourceFuse {
         let fns = Metadata.everything["src/excmds.ts"]
         this.options = (await this.scoreOptions(
             Object.keys(fns).filter(f => f.startsWith(exstr)),
-        )).map(f => new ExcmdCompletionOption(f, fns[f].type, fns[f].doc))
+        )).map(f => {
+            let t = ""
+            if (fns[f].type) t = typeToSimpleString(fns[f].type)
+            return new ExcmdCompletionOption(f, t, fns[f].doc)
+        })
 
         let exaliases = config.get("exaliases")
         for (let alias of Object.keys(exaliases).filter(a =>
@@ -62,7 +67,7 @@ export class ExcmdCompletionSource extends Completions.CompletionSourceFuse {
                 this.options = this.options.concat(
                     new ExcmdCompletionOption(
                         alias,
-                        fns[cmd].type,
+                        fns[cmd].type ? typeToSimpleString(fns[cmd].type) : "",
                         `Alias for \`${cmd}\`. ${fns[cmd].doc}`,
                     ),
                 )

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,0 +1,68 @@
+// Gets the type sitting inside a promise
+function unwrapPromise(type) {
+    while (type.kind == "Promise") type = type.arguments[0]
+    return type
+}
+
+// This turns TYPE into a string, the format of which is quite short in order to be useful for completions
+export function typeToSimpleString(type): string {
+    let result = ""
+    switch (type.kind) {
+        case "function":
+            result = type.arguments.map(typeToSimpleString).join(", ")
+            let t = unwrapPromise(type.type)
+            if (!["any", "object", "void"].includes(t.kind)) {
+                if (result == "") result = "()"
+                result += "->" + typeToString(t)
+            }
+            break
+        default:
+            result = type.name || ""
+    }
+    return result
+}
+
+// This turns TYPE into a string, the format of which is quite close to the one tsc uses to display type strings
+export function typeToString(type): string {
+    let allTypes = arr => arr.map(typeToString).join(", ")
+    let result = ""
+    switch (type.kind) {
+        case "function":
+            result =
+                "(" +
+                allTypes(type.arguments) +
+                ")" +
+                " => " +
+                typeToString(type.type)
+            break
+        case "array":
+            result = typeToString(type.type) + "[]"
+            break
+        case "Promise":
+            result = "Promise<" + allTypes(type.arguments) + ">"
+            break
+        case "union":
+            result = type.arguments.map(typeToString).join(" | ")
+            break
+        case "LiteralType":
+            result = type.name
+            break
+        case "tuple":
+            result = "(" + type.arguments.map(typeToString).join(", ") + ")"
+        case "any":
+        case "object":
+        case "boolean":
+        case "number":
+        case "string":
+        case "void":
+        default:
+            result = type.kind
+    }
+
+    let name = ""
+    // If the type has a name, it could be interesting to add it to the string
+    // representation of the type. However, when the type is a LiteralType, the
+    // name is already in result, so there's no need to add it.
+    if (type.kind != "LiteralType" && type.name) name = type.name + ": "
+    return name + result
+}

--- a/src/static/css/commandline.css
+++ b/src/static/css/commandline.css
@@ -230,5 +230,5 @@ a.url:hover {
     width: 30%;
 }
 .ExcmdCompletionOption td.documentation {
-    width: 50%;
+    width: 100%;
 }


### PR DESCRIPTION
This commit makes type information generated by our compiler pass more
precise. This lets us choose what information we want to display in the
command line.

Although I find it useful for the commands I don't use that often (e.g. `container*` commands) and that have sensible argument names, I think I agree with what's been said in https://github.com/cmcaine/tridactyl/issues/912, giving more space to the documentation might be a better idea. Let me know what you think.

Note that this PR makes compilation quite slower (it adds about 0.5 seconds of compilation time on my computer). I think we shouldn't take this into account though, in the end it'll let us get rid of `excmds_macros.py` and we could even replace TypeDoc with a help page written in Inferno that would use information taken from `.metadata.generated.ts`. I believe both of these changes would improve compilation times enough to offset the slowdown induced by this PR.