### PR TITLE
FreeBSD support for native install

### DIFF
--- a/native/install.sh
+++ b/native/install.sh
@@ -22,13 +22,18 @@ manifest_loc="https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/
 native_loc="https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/native_main.py"
 
 # Decide where to put the manifest based on OS
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    manifest_home="$HOME/.mozilla/native-messaging-hosts/"
-elif [[ "$OSTYPE" == "linux" ]]; then
-    manifest_home="$HOME/.mozilla/native-messaging-hosts/"
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-    manifest_home="$HOME/Library/Application Support/Mozilla/NativeMessagingHosts/"
-fi
+case "$OSTYPE" in
+    linux-gnu|linux|freebsd*)
+        manifest_home="$HOME/.mozilla/native-messaging-hosts/"
+        ;;
+    darwin*)
+        manifest_home="$HOME/Library/Application Support/Mozilla/NativeMessagingHosts/"
+        ;;
+    *)
+        # Fallback to default Linux location for unknown OSTYPE
+        manifest_home="$HOME/.mozilla/native-messaging-hosts/"
+        ;;
+esac
 
 mkdir -p "$manifest_home" "$XDG_DATA_HOME"
 


### PR DESCRIPTION
Handle FreeBSD's OSTYPE (which has "freebsdX.Y" format). While here,
convert OSTYPE check to use 'case' instead of if's/elif's.