### PR TITLE
use /usr/bin/env to find bash

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source ./scripts/common
 

--- a/native/install.sh
+++ b/native/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/common
+++ b/scripts/common
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Accepts no arguments
 # Returns git-add'ed files as a list of filenames separated by a newline character

--- a/scripts/pretty
+++ b/scripts/pretty
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source ./scripts/common
 

--- a/scripts/wine-pyinstaller.sh
+++ b/scripts/wine-pyinstaller.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 # This script must be run from the root Tridactyl directory
 TRIDIR="$(pwd)"


### PR DESCRIPTION
`/usr/bin/env` is a more reliable way to find `bash`, because it doesn't always live at `/bin/bash`.  In particular I am using NixOS, so `/bin/bash` doesn't work for me.  But in general I think `/usr/bin/env` will be available on any system where `/bin/bash` is available.