### PR TITLE
Fix the incorrect invocation of urlmodify in the tridactylrc example

### DIFF
--- a/.tridactylrc
+++ b/.tridactylrc
@@ -52,9 +52,9 @@ quickmark t https://github.com/cmcaine/tridactyl/issues?utf8=%E2%9C%93&q=sort%3A
 " 
 
 " New reddit is bad
-autocmd DocStart www.reddit.com js tri.excmds.urlmodify("-t www old")
+autocmd DocStart www.reddit.com js tri.excmds.urlmodify("-t", "www", "old")
 " Mosquito nets won't make themselves
-autocmd DocStart www.amazon.co.uk js tri.excmds.urlmodify("-t www smile")
+autocmd DocStart www.amazon.co.uk js tri.excmds.urlmodify("-t", "www", "smile")
 
 " This will have to do until someone writes us a nice syntax file :)
 " vim: set filetype=vim:


### PR DESCRIPTION
The old one (first mentioned as a workaround in #727) doesn't work for me so I checked the function signature in [excmds.ts](https://github.com/cmcaine/tridactyl/blob/15140b1bea64cdfff887f837a87b2abe2e6a9a76/src/excmds.ts#L1238).

This PR gives the workable example (tested on macos, firefox 61.0.2, tridactyl 1.13.3).