### PR TITLE
Honor config.profiledir in getProfileDir

### DIFF
--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -208,7 +208,7 @@ export async function firstinpath(cmdarray) {
     let ind = 0
     let cmd = cmdarray[ind]
     // Try to find a text editor
-    while (!await inpath(cmd.split(" ")[0])) {
+    while (!(await inpath(cmd.split(" ")[0]))) {
         ind++
         cmd = cmdarray[ind]
         if (cmd === undefined) break
@@ -252,7 +252,7 @@ export async function winFirefoxRestart(
 ) {
     let required_version = "0.1.6"
 
-    if (!await nativegate(required_version, false)) {
+    if (!(await nativegate(required_version, false))) {
         throw `'restart' on Windows needs native messenger version >= ${required_version}.`
     }
 
@@ -275,7 +275,7 @@ export async function pyeval(command: string): Promise<MessageResp> {
 export async function getenv(variable: string) {
     let required_version = "0.1.2"
 
-    if (!await nativegate(required_version, false)) {
+    if (!(await nativegate(required_version, false))) {
         throw `'getenv' needs native messenger version >= ${required_version}.`
     }
 
@@ -379,6 +379,10 @@ export async function getProfileDir() {
                 "Your profile directory must be set manually on Windows, which you can find on 'about:support', with `set profiledir [directory]`.",
             )
         }
+    }
+
+    if (config.get("profiledir") != "auto") {
+        return config.get("profiledir")
     }
 
     // First, see if we can get the profile from the arguments that were given


### PR DESCRIPTION
I have my profiledir in a non-standard place.  The `getProfileDir` function can't find it automatically, but it also doesn't look at the `config.profiledir` variable which I set.  This fixes it.

Since the default value of `config.profiledir` is `"auto"`, I put the check before any automatic searching.  However, I think it would be nice to use the `--profile` argument but fall back to the configuration setting if that doesn't work.  In other words, I would like it to be automatic in the case where the automatic handling works, but defer to my configuration when the reliable search fails.  Since that behavior doesn't match what I expect when I change a variable *away* from `auto`, I have not implemented that.

Let me know your thoughts on the options here.  Maybe it would make more sense to do what I explicitly didn't.